### PR TITLE
feat: load registry from per-host manifest directories

### DIFF
--- a/src/infralink/core/registry.py
+++ b/src/infralink/core/registry.py
@@ -251,6 +251,31 @@ class Registry:
         return cls(hosts, schema.ansible_defaults, schema.tailnet_domain)
 
     @classmethod
+    def load_dir(cls, root: str | Path, pattern: str = "**/manifest.yml") -> Registry:
+        """Load registry from a directory of per-host manifest files.
+
+        Expects files named `manifest.yml` under `root` (any depth by default).
+        Each manifest should have a top-level `hosts:` mapping of UUID → host data.
+        """
+        root_path = Path(root)
+        hosts: dict[str, Host] = {}
+        tailnet_domain: str | None = None
+
+        for manifest in sorted(root_path.glob(pattern)):
+            with manifest.open() as f:
+                data = yaml.safe_load(f) or {}
+
+            # Prefer tailnet_domain if provided in any manifest
+            if not tailnet_domain:
+                tailnet_domain = data.get("tailnet_domain")
+
+            for uuid, host_data in (data.get("hosts") or {}).items():
+                host_schema = HostSchema(**host_data)
+                hosts[uuid] = Host(uuid, host_schema.model_dump(), tailnet_domain)
+
+        return cls(hosts, defaults=None, tailnet_domain=tailnet_domain)
+
+    @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Registry:
         """Create registry from dictionary."""
         hosts_data = data.get("hosts", {})

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pathlib import Path
+import yaml
 
 from infralink.core.registry import Registry, Host
 from infralink.core.schema import HostStatus
@@ -166,3 +167,39 @@ class TestRegistry:
         assert "d1b9e5d5-36b0-459d-a556-96622811fbd5" in registry
         assert "test-host-1" in registry
         assert "nonexistent" not in registry
+
+def test_load_dir(tmp_path):
+    """Load per-host manifests from a directory."""
+    manifests = [
+        (
+            "3dd6fbff-a23f-4e0c-bbd5-b3e800451c84",
+            {
+                "canonical_name": "infralink0",
+                "status": "active",
+                "group": "infralink-dev",
+                "cloud": "hetzner-cloud",
+                "services": {"prometheus": {"port": 9090}},
+            },
+        ),
+        (
+            "949fd148-40e7-437b-9adc-b3e800454bf3",
+            {
+                "canonical_name": "infralink1",
+                "status": "active",
+                "group": "infralink-dev",
+                "cloud": "hetzner-cloud",
+                "services": {"woodpecker-agent": {"port": 3000}},
+            },
+        ),
+    ]
+
+    for uuid, host_data in manifests:
+        host_dir = tmp_path / uuid
+        host_dir.mkdir(parents=True)
+        (host_dir / "manifest.yml").write_text(yaml.safe_dump({"hosts": {uuid: host_data}}))
+
+    registry = Registry.load_dir(tmp_path)
+
+    assert len(registry.active_hosts()) == 2
+    assert registry.get_by_name("infralink0").uuid == "3dd6fbff-a23f-4e0c-bbd5-b3e800451c84"
+    assert registry.get_by_name("infralink1").uuid == "949fd148-40e7-437b-9adc-b3e800454bf3"


### PR DESCRIPTION
Adds `Registry.load_dir` to build a registry from per-host manifest files (`**/manifest.yml`).\n\n- Scans a root directory for `manifest.yml` files\n- Validates each host with `HostSchema`, merges into a registry\n- Keeps `tailnet_domain` if present in any manifest\n- Test: loads two per-host manifests via `tmp_path` (46 tests total, all passing)\n\nContext: infra-management dev cluster uses per-host manifests under `network/main-dev/hosts/<uuid>/manifest.yml`. This method lets infra-management consume per-host manifests directly.