### PR TITLE
ci: add GitHub Actions pytest workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main, feat/*]
+  pull_request:
+    branches: [main, feat/*]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install -e ".[dev]" 2>/dev/null || pip install -e .
+      - name: Install test deps
+        run: pip install pytest
+      - name: Test
+        run: python -m pytest tests/ -q


### PR DESCRIPTION
Adds CI via GitHub Actions — runs pytest on Python 3.10 + 3.12 for all PRs and pushes to main/feat branches. Gives reviewer CI signal on PRs.