### PR TITLE
security: rebind approved Infralink gate

### DIFF
--- a/security/approved-private-gate.json
+++ b/security/approved-private-gate.json
@@ -1,5 +1,5 @@
 {
   "contract_harness_sha256": "20d74986c30447236c7da09d715752c581955473e9a437fc22fb45b49a556751",
   "dependency_lock_sha256": "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750",
-  "infra_management_commit": "f420ed121516b28005acf62f7b911262c54f23be"
+  "infra_management_commit": "1dc4e7f0ea98f5c895331cd3af6977c6cd8d3384"
 }

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -60,7 +60,7 @@ def test_private_gate_approval_matches_approved_infra_management_sources() -> No
         "dependency_lock_sha256": (
             "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750"
         ),
-        "infra_management_commit": "f420ed121516b28005acf62f7b911262c54f23be",
+        "infra_management_commit": "1dc4e7f0ea98f5c895331cd3af6977c6cd8d3384",
     }
 
 


### PR DESCRIPTION
## Summary
- bind private release evidence to infra-management `1dc4e7f0ea98f5c895331cd3af6977c6cd8d3384`
- retain the independently recomputed exact harness and lock hashes

## Scope
Approval tuple and exact policy expectation only. No key, workflow, version, tag, or release change.

## Verification
40 release policy/promotion tests passed; fresh `git show` hashes and JSON validated.