### PR TITLE
fix(core): accept Jinja-safe secret references

### DIFF
--- a/security/approved-private-gate.json
+++ b/security/approved-private-gate.json
@@ -1,5 +1,5 @@
 {
   "contract_harness_sha256": "20d74986c30447236c7da09d715752c581955473e9a437fc22fb45b49a556751",
   "dependency_lock_sha256": "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750",
-  "infra_management_commit": "1dc4e7f0ea98f5c895331cd3af6977c6cd8d3384"
+  "infra_management_commit": "583d80fe52371796a4cae1f210fd9c4a77c0a7d2"
 }

--- a/security/approved-private-gate.json
+++ b/security/approved-private-gate.json
@@ -1,5 +1,5 @@
 {
-  "contract_harness_sha256": "20d74986c30447236c7da09d715752c581955473e9a437fc22fb45b49a556751",
+  "contract_harness_sha256": "325fdf588ab5dad089c62e48d2b680b1397c242c37882369ce06a90b44d4785e",
   "dependency_lock_sha256": "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750",
-  "infra_management_commit": "583d80fe52371796a4cae1f210fd9c4a77c0a7d2"
+  "infra_management_commit": "bcf0428935a29605642107343373de94f0af7161"
 }

--- a/src/infralink/core/schema.py
+++ b/src/infralink/core/schema.py
@@ -10,7 +10,8 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 SAFE_SECRET_REF_PATTERN = re.compile(
-    r"[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*\Z",
+    r"(?:[A-Za-z0-9]|_[A-Za-z0-9])[A-Za-z0-9._-]*"
+    r"(?:/(?:[A-Za-z0-9]|_[A-Za-z0-9])[A-Za-z0-9._-]*)*\Z",
     re.ASCII,
 )
 

--- a/tests/test_node_schema.py
+++ b/tests/test_node_schema.py
@@ -69,12 +69,35 @@ def test_credential_auth_accepts_hierarchical_secret_reference(auth_type):
 @pytest.mark.parametrize(
     "secret_ref",
     [
+        "postgresql_rw_password_woodpecker",
+        "9157ddeb_postgresql_rw_password_woodpecker",
+        "_9157ddeb_postgresql_rw_password_woodpecker",
+        "production/_9157ddeb_postgresql_rw_password_woodpecker",
+    ],
+)
+def test_credential_auth_accepts_jinja_safe_secret_reference(secret_ref):
+    auth = AuthConfig(type="password", secret_ref=secret_ref)
+
+    assert auth.secret_ref == secret_ref
+
+
+@pytest.mark.parametrize(
+    "secret_ref",
+    [
         "/production/db-password",
         "production/db-password/",
         "production//db-password",
         "production/./db-password",
         "production/../db-password",
         "production/.../db-password",
+        "_",
+        "_.",
+        "_..",
+        "production/_",
+        "production/_./db-password",
+        "production/_../db-password",
+        "_9157 bad",
+        "_9157}bad",
     ],
 )
 def test_secret_reference_rejects_empty_dot_and_traversal_segments(secret_ref):

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -55,12 +55,12 @@ def test_woodpecker_evidence_public_key_is_parseable_and_has_approved_fingerprin
 def test_private_gate_approval_matches_approved_infra_management_sources() -> None:
     assert json.loads(APPROVED_PRIVATE_GATE.read_text(encoding="utf-8")) == {
         "contract_harness_sha256": (
-            "20d74986c30447236c7da09d715752c581955473e9a437fc22fb45b49a556751"
+            "325fdf588ab5dad089c62e48d2b680b1397c242c37882369ce06a90b44d4785e"
         ),
         "dependency_lock_sha256": (
             "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750"
         ),
-        "infra_management_commit": "583d80fe52371796a4cae1f210fd9c4a77c0a7d2",
+        "infra_management_commit": "bcf0428935a29605642107343373de94f0af7161",
     }
 
 

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -60,7 +60,7 @@ def test_private_gate_approval_matches_approved_infra_management_sources() -> No
         "dependency_lock_sha256": (
             "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750"
         ),
-        "infra_management_commit": "1dc4e7f0ea98f5c895331cd3af6977c6cd8d3384",
+        "infra_management_commit": "583d80fe52371796a4cae1f210fd9c4a77c0a7d2",
     }
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -560,6 +560,32 @@ class TestEdgeResolver:
         assert parsed.username == "app"
         assert unquote(parsed.password or "") == "p@ss word"
 
+    def test_connection_template_preserves_jinja_safe_secret_reference(self, registry):
+        secret_ref = "_9157ddeb_postgresql_rw_password_woodpecker"
+        edges = EdgeSet.from_dict(
+            {
+                "edges": [
+                    {
+                        "id": SECRET_EDGE_ID,
+                        "type": "database",
+                        "from": {"hosts": [], "service": "app"},
+                        "to": {
+                            "host": "d1b9e5d5-36b0-459d-a556-96622811fbd5",
+                            "service": "database",
+                            "port": 5432,
+                        },
+                        "protocol": "postgresql",
+                        "auth": {"type": "password", "secret_ref": secret_ref},
+                    }
+                ]
+            }
+        )
+
+        template = EdgeResolver(registry, edges).get_connection_template(SECRET_EDGE_ID)
+
+        assert template is not None
+        assert f"${{secret:{secret_ref}}}" in template
+
     def test_basic_auth_connection_template_uses_secret_placeholder(self, registry):
         edges = EdgeSet.from_dict(
             {

--- a/tests/test_secret_inventory.py
+++ b/tests/test_secret_inventory.py
@@ -155,6 +155,24 @@ def test_collect_secret_references_does_not_share_mutable_locations() -> None:
     assert first[0].locations == (f"edges.{EDGE_A}.auth.secret_ref",)
 
 
+def test_collect_secret_references_accepts_jinja_safe_reference() -> None:
+    from infralink.secrets.inventory import collect_secret_references
+
+    secret_ref = "_9157ddeb_postgresql_rw_password_woodpecker"
+    registry = Registry.from_dict(
+        {"hosts": {"host-a": {"canonical_name": "database", "bws_project": "core"}}}
+    )
+    edges = EdgeSet.from_dict({"edges": [_edge(EDGE_A, "host-a", secret_ref)]})
+
+    assert collect_secret_references(registry, edges) == [
+        SecretReference(
+            ref=secret_ref,
+            project="core",
+            locations=(f"edges.{EDGE_A}.auth.secret_ref",),
+        )
+    ]
+
+
 def test_inventory_reports_token_and_certificate_references() -> None:
     from infralink.secrets.inventory import collect_secret_references
 


### PR DESCRIPTION
## Summary
- accept UUID-derived secret references prefixed with `_` for Jinja identifier safety
- retain traversal, control, empty, dot, and punctuation rejection
- bind private gate policy to management sandbox fix `bcf0428935a29605642107343373de94f0af7161`

## Verification
- full suite: 932 passed, 1 skipped
- independent focused review: 172 passed
- Ruff and mypy passed
- approved harness/lock hashes independently recomputed

No tag, release, workflow, or live-state changes.