### PR TITLE
security: rebind ORAS publisher gate

### DIFF
--- a/security/approved-private-gate.json
+++ b/security/approved-private-gate.json
@@ -1,5 +1,5 @@
 {
   "contract_harness_sha256": "e729476e50aae3604f5f2a4602cae13a29668ee8d8803fc43f9993b6c888d2b6",
   "dependency_lock_sha256": "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750",
-  "infra_management_commit": "5c041602c4532b5c25a8daebde3c2f124163255f"
+  "infra_management_commit": "160fc077ab63241eab8a6f33b923156e1dd609f2"
 }

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -60,7 +60,7 @@ def test_private_gate_approval_matches_approved_infra_management_sources() -> No
         "dependency_lock_sha256": (
             "2ed331ff627426f164b40ade8652756c22fcdcaf82de5214ed3700e664839750"
         ),
-        "infra_management_commit": "5c041602c4532b5c25a8daebde3c2f124163255f",
+        "infra_management_commit": "160fc077ab63241eab8a6f33b923156e1dd609f2",
     }
 
 


### PR DESCRIPTION
## Summary
- approve infra-management main `160fc077ab63241eab8a6f33b923156e1dd609f2`
- retain the independently reviewed harness and dependency lock hashes
- bind the ORAS 1.3 absolute-path compatibility fix

## Verification
- 40 release policy/promotion tests passed
- Ruff and diff checks passed
- publisher fix independently approved and infra-management PR CI green