### PR TITLE
feat: add Redis observation readiness contract

### DIFF
--- a/src/infralink/cli/observation.py
+++ b/src/infralink/cli/observation.py
@@ -298,6 +298,8 @@ def _project_failure(
 @click.pass_obj
 def capabilities(ctx: Any) -> int:
     """Describe the offline observation contract surface."""
+    from infralink.observation.models import HealthEvaluator, LogEvaluator, MetricsEvaluator
+
     result = CapabilitiesResult(
         document_schema_versions=["infralink.observation/v1"],
         plan_schema_versions=["infralink.plan.v1"],
@@ -314,15 +316,9 @@ def capabilities(ctx: Any) -> int:
             )
         },
         evaluator_types={
-            "health": [
-                "http-status",
-                "irc-handshake",
-                "postgres-ready",
-                "smtp-banner",
-                "tcp-connect",
-            ],
-            "metrics": ["prometheus-scrape"],
-            "logs": ["contains", "regex"],
+            "health": sorted(evaluator.value for evaluator in HealthEvaluator),
+            "metrics": sorted(evaluator.value for evaluator in MetricsEvaluator),
+            "logs": sorted(evaluator.value for evaluator in LogEvaluator),
         },
         projections=["observation", "secrets", "view", "readiness"],
     )

--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -56,6 +56,7 @@ class EndpointProtocol(str, Enum):
     SMTP = "smtp"
     IRC = "irc"
     POSTGRESQL = "postgresql"
+    REDIS = "redis"
 
 
 class HealthEvaluator(str, Enum):
@@ -64,6 +65,7 @@ class HealthEvaluator(str, Enum):
     SMTP_BANNER = "smtp-banner"
     IRC_HANDSHAKE = "irc-handshake"
     POSTGRES_READY = "postgres-ready"
+    REDIS_READY = "redis-ready"
 
 
 class MetricsEvaluator(str, Enum):

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -156,7 +156,8 @@
         "https",
         "smtp",
         "irc",
-        "postgresql"
+        "postgresql",
+        "redis"
       ],
       "title": "EndpointProtocol",
       "type": "string"
@@ -213,7 +214,8 @@
         "http-status",
         "smtp-banner",
         "irc-handshake",
-        "postgres-ready"
+        "postgres-ready",
+        "redis-ready"
       ],
       "title": "HealthEvaluator",
       "type": "string"

--- a/src/infralink/schemas/observation/v1/dependency.json
+++ b/src/infralink/schemas/observation/v1/dependency.json
@@ -74,7 +74,8 @@
         "https",
         "smtp",
         "irc",
-        "postgresql"
+        "postgresql",
+        "redis"
       ],
       "title": "EndpointProtocol",
       "type": "string"

--- a/src/infralink/schemas/observation/v1/profile.json
+++ b/src/infralink/schemas/observation/v1/profile.json
@@ -70,7 +70,8 @@
         "https",
         "smtp",
         "irc",
-        "postgresql"
+        "postgresql",
+        "redis"
       ],
       "title": "EndpointProtocol",
       "type": "string"
@@ -127,7 +128,8 @@
         "http-status",
         "smtp-banner",
         "irc-handshake",
-        "postgres-ready"
+        "postgres-ready",
+        "redis-ready"
       ],
       "title": "HealthEvaluator",
       "type": "string"

--- a/tests/observation/test_models.py
+++ b/tests/observation/test_models.py
@@ -412,6 +412,24 @@ def test_representative_profiles_use_only_closed_vendor_neutral_contracts() -> N
             ],
         ),
         ServiceProfile(
+            id="redis",
+            endpoints=[Endpoint(id="redis", protocol=EndpointProtocol.REDIS, port=6379)],
+            health=[
+                HealthCapability(
+                    id="ready",
+                    endpoint_id="redis",
+                    evaluator=HealthEvaluator.REDIS_READY,
+                )
+            ],
+            secret_slots=[
+                SecretSlot(
+                    id="password",
+                    delivery_forms=[SecretDeliveryForm.ENVIRONMENT],
+                    purpose="Redis authentication",
+                )
+            ],
+        ),
+        ServiceProfile(
             id="ci",
             endpoints=[Endpoint(id="agent", protocol=EndpointProtocol.TCP, port=3000)],
             metrics=[
@@ -430,6 +448,7 @@ def test_representative_profiles_use_only_closed_vendor_neutral_contracts() -> N
         "postfix",
         "inspircd",
         "postgresql",
+        "redis",
         "ci",
     ]
 

--- a/tests/test_cli_observation.py
+++ b/tests/test_cli_observation.py
@@ -81,6 +81,7 @@ def test_project_observation_and_capabilities_are_offline_yaml(tmp_path: Path) -
     advertised = yaml.safe_load(capabilities.output)["result"]
     assert "infralink.observation/v1" in advertised["document_schema_versions"]
     assert "observation" in advertised["projections"]
+    assert "redis-ready" in advertised["evaluator_types"]["health"]
 
 
 def test_observation_errors_are_typed_and_exact_exit_codes(tmp_path: Path) -> None:
@@ -141,6 +142,17 @@ def test_generated_observation_schemas_validate_public_examples() -> None:
         wrong = dict(document, schema_version="infralink.observation/v99")
         with pytest.raises(JsonSchemaValidationError):
             Draft202012Validator(schema).validate(wrong)
+
+
+def test_generated_schemas_publish_redis_protocol_and_readiness() -> None:
+    root = Path(__file__).parents[1] / "src/infralink/schemas"
+    profile_schema = (root / "observation/v1/profile.json").read_text()
+    dependency_schema = (root / "observation/v1/dependency.json").read_text()
+    projection_schema = (root / "cli/v1/project-observation.json").read_text()
+
+    for schema in (profile_schema, dependency_schema, projection_schema):
+        assert '"redis"' in schema
+    assert '"redis-ready"' in profile_schema
 
 
 def test_end_to_end_example_directory_validates_and_projects() -> None:


### PR DESCRIPTION
## Summary
- add typed Redis endpoint protocol and readiness evaluator
- derive advertised evaluator capabilities from authoritative enums
- regenerate input and projection schemas with Redis support

## Scope
This is the narrow prerequisite for modeling Citadel authenticated Redis readiness in the private core registry. No planner, deployment, provider, or runtime behavior changes.

## Verification
- 1,163 full-suite tests passed before the discovery correction
- 110 focused model and CLI tests passed after correction
- Ruff and mypy passed
- schema generation is byte-idempotent
- independent review approved