### PR TITLE
fix(observation): scope service instance identity by host

### DIFF
--- a/src/infralink/observation/loader.py
+++ b/src/infralink/observation/loader.py
@@ -304,7 +304,10 @@ def _duplicate_id_diagnostics(documents: Iterable[ObservationDocument]) -> list[
                 continue
             for index, item in enumerate(objects):
                 if isinstance(item, Mapping) and isinstance(item.get("id"), str):
-                    locations[(collection, item["id"])].append(
+                    object_id = item["id"]
+                    if collection == "service_instances" and isinstance(item.get("host_id"), str):
+                        object_id = f"{item['host_id']}/{object_id}"
+                    locations[(collection, object_id)].append(
                         SourceLocation(
                             document.source_path,
                             f"/{collection}/{index}/id",

--- a/src/infralink/observation/loader.py
+++ b/src/infralink/observation/loader.py
@@ -305,8 +305,11 @@ def _duplicate_id_diagnostics(documents: Iterable[ObservationDocument]) -> list[
             for index, item in enumerate(objects):
                 if isinstance(item, Mapping) and isinstance(item.get("id"), str):
                     object_id = item["id"]
-                    if collection == "service_instances" and isinstance(item.get("host_id"), str):
-                        object_id = f"{item['host_id']}/{object_id}"
+                    if collection == "service_instances":
+                        host_id = item.get("host_id")
+                        if not isinstance(host_id, str):
+                            continue
+                        object_id = f"{host_id}/{object_id}"
                     locations[(collection, object_id)].append(
                         SourceLocation(
                             document.source_path,

--- a/tests/observation/test_loader.py
+++ b/tests/observation/test_loader.py
@@ -278,6 +278,32 @@ service_instances:
     ]
 
 
+def test_malformed_instance_hosts_defer_identity_validation_to_the_model(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "missing.yml",
+        """schema_version: infralink.observation/v1
+service_instances:
+  - id: node-exporter
+    profile_id: node-exporter
+""",
+    )
+    _write(
+        tmp_path / "malformed.yml",
+        """schema_version: infralink.observation/v1
+service_instances:
+  - id: node-exporter
+    host_id: [not-a-host]
+    profile_id: node-exporter
+""",
+    )
+
+    report = load_observation_documents(tmp_path)
+
+    assert not [item for item in report.diagnostics if item.code == "duplicate-object-id"]
+
+
 def test_duplicate_ids_in_same_multi_document_file_have_distinct_locations(
     tmp_path: Path,
 ) -> None:

--- a/tests/observation/test_loader.py
+++ b/tests/observation/test_loader.py
@@ -220,6 +220,64 @@ def test_duplicate_ids_across_documents_report_both_locations(tmp_path: Path) ->
     ]
 
 
+def test_service_instance_ids_are_scoped_to_their_host(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "watchtower.yml",
+        """schema_version: infralink.observation/v1
+service_instances:
+  - id: node-exporter
+    host_id: 11111111-1111-4111-8111-111111111111
+    profile_id: node-exporter
+""",
+    )
+    _write(
+        tmp_path / "citadel.yml",
+        """schema_version: infralink.observation/v1
+service_instances:
+  - id: node-exporter
+    host_id: 22222222-2222-4222-8222-222222222222
+    profile_id: node-exporter
+""",
+    )
+
+    report = load_observation_documents(tmp_path)
+
+    assert report.valid
+    assert not [item for item in report.diagnostics if item.code == "duplicate-object-id"]
+
+
+def test_duplicate_service_instance_ids_on_one_host_report_both_locations(
+    tmp_path: Path,
+) -> None:
+    host_id = "11111111-1111-4111-8111-111111111111"
+    for path in (tmp_path / "a.yml", tmp_path / "nested" / "b.yml"):
+        _write(
+            path,
+            f"""schema_version: infralink.observation/v1
+service_instances:
+  - id: node-exporter
+    host_id: {host_id}
+    profile_id: node-exporter
+""",
+        )
+
+    report = load_observation_documents(tmp_path)
+
+    duplicates = [item for item in report.diagnostics if item.code == "duplicate-object-id"]
+    assert [(item.location.path, item.location.pointer, item.identity) for item in duplicates] == [
+        (
+            "a.yml",
+            "/service_instances/0/id",
+            f"service_instances/{host_id}/node-exporter",
+        ),
+        (
+            "nested/b.yml",
+            "/service_instances/0/id",
+            f"service_instances/{host_id}/node-exporter",
+        ),
+    ]
+
+
 def test_duplicate_ids_in_same_multi_document_file_have_distinct_locations(
     tmp_path: Path,
 ) -> None:

--- a/tests/observation/test_public_api.py
+++ b/tests/observation/test_public_api.py
@@ -113,6 +113,40 @@ service_instances:
     ]
 
 
+def test_bounded_validation_prioritizes_malformed_instance_host_diagnostic(
+    tmp_path: Path,
+) -> None:
+    from infralink.observation import validate
+
+    source = tmp_path / "invalid.yml"
+    source.write_text(
+        """schema_version: infralink.observation/v1
+service_profiles:
+  - id: node-exporter
+    endpoints: []
+    health: []
+    metrics: []
+    logs: []
+    signals: []
+    secret_slots: []
+service_instances:
+  - id: node-exporter
+    profile_id: node-exporter
+  - id: node-exporter
+    host_id: [not-a-host]
+    profile_id: node-exporter
+""",
+        encoding="ascii",
+    )
+
+    report = validate([source], limit=1, as_of=AS_OF)
+
+    assert not report.valid
+    assert report.diagnostics.total_count == 2
+    assert [item.code for item in report.diagnostics] == ["invalid-document-record"]
+    assert report.diagnostics[0].location.pointer == "/service_instances/1/host_id"
+
+
 def test_validate_aggregates_model_errors_and_is_bounded(tmp_path: Path) -> None:
     from infralink.observation import validate
 

--- a/tests/observation/test_public_api.py
+++ b/tests/observation/test_public_api.py
@@ -75,6 +75,44 @@ def test_public_api_imports_without_click_or_provider_modules(
     assert callable(validate)
 
 
+def test_public_api_projects_same_instance_key_on_distinct_hosts(tmp_path: Path) -> None:
+    from infralink.observation import project, validate
+
+    source = tmp_path / "contract.yml"
+    source.write_text(
+        """schema_version: infralink.observation/v1
+hosts:
+  - id: 11111111-1111-4111-8111-111111111111
+  - id: 22222222-2222-4222-8222-222222222222
+service_profiles:
+  - id: node-exporter
+    endpoints: []
+    health: []
+    metrics: []
+    logs: []
+    signals: []
+    secret_slots: []
+service_instances:
+  - id: node-exporter
+    host_id: 11111111-1111-4111-8111-111111111111
+    profile_id: node-exporter
+  - id: node-exporter
+    host_id: 22222222-2222-4222-8222-222222222222
+    profile_id: node-exporter
+""",
+        encoding="ascii",
+    )
+
+    report = validate([source], as_of=AS_OF)
+    result = project([source], as_of=AS_OF)
+
+    assert report.valid
+    assert [service.id for service in result.plan.services] == [
+        "11111111-1111-4111-8111-111111111111/node-exporter",
+        "22222222-2222-4222-8222-222222222222/node-exporter",
+    ]
+
+
 def test_validate_aggregates_model_errors_and_is_bounded(tmp_path: Path) -> None:
     from infralink.observation import validate
 


### PR DESCRIPTION
## Summary
- scope loader duplicate detection for service instances by host and runtime key
- preserve global identity checks for every other observation object
- defer malformed host identities to schema/model diagnostics

## Verification
- 1,164 passed, 5 skipped; 90.16% coverage
- Ruff and mypy clean
- generated schemas byte-idempotent
- wheel/sdist build and Twine checks pass

Required by the private core registry migration, where the same runtime keys (for example nginx and node-exporter) correctly occur on multiple hosts.