### PR TITLE
feat(observation): project explicit display identities

### DIFF
--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -203,6 +203,7 @@ class SecretSlot(StrictModel):
 
 class ServiceProfile(StrictModel):
     id: CanonicalId
+    display_name: Annotated[str, Field(min_length=1)] | None = None
     endpoints: list[Endpoint] = Field(default_factory=list)
     health: list[HealthCapability] = Field(default_factory=list)
     metrics: list[MetricsCapability] = Field(default_factory=list)
@@ -278,6 +279,7 @@ class ServiceInstance(StrictModel):
     id: CanonicalId
     host_id: HostId | None = None
     profile_id: CanonicalId
+    display_name: Annotated[str, Field(min_length=1)] | None = None
     endpoint_ids: list[CanonicalId] = Field(default_factory=list)
     endpoint_overrides: list[EndpointOverride] = Field(default_factory=list)
     secret_binding_ids: list[CanonicalId] = Field(default_factory=list)
@@ -285,6 +287,7 @@ class ServiceInstance(StrictModel):
 
 class Host(StrictModel):
     id: HostId
+    display_name: Annotated[str, Field(min_length=1)] | None = None
 
 
 _SENSITIVE_KEY = re.compile(r"(?:^|[^a-z])(value|secret|password|token)(?:$|[^a-z])")

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -56,7 +56,7 @@ class SourceRef(PlanModel):
 
 class PlannedHost(PlanModel):
     id: str
-    display_name: str | None
+    display_name: str | None = None
     source_refs: tuple[SourceRef, ...]
 
 
@@ -65,7 +65,7 @@ class PlannedService(PlanModel):
     host_id: str
     instance_key: str
     profile_id: str
-    display_name: str | None
+    display_name: str | None = None
     source_refs: tuple[SourceRef, ...]
 
 

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -6,7 +6,7 @@ import json
 import re
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -56,7 +56,7 @@ class SourceRef(PlanModel):
 
 class PlannedHost(PlanModel):
     id: str
-    display_name: str | None = None
+    display_name: Annotated[str, Field(min_length=1)] | None = None
     source_refs: tuple[SourceRef, ...]
 
 
@@ -65,7 +65,7 @@ class PlannedService(PlanModel):
     host_id: str
     instance_key: str
     profile_id: str
-    display_name: str | None = None
+    display_name: Annotated[str, Field(min_length=1)] | None = None
     source_refs: tuple[SourceRef, ...]
 
 

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -56,6 +56,7 @@ class SourceRef(PlanModel):
 
 class PlannedHost(PlanModel):
     id: str
+    display_name: str | None
     source_refs: tuple[SourceRef, ...]
 
 
@@ -64,6 +65,7 @@ class PlannedService(PlanModel):
     host_id: str
     instance_key: str
     profile_id: str
+    display_name: str | None
     source_refs: tuple[SourceRef, ...]
 
 
@@ -458,7 +460,11 @@ def resolve_observation_documents(
     planned_hosts: list[PlannedHost] = []
     for host, ref in hosts.values():
         assert isinstance(host, Host)
-        planned_hosts.append(PlannedHost(id=str(host.id), source_refs=(ref,)))
+        planned_hosts.append(
+            PlannedHost(
+                id=str(host.id), display_name=host.display_name, source_refs=(ref,)
+            )
+        )
     host_ids = {item.id for item in planned_hosts}
     planned_services: list[PlannedService] = []
     planned_endpoints: list[PlannedEndpoint] = []
@@ -519,6 +525,7 @@ def resolve_observation_documents(
                 host_id=host_id,
                 instance_key=instance.id,
                 profile_id=profile.id,
+                display_name=instance.display_name or profile.display_name,
                 source_refs=(ref, profile_entry[1]),
             )
         )

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -461,9 +461,7 @@ def resolve_observation_documents(
     for host, ref in hosts.values():
         assert isinstance(host, Host)
         planned_hosts.append(
-            PlannedHost(
-                id=str(host.id), display_name=host.display_name, source_refs=(ref,)
-            )
+            PlannedHost(id=str(host.id), display_name=host.display_name, source_refs=(ref,))
         )
     host_ids = {item.id for item in planned_hosts}
     planned_services: list[PlannedService] = []

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -910,6 +910,18 @@
     "PlannedHost": {
       "additionalProperties": false,
       "properties": {
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
         "id": {
           "title": "Id",
           "type": "string"
@@ -1110,6 +1122,18 @@
     "PlannedService": {
       "additionalProperties": false,
       "properties": {
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
         "host_id": {
           "title": "Host Id",
           "type": "string"

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -913,6 +913,7 @@
         "display_name": {
           "anyOf": [
             {
+              "minLength": 1,
               "type": "string"
             },
             {
@@ -1125,6 +1126,7 @@
         "display_name": {
           "anyOf": [
             {
+              "minLength": 1,
               "type": "string"
             },
             {

--- a/src/infralink/schemas/observation/v1/instance.json
+++ b/src/infralink/schemas/observation/v1/instance.json
@@ -102,6 +102,19 @@
     "Host": {
       "additionalProperties": false,
       "properties": {
+        "display_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
         "id": {
           "title": "Id",
           "type": "string"
@@ -116,6 +129,19 @@
     "ServiceInstance": {
       "additionalProperties": false,
       "properties": {
+        "display_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
         "endpoint_ids": {
           "items": {
             "pattern": "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",

--- a/src/infralink/schemas/observation/v1/profile.json
+++ b/src/infralink/schemas/observation/v1/profile.json
@@ -356,6 +356,19 @@
     "ServiceProfile": {
       "additionalProperties": false,
       "properties": {
+        "display_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
         "endpoints": {
           "items": {
             "$ref": "#/$defs/Endpoint"

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 import pytest
 
 from infralink.observation.loader import ObservationDocument
-from infralink.observation.planner import PlanValidationError, resolve_observation_documents
+from infralink.observation.planner import Plan, PlanValidationError, resolve_observation_documents
 
 AS_OF = datetime(2026, 8, 4, tzinfo=timezone.utc)
 
@@ -140,6 +140,20 @@ def test_legacy_source_documents_project_no_display_names() -> None:
 
     assert [host.display_name for host in plan.hosts] == [None, None]
     assert [service.display_name for service in plan.services] == [None, None]
+
+
+def test_legacy_v1_plan_payload_without_display_names_still_validates() -> None:
+    payload = resolve_observation_documents([document(base_data())], as_of=AS_OF).model_dump()
+    for host in payload["hosts"]:
+        host.pop("display_name")
+    for service in payload["services"]:
+        service.pop("display_name")
+
+    restored = Plan.model_validate(payload)
+
+    assert restored.schema_version == "infralink.plan.v1"
+    assert [host.display_name for host in restored.hosts] == [None, None]
+    assert [service.display_name for service in restored.services] == [None, None]
 
 
 def test_instance_applies_only_address_exposure_and_route_overrides() -> None:

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -115,6 +115,33 @@ def test_resolves_two_hosts_and_exact_signal_namespaces_deterministically() -> N
     assert plan.document_digests == ("contract.yml",)
 
 
+def test_projects_explicit_host_and_service_display_names_without_identity_changes() -> None:
+    data = base_data()
+    data["hosts"][0]["display_name"] = "Operations API"  # type: ignore[index]
+    data["hosts"][1]["display_name"] = "Customer Edge"  # type: ignore[index]
+    data["service_profiles"][0]["display_name"] = "Web Service"  # type: ignore[index]
+    data["service_instances"][0]["display_name"] = "Public Frontend"  # type: ignore[index]
+
+    plan = resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert [(host.id, host.display_name) for host in plan.hosts] == [
+        ("11111111-1111-4111-8111-111111111111", "Operations API"),
+        ("22222222-2222-4222-8222-222222222222", "Customer Edge"),
+    ]
+    assert [(service.id, service.display_name) for service in plan.services] == [
+        ("11111111-1111-4111-8111-111111111111/api", "Web Service"),
+        ("22222222-2222-4222-8222-222222222222/frontend", "Public Frontend"),
+    ]
+    assert resolve_observation_documents([document(data)], as_of=AS_OF) == plan
+
+
+def test_legacy_source_documents_project_no_display_names() -> None:
+    plan = resolve_observation_documents([document(base_data())], as_of=AS_OF)
+
+    assert [host.display_name for host in plan.hosts] == [None, None]
+    assert [service.display_name for service in plan.services] == [None, None]
+
+
 def test_instance_applies_only_address_exposure_and_route_overrides() -> None:
     data = base_data()
     data["service_instances"][0]["endpoint_overrides"] = [  # type: ignore[index]

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from types import MappingProxyType
 
 import pytest
+from pydantic import ValidationError
 
 from infralink.observation.loader import ObservationDocument
 from infralink.observation.planner import Plan, PlanValidationError, resolve_observation_documents
@@ -154,6 +155,15 @@ def test_legacy_v1_plan_payload_without_display_names_still_validates() -> None:
     assert restored.schema_version == "infralink.plan.v1"
     assert [host.display_name for host in restored.hosts] == [None, None]
     assert [service.display_name for service in restored.services] == [None, None]
+
+
+@pytest.mark.parametrize(("section", "index"), [("hosts", 0), ("services", 0)])
+def test_plan_rejects_empty_display_names(section: str, index: int) -> None:
+    payload = resolve_observation_documents([document(base_data())], as_of=AS_OF).model_dump()
+    payload[section][index]["display_name"] = ""
+
+    with pytest.raises(ValidationError, match="at least 1 character"):
+        Plan.model_validate(payload)
 
 
 def test_instance_applies_only_address_exposure_and_route_overrides() -> None:


### PR DESCRIPTION
## Summary

- Projects optional explicit display names from observation hosts, service profiles, and service-instance overrides into the normalized plan.
- Preserves canonical host, service, endpoint, dependency, and signal IDs unchanged.
- Updates the public observation input and CLI projection schemas.

## Scope

This does not modify private registry declarations, Gatus rendering, or the canonical-to-rendered reconciliation migration.

## Validation

- `154` focused model, planner, and CLI-observation tests passed.
- Prior independent review recorded the full suite as `1171 passed, 1 skipped`.
- Schema generators were rerun and verified deterministic.