### PR TITLE
feat(release): publish producer contract v1

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,6 +17,7 @@ steps:
       - python -m mypy src scripts
       - python -m pytest
       - python scripts/generate_cli_schemas.py
+      - python scripts/generate_release_schemas.py
       - git diff --exit-code
       - test -z "$(git ls-files --others --exclude-standard src/infralink/schemas)"
       - python -m build
@@ -35,6 +36,7 @@ steps:
       - python -m mypy src scripts
       - python -m pytest
       - python scripts/generate_cli_schemas.py
+      - python scripts/generate_release_schemas.py
       - git diff --exit-code
       - test -z "$(git ls-files --others --exclude-standard src/infralink/schemas)"
       - python -m build
@@ -53,6 +55,7 @@ steps:
       - python -m mypy src scripts
       - python -m pytest
       - python scripts/generate_cli_schemas.py
+      - python scripts/generate_release_schemas.py
       - git diff --exit-code
       - test -z "$(git ls-files --others --exclude-standard src/infralink/schemas)"
       - python -m build

--- a/docs/release-operator-workflow.md
+++ b/docs/release-operator-workflow.md
@@ -23,9 +23,16 @@ does not include logs.
 ## Inputs And Handoffs
 
 `infralink.release-candidate.v1` is generated from an ordinary YAML change by
-CI. It binds an immutable release identity, exact registry/controller commits,
-CI receipt, SHA-256 artifacts, and eligible consumers. It cannot contain a
-branch or other mutable ref as authority.
+CI. Its packaged structural JSON Schema is
+`infralink/schemas/release/v1/release-candidate.v1.schema.json`; a sanitized
+example is `examples/release/release-candidate.v1.json`. It binds a release
+identity and its explicit channel/sequence, exact registry/controller commits,
+a CI receipt, SHA-256 artifact digests, and a bounded, unique consumer list.
+The typed `infralink.release.contracts.ReleaseCandidateV1` model is the
+normative semantic validator used by the CLI and registry CI; it additionally
+checks identity/channel/sequence coherence, safe unique artifact paths, and
+unique consumers. Both layers reject unknown fields, including branch/ref
+fields: mutable refs cannot be release authority.
 
 `render-publisher-request` validates that candidate and the local admission
 policy, then produces `infralink.publisher-request.v1`. The request binds the
@@ -33,9 +40,21 @@ same immutable release facts, channel, and sequence. It is an explicit input
 to the trusted publisher, not an invocation of one.
 
 `infralink.release-attestation.v1` is the publisher's immutable completion
-record. Inspection reports its release binding and bounded consumer list. It
-does not advertise an unimplemented host-shadow command; registry CI owns that
-later workflow.
+record. Its packaged structural JSON Schema is
+`infralink/schemas/release/v1/release-attestation.v1.schema.json`; a sanitized
+example is `examples/release/release-attestation.v1.json`. It repeats every
+candidate evidence binding, adds a bounded publisher CI receipt, and binds the
+created tag name to the release identity plus the immutable annotated tag
+object SHA-1. The typed `ReleaseAttestationV1` model additionally verifies the
+tag/release binding. Inspection reports the full evidence binding and bounded
+consumer list. It does not advertise an unimplemented host-shadow command;
+registry CI owns that later workflow.
+
+The CLI retains reader compatibility for the flat `v1` shapes emitted by the
+initial #37 release CLI. Those older attestations contain no publisher
+repository, tag object, candidate receipt, or artifact evidence; inspection
+represents each as absent rather than inventing provenance. New registry CI
+must emit the public nested contract above.
 
 ## Current Stubs
 
@@ -45,9 +64,10 @@ Woodpecker/BWS/Gitea path tracked by infra-registry issue #251. Until that is
 active, publisher eligibility is a clear no-go state; operators must not turn
 the request object into raw signing or Git commands.
 
-The producer contract has not yet selected canonical request bytes or a request
-digest, so this slice does not invent an attestation-to-request digest binding.
-That precise producer integration is tracked by Infralink issue #38.
+The producer contract deliberately does not select canonical publisher-request
+bytes or a request digest. Registry #251 must add that implementation-specific
+publisher evidence without weakening these release facts or creating a second
+signing path.
 
 ## Examples
 

--- a/examples/release/release-attestation.v1.json
+++ b/examples/release/release-attestation.v1.json
@@ -14,7 +14,7 @@
   },
   "artifacts": [
     {
-      "path": "release/runtime.tar.gz",
+      "path": "release/runtime-archive",
       "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     }
   ],

--- a/examples/release/release-attestation.v1.json
+++ b/examples/release/release-attestation.v1.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "infralink.release-attestation.v1",
+  "release": {
+    "identity": "releases/core-v2/42",
+    "channel": "core-v2",
+    "sequence": 42
+  },
+  "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ci_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/registry",
+    "run": "576"
+  },
+  "artifacts": [
+    {
+      "path": "release/runtime.tar.gz",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consumers": ["citadel", "watchtower"],
+  "publisher_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/registry",
+    "run": "600"
+  },
+  "tag": {
+    "name": "releases/core-v2/42",
+    "object_sha1": "dddddddddddddddddddddddddddddddddddddddd"
+  }
+}

--- a/examples/release/release-candidate.v1.json
+++ b/examples/release/release-candidate.v1.json
@@ -14,7 +14,7 @@
   },
   "artifacts": [
     {
-      "path": "release/runtime.tar.gz",
+      "path": "release/runtime-archive",
       "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     }
   ],

--- a/examples/release/release-candidate.v1.json
+++ b/examples/release/release-candidate.v1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "infralink.release-candidate.v1",
+  "release": {
+    "identity": "releases/core-v2/42",
+    "channel": "core-v2",
+    "sequence": 42
+  },
+  "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ci_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/registry",
+    "run": "576"
+  },
+  "artifacts": [
+    {
+      "path": "release/runtime.tar.gz",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consumers": ["citadel", "watchtower"]
+}

--- a/scripts/generate_release_schemas.py
+++ b/scripts/generate_release_schemas.py
@@ -1,0 +1,39 @@
+"""Generate packaged public release producer schemas deterministically."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+
+ROOT = Path(__file__).parents[1]
+OUTPUT = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
+MODELS: dict[str, Any] = {
+    "release-candidate.v1.schema.json": ReleaseCandidateV1,
+    "release-attestation.v1.schema.json": ReleaseAttestationV1,
+}
+
+
+def render_schemas() -> dict[str, str]:
+    rendered: dict[str, str] = {}
+    for filename, model in MODELS.items():
+        schema = model.model_json_schema()
+        schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+        rendered[filename] = json.dumps(schema, indent=2, sort_keys=True) + "\n"
+    return rendered
+
+
+def write_schemas(output: Path = OUTPUT) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    rendered = render_schemas()
+    for path in output.glob("*.json"):
+        if path.name not in rendered:
+            path.unlink()
+    for filename, body in rendered.items():
+        (output / filename).write_text(body, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    write_schemas()

--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -295,6 +295,7 @@ class PublisherRequestResult(ContractModel):
 
 class ReleasePublisherReceipt(ContractModel):
     provider: str = Field(min_length=1, max_length=128)
+    repository: str | None = Field(default=None, min_length=1, max_length=256)
     run: str = Field(min_length=1, max_length=128)
 
 
@@ -302,8 +303,11 @@ class ReleaseAttestation(ContractModel):
     release_identity: str = Field(pattern=r"^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$")
     registry_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
     controller_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
+    ci_receipt: ReleaseCiReceipt | None = None
+    artifacts: list[ReleaseArtifactBinding] = Field(default_factory=list, max_length=64)
     publisher_receipt: ReleasePublisherReceipt
     tag: str = Field(pattern=r"^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$")
+    tag_object_sha1: str | None = Field(default=None, pattern=r"^[0-9a-f]{40}$")
     consumers: list[ReleaseConsumer] = Field(min_length=1, max_length=64)
 
     @model_validator(mode="after")

--- a/src/infralink/cli/release.py
+++ b/src/infralink/cli/release.py
@@ -48,6 +48,12 @@ from infralink.cli.contracts import (
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
 from infralink.cli.main import _context_for, _emit
 from infralink.cli.output import ok_envelope
+from infralink.release.contracts import (
+    ArtifactBindingV1,
+    CiReceiptV1,
+    ReleaseAttestationV1,
+    ReleaseCandidateV1,
+)
 
 _IDENTITY = re.compile(r"^releases/([a-z0-9][a-z0-9-]{0,62})/([1-9][0-9]*)$")
 
@@ -125,47 +131,42 @@ class _AdmissionDocument(_StrictModel):
     publisher: _Publisher = _Publisher(state="unavailable")
 
 
-class _CiReceipt(_StrictModel):
-    provider: str = Field(min_length=1, max_length=128)
-    repository: str = Field(min_length=1, max_length=256)
-    run: str = Field(min_length=1, max_length=128)
+_CandidateDocument = ReleaseCandidateV1
+_AttestationDocument = ReleaseAttestationV1
 
 
-class _ArtifactBinding(_StrictModel):
-    path: str = Field(min_length=1, max_length=256)
-    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+class _LegacyCandidateDocument(_StrictModel):
+    """Temporary reader compatibility for #37's already-published v1 shape."""
 
-
-class _CandidateDocument(_StrictModel):
     schema_version: Literal["infralink.release-candidate.v1"]
     release_identity: str = Field(pattern=_IDENTITY.pattern)
     registry_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
     controller_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
-    ci_receipt: _CiReceipt
-    artifacts: list[_ArtifactBinding] = Field(min_length=1, max_length=64)
+    ci_receipt: CiReceiptV1
+    artifacts: list[ArtifactBindingV1] = Field(min_length=1, max_length=64)
     consumers: list[Annotated[str, Field(min_length=1, max_length=128)]] = Field(
         min_length=1, max_length=64
     )
 
 
-class _PublisherReceipt(_StrictModel):
+class _LegacyPublisherReceipt(_StrictModel):
     provider: str = Field(min_length=1, max_length=128)
     run: str = Field(min_length=1, max_length=128)
 
 
-class _AttestationDocument(_StrictModel):
+class _LegacyAttestationDocument(_StrictModel):
     schema_version: Literal["infralink.release-attestation.v1"]
     release_identity: str = Field(pattern=_IDENTITY.pattern)
     registry_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
     controller_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
-    publisher_receipt: _PublisherReceipt
+    publisher_receipt: _LegacyPublisherReceipt
     tag: str = Field(pattern=_IDENTITY.pattern)
     consumers: list[Annotated[str, Field(min_length=1, max_length=128)]] = Field(
         min_length=1, max_length=64
     )
 
     @model_validator(mode="after")
-    def tag_matches_release(self) -> _AttestationDocument:
+    def tag_matches_release(self) -> _LegacyAttestationDocument:
         if self.tag != self.release_identity:
             raise ValueError("tag must match release identity")
         return self
@@ -226,26 +227,33 @@ def _parse_inputs(
     return validation, admission
 
 
-def _parse_candidate(path: Path) -> _CandidateDocument:
+def _parse_candidate(path: Path) -> _CandidateDocument | _LegacyCandidateDocument:
     try:
         return _CandidateDocument.model_validate(_load(path, kind="candidate"))
     except (ValidationError, TypeError) as error:
-        raise _invalid(
-            "candidate",
-            "does not match infralink.release-candidate.v1",
-            {"path": str(path)},
-        ) from error
+        try:
+            legacy = _LegacyCandidateDocument.model_validate(_load(path, kind="candidate"))
+            return legacy
+        except (ValidationError, TypeError):
+            raise _invalid(
+                "candidate",
+                "does not match infralink.release-candidate.v1",
+                {"path": str(path)},
+            ) from error
 
 
-def _parse_attestation(path: Path) -> _AttestationDocument:
+def _parse_attestation(path: Path) -> _AttestationDocument | _LegacyAttestationDocument:
     try:
         return _AttestationDocument.model_validate(_load(path, kind="attestation"))
     except (ValidationError, TypeError) as error:
-        raise _invalid(
-            "attestation",
-            "does not match infralink.release-attestation.v1",
-            {"path": str(path)},
-        ) from error
+        try:
+            return _LegacyAttestationDocument.model_validate(_load(path, kind="attestation"))
+        except (ValidationError, TypeError):
+            raise _invalid(
+                "attestation",
+                "does not match infralink.release-attestation.v1",
+                {"path": str(path)},
+            ) from error
 
 
 def _admission_for(
@@ -288,9 +296,17 @@ def _publisher(value: _Publisher) -> ReleasePublisher:
     return ReleasePublisher(state=value.state, provider=value.provider)
 
 
-def _candidate_output(candidate: _CandidateDocument) -> ReleaseCandidate:
+def _candidate_identity(candidate: _CandidateDocument | _LegacyCandidateDocument) -> str:
+    return (
+        candidate.release.identity
+        if isinstance(candidate, _CandidateDocument)
+        else candidate.release_identity
+    )
+
+
+def _candidate_output(candidate: _CandidateDocument | _LegacyCandidateDocument) -> ReleaseCandidate:
     return ReleaseCandidate(
-        identity=candidate.release_identity,
+        identity=_candidate_identity(candidate),
         registry_commit=candidate.registry_commit,
         controller_commit=candidate.controller_commit,
         ci_receipt=ReleaseCiReceipt(**candidate.ci_receipt.model_dump()),
@@ -412,7 +428,7 @@ def render_publisher_request(candidate: Path, admission: Path) -> None:
         ) from error
     validation = _ValidationRecord(
         schema_version="infralink.release-validation.v1",
-        release_identity=candidate_document.release_identity,
+        release_identity=_candidate_identity(candidate_document),
         registry_commit=candidate_document.registry_commit,
         controller_commit=candidate_document.controller_commit,
         annotated=True,
@@ -433,11 +449,11 @@ def render_publisher_request(candidate: Path, admission: Path) -> None:
                 )
             ],
         )
-    match = _IDENTITY.fullmatch(candidate_document.release_identity)
+    match = _IDENTITY.fullmatch(_candidate_identity(candidate_document))
     assert match is not None
     request = PublisherRequest(
         schema_version="infralink.publisher-request.v1",
-        release_identity=candidate_document.release_identity,
+        release_identity=_candidate_identity(candidate_document),
         channel=match.group(1),
         sequence=int(match.group(2)),
         registry_commit=candidate_document.registry_commit,
@@ -483,14 +499,31 @@ def render_publisher_request(candidate: Path, admission: Path) -> None:
 def inspect_attestation(attestation: Path) -> None:
     """Inspect a publisher completion record without contacting a provider."""
     value = _parse_attestation(attestation)
-    output = ReleaseAttestation(
-        release_identity=value.release_identity,
-        registry_commit=value.registry_commit,
-        controller_commit=value.controller_commit,
-        publisher_receipt=ReleasePublisherReceipt(**value.publisher_receipt.model_dump()),
-        tag=value.tag,
-        consumers=value.consumers,
-    )
+    if isinstance(value, _LegacyAttestationDocument):
+        output = ReleaseAttestation(
+            release_identity=value.release_identity,
+            registry_commit=value.registry_commit,
+            controller_commit=value.controller_commit,
+            publisher_receipt=ReleasePublisherReceipt(
+                provider=value.publisher_receipt.provider,
+                repository=None,
+                run=value.publisher_receipt.run,
+            ),
+            tag=value.tag,
+            consumers=value.consumers,
+        )
+    else:
+        output = ReleaseAttestation(
+            release_identity=value.release.identity,
+            registry_commit=value.registry_commit,
+            controller_commit=value.controller_commit,
+            ci_receipt=ReleaseCiReceipt(**value.ci_receipt.model_dump()),
+            artifacts=[ReleaseArtifactBinding(**item.model_dump()) for item in value.artifacts],
+            publisher_receipt=ReleasePublisherReceipt(**value.publisher_receipt.model_dump()),
+            tag=value.tag.name,
+            tag_object_sha1=value.tag.object_sha1,
+            consumers=value.consumers,
+        )
     _emit(
         ok_envelope(
             _context_for(path=["release", "inspect-attestation"]),

--- a/src/infralink/release/__init__.py
+++ b/src/infralink/release/__init__.py
@@ -1,0 +1,5 @@
+"""Public, versioned release producer contracts."""
+
+from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+
+__all__ = ["ReleaseAttestationV1", "ReleaseCandidateV1"]

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -1,0 +1,105 @@
+"""Typed inputs emitted by registry CI around the trusted publisher boundary."""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_CHANNEL = r"^[a-z0-9][a-z0-9-]{0,62}$"
+_IDENTITY = r"^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$"
+_COMMIT = r"^[0-9a-f]{40}$"
+_SHA256 = r"^[0-9a-f]{64}$"
+
+
+class _Contract(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class ReleaseIdentityV1(_Contract):
+    """Immutable release identity, expressed redundantly for simple CI consumers."""
+
+    identity: str = Field(pattern=_IDENTITY)
+    channel: str = Field(pattern=_CHANNEL)
+    sequence: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def identity_matches_parts(self) -> ReleaseIdentityV1:
+        if self.identity != f"releases/{self.channel}/{self.sequence}":
+            raise ValueError("identity must encode channel and sequence")
+        return self
+
+
+class CiReceiptV1(_Contract):
+    provider: str = Field(min_length=1, max_length=128)
+    repository: str = Field(min_length=1, max_length=256)
+    run: str = Field(min_length=1, max_length=128)
+
+
+class ArtifactBindingV1(_Contract):
+    path: str = Field(min_length=1, max_length=256)
+    sha256: str = Field(pattern=_SHA256)
+
+    @field_validator("path")
+    @classmethod
+    def safe_relative_path(cls, value: str) -> str:
+        path = PurePath(value)
+        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            raise ValueError("artifact path must be safe and relative")
+        return value
+
+
+ConsumerId = Annotated[str, Field(pattern=_CHANNEL, min_length=1, max_length=63)]
+
+
+class _ReleaseEvidenceV1(_Contract):
+    release: ReleaseIdentityV1
+    registry_commit: str = Field(pattern=_COMMIT)
+    controller_commit: str = Field(pattern=_COMMIT)
+    ci_receipt: CiReceiptV1
+    artifacts: list[ArtifactBindingV1] = Field(min_length=1, max_length=64)
+    consumers: list[ConsumerId] = Field(min_length=1, max_length=64)
+
+    @field_validator("artifacts")
+    @classmethod
+    def artifacts_have_unique_paths(cls, value: list[ArtifactBindingV1]) -> list[ArtifactBindingV1]:
+        if len({artifact.path for artifact in value}) != len(value):
+            raise ValueError("artifact paths must be unique")
+        return value
+
+    @field_validator("consumers")
+    @classmethod
+    def consumers_are_unique(cls, value: list[str]) -> list[str]:
+        if len(set(value)) != len(value):
+            raise ValueError("consumers must be unique")
+        return value
+
+
+class ReleaseCandidateV1(_ReleaseEvidenceV1):
+    """Immutable CI output used to render a trusted publisher request."""
+
+    schema_version: Literal["infralink.release-candidate.v1"]
+
+
+class PublisherReceiptV1(CiReceiptV1):
+    """Bounded receipt for the dedicated protected publisher run."""
+
+
+class ReleaseTagV1(_Contract):
+    name: str = Field(pattern=_IDENTITY)
+    object_sha1: str = Field(pattern=_COMMIT)
+
+
+class ReleaseAttestationV1(_ReleaseEvidenceV1):
+    """Immutable publisher completion record, including the created tag object."""
+
+    schema_version: Literal["infralink.release-attestation.v1"]
+    publisher_receipt: PublisherReceiptV1
+    tag: ReleaseTagV1
+
+    @model_validator(mode="after")
+    def tag_matches_release(self) -> ReleaseAttestationV1:
+        if self.tag.name != self.release.identity:
+            raise ValueError("tag name must match release identity")
+        return self

--- a/src/infralink/schemas/cli/v1/release-inspect-attestation.json
+++ b/src/infralink/schemas/cli/v1/release-inspect-attestation.json
@@ -140,9 +140,50 @@
       "title": "Meta",
       "type": "object"
     },
+    "ReleaseArtifactBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "title": "ReleaseArtifactBinding",
+      "type": "object"
+    },
     "ReleaseAttestation": {
       "additionalProperties": false,
       "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ReleaseArtifactBinding"
+          },
+          "maxItems": 64,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReleaseCiReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "consumers": {
           "items": {
             "maxLength": 128,
@@ -176,6 +217,19 @@
           "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
           "title": "Tag",
           "type": "string"
+        },
+        "tag_object_sha1": {
+          "anyOf": [
+            {
+              "pattern": "^[0-9a-f]{40}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tag Object Sha1"
         }
       },
       "required": [
@@ -202,6 +256,36 @@
       "title": "ReleaseAttestationResult",
       "type": "object"
     },
+    "ReleaseCiReceipt": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run"
+      ],
+      "title": "ReleaseCiReceipt",
+      "type": "object"
+    },
     "ReleasePublisherReceipt": {
       "additionalProperties": false,
       "properties": {
@@ -210,6 +294,20 @@
           "minLength": 1,
           "title": "Provider",
           "type": "string"
+        },
+        "repository": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repository"
         },
         "run": {
           "maxLength": 128,

--- a/src/infralink/schemas/release/v1/release-attestation.v1.schema.json
+++ b/src/infralink/schemas/release/v1/release-attestation.v1.schema.json
@@ -1,0 +1,202 @@
+{
+  "$defs": {
+    "ArtifactBindingV1": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "title": "ArtifactBindingV1",
+      "type": "object"
+    },
+    "CiReceiptV1": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run"
+      ],
+      "title": "CiReceiptV1",
+      "type": "object"
+    },
+    "PublisherReceiptV1": {
+      "additionalProperties": false,
+      "description": "Bounded receipt for the dedicated protected publisher run.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run"
+      ],
+      "title": "PublisherReceiptV1",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseTagV1": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "object_sha1": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Object Sha1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "object_sha1"
+      ],
+      "title": "ReleaseTagV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Immutable publisher completion record, including the created tag object.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactBindingV1"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Artifacts",
+      "type": "array"
+    },
+    "ci_receipt": {
+      "$ref": "#/$defs/CiReceiptV1"
+    },
+    "consumers": {
+      "items": {
+        "maxLength": 63,
+        "minLength": 1,
+        "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+        "type": "string"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Consumers",
+      "type": "array"
+    },
+    "controller_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Controller Commit",
+      "type": "string"
+    },
+    "publisher_receipt": {
+      "$ref": "#/$defs/PublisherReceiptV1"
+    },
+    "registry_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Registry Commit",
+      "type": "string"
+    },
+    "release": {
+      "$ref": "#/$defs/ReleaseIdentityV1"
+    },
+    "schema_version": {
+      "const": "infralink.release-attestation.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tag": {
+      "$ref": "#/$defs/ReleaseTagV1"
+    }
+  },
+  "required": [
+    "release",
+    "registry_commit",
+    "controller_commit",
+    "ci_receipt",
+    "artifacts",
+    "consumers",
+    "schema_version",
+    "publisher_receipt",
+    "tag"
+  ],
+  "title": "ReleaseAttestationV1",
+  "type": "object"
+}

--- a/src/infralink/schemas/release/v1/release-candidate.v1.schema.json
+++ b/src/infralink/schemas/release/v1/release-candidate.v1.schema.json
@@ -1,0 +1,142 @@
+{
+  "$defs": {
+    "ArtifactBindingV1": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "title": "ArtifactBindingV1",
+      "type": "object"
+    },
+    "CiReceiptV1": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run"
+      ],
+      "title": "CiReceiptV1",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Immutable CI output used to render a trusted publisher request.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactBindingV1"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Artifacts",
+      "type": "array"
+    },
+    "ci_receipt": {
+      "$ref": "#/$defs/CiReceiptV1"
+    },
+    "consumers": {
+      "items": {
+        "maxLength": 63,
+        "minLength": 1,
+        "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+        "type": "string"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Consumers",
+      "type": "array"
+    },
+    "controller_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Controller Commit",
+      "type": "string"
+    },
+    "registry_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Registry Commit",
+      "type": "string"
+    },
+    "release": {
+      "$ref": "#/$defs/ReleaseIdentityV1"
+    },
+    "schema_version": {
+      "const": "infralink.release-candidate.v1",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "release",
+    "registry_commit",
+    "controller_commit",
+    "ci_receipt",
+    "artifacts",
+    "consumers",
+    "schema_version"
+  ],
+  "title": "ReleaseCandidateV1",
+  "type": "object"
+}

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -50,7 +50,11 @@ def _admission(path: Path, payload: dict[str, object] | None = None) -> Path:
 def _candidate(path: Path, **overrides: object) -> Path:
     payload: dict[str, object] = {
         "schema_version": "infralink.release-candidate.v1",
-        "release_identity": "releases/core-v2/42",
+        "release": {
+            "identity": "releases/core-v2/42",
+            "channel": "core-v2",
+            "sequence": 42,
+        },
         "registry_commit": REGISTRY_COMMIT,
         "controller_commit": CONTROLLER_COMMIT,
         "ci_receipt": {
@@ -74,11 +78,25 @@ def _candidate(path: Path, **overrides: object) -> Path:
 def _attestation(path: Path, **overrides: object) -> Path:
     payload: dict[str, object] = {
         "schema_version": "infralink.release-attestation.v1",
-        "release_identity": "releases/core-v2/42",
+        "release": {
+            "identity": "releases/core-v2/42",
+            "channel": "core-v2",
+            "sequence": 42,
+        },
         "registry_commit": REGISTRY_COMMIT,
         "controller_commit": CONTROLLER_COMMIT,
-        "publisher_receipt": {"provider": "woodpecker", "run": "600"},
-        "tag": "releases/core-v2/42",
+        "ci_receipt": {
+            "provider": "woodpecker",
+            "repository": "relaxgg/infra-registry",
+            "run": "576",
+        },
+        "artifacts": [{"path": "release/runtime.tar.gz", "sha256": "c" * 64}],
+        "publisher_receipt": {
+            "provider": "woodpecker",
+            "repository": "relaxgg/infra-registry",
+            "run": "600",
+        },
+        "tag": {"name": "releases/core-v2/42", "object_sha1": "d" * 40},
         "consumers": ["citadel", "watchtower"],
     }
     payload.update(overrides)
@@ -223,6 +241,14 @@ def test_release_inspect_attestation_reports_consumer_shadow_actions(tmp_path: P
     payload = _payload(result)
     assert_schema(payload, "release-inspect-attestation")
     assert payload["result"]["attestation"]["tag"] == "releases/core-v2/42"
+    assert payload["result"]["attestation"]["tag_object_sha1"] == "d" * 40
+    assert payload["result"]["attestation"]["ci_receipt"]["run"] == "576"
+    assert payload["result"]["attestation"]["artifacts"] == [
+        {"path": "release/runtime.tar.gz", "sha256": "c" * 64}
+    ]
+    assert payload["result"]["attestation"]["publisher_receipt"]["repository"] == (
+        "relaxgg/infra-registry"
+    )
     assert payload["result"]["attestation"]["consumers"] == ["citadel", "watchtower"]
     assert payload["next_actions"] == []
 
@@ -237,6 +263,61 @@ def test_release_validate_candidate_rejects_mutable_branch_authority(tmp_path: P
     assert result.exit_code == 3
     payload = _payload(result)
     assert payload["error"]["code"] == "release_candidate_invalid"
+
+
+def test_release_reads_the_already_published_flat_v1_candidate_shape(tmp_path: Path) -> None:
+    candidate = tmp_path / "legacy-candidate.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "schema_version": "infralink.release-candidate.v1",
+                "release_identity": "releases/core-v2/42",
+                "registry_commit": REGISTRY_COMMIT,
+                "controller_commit": CONTROLLER_COMMIT,
+                "ci_receipt": {
+                    "provider": "woodpecker",
+                    "repository": "relaxgg/infra-registry",
+                    "run": "576",
+                },
+                "artifacts": [{"path": "release/runtime.tar.gz", "sha256": "c" * 64}],
+                "consumers": ["CITADEL", "c" * 64],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli, ["release", "validate-candidate", "--candidate", str(candidate)]
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_release_reads_the_already_published_flat_v1_attestation_shape(tmp_path: Path) -> None:
+    attestation = tmp_path / "legacy-attestation.json"
+    attestation.write_text(
+        json.dumps(
+            {
+                "schema_version": "infralink.release-attestation.v1",
+                "release_identity": "releases/core-v2/42",
+                "registry_commit": REGISTRY_COMMIT,
+                "controller_commit": CONTROLLER_COMMIT,
+                "publisher_receipt": {"provider": "woodpecker", "run": "600"},
+                "tag": "releases/core-v2/42",
+                "consumers": ["CITADEL", "c" * 64],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli, ["release", "inspect-attestation", "--attestation", str(attestation)]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _payload(result)
+    assert payload["result"]["attestation"]["tag_object_sha1"] is None
+    assert payload["result"]["attestation"]["publisher_receipt"]["repository"] is None
 
 
 def test_release_validate_candidate_bounds_each_consumer_name(tmp_path: Path) -> None:

--- a/tests/test_cli_secret_leaks.py
+++ b/tests/test_cli_secret_leaks.py
@@ -176,7 +176,11 @@ selection:
         json.dumps(
             {
                 "schema_version": "infralink.release-candidate.v1",
-                "release_identity": "releases/core-v2/42",
+                "release": {
+                    "identity": "releases/core-v2/42",
+                    "channel": "core-v2",
+                    "sequence": 42,
+                },
                 "registry_commit": "a" * 40,
                 "controller_commit": "b" * 40,
                 "ci_receipt": {
@@ -195,11 +199,25 @@ selection:
         json.dumps(
             {
                 "schema_version": "infralink.release-attestation.v1",
-                "release_identity": "releases/core-v2/42",
+                "release": {
+                    "identity": "releases/core-v2/42",
+                    "channel": "core-v2",
+                    "sequence": 42,
+                },
                 "registry_commit": "a" * 40,
                 "controller_commit": "b" * 40,
-                "publisher_receipt": {"provider": "woodpecker", "run": "600"},
-                "tag": "releases/core-v2/42",
+                "ci_receipt": {
+                    "provider": "woodpecker",
+                    "repository": "relaxgg/infra-registry",
+                    "run": "576",
+                },
+                "artifacts": [{"path": "release/runtime.tar.gz", "sha256": "c" * 64}],
+                "publisher_receipt": {
+                    "provider": "woodpecker",
+                    "repository": "relaxgg/infra-registry",
+                    "run": "600",
+                },
+                "tag": {"name": "releases/core-v2/42", "object_sha1": "d" * 40},
                 "consumers": ["citadel"],
             }
         ),

--- a/tests/test_public_data_boundary.py
+++ b/tests/test_public_data_boundary.py
@@ -92,6 +92,8 @@ SAFE_DOTTED_TOKENS = {
     "infralink-0.2.0-py3-none-any.whl",
     "infralink-0.2.0.tar.gz",
     "infralink.cli",
+    "infralink.release-attestation.v1",
+    "infralink.release-candidate.v1",
     "agent-cli.response.v1",
     "infralink.observation",
     "nginx.access",
@@ -810,7 +812,8 @@ def test_boundary_detector_allows_public_examples_and_domain_uuids() -> None:
     BWS_PROJECT_ID=<project-id>
     BWS_ORGANIZATION_ID=<organization-id>
     export BWS_ORGANIZATION_ID="<organization-uuid>"
-    prose: infralink.cli/v1, manifest.json, and resolver.get are identifiers.
+    prose: infralink.cli/v1, infralink.release-candidate.v1,
+    infralink.release-attestation.v1, manifest.json, and resolver.get are identifiers.
     files: registry.yml, edges.yml, PRD.md, and BACKLOG.md are public files.
     line_refs: README.md:12, manifest.json:12, and registry.yml:12 are public file references.
     path: docs/reference.md is an unambiguous public file path.

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+from infralink.cli.main import cli
+from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+
+ROOT = Path(__file__).parents[1]
+FIXTURES = ROOT / "examples" / "release"
+SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_public_candidate_fixture_has_explicit_immutable_release_bindings() -> None:
+    candidate = ReleaseCandidateV1.model_validate(_fixture("release-candidate.v1.json"))
+
+    assert candidate.release.identity == "releases/core-v2/42"
+    assert candidate.release.channel == "core-v2"
+    assert candidate.release.sequence == 42
+    assert candidate.registry_commit == "a" * 40
+    assert candidate.controller_commit == "b" * 40
+    assert candidate.artifacts[0].sha256 == "c" * 64
+    assert candidate.consumers == ["citadel", "watchtower"]
+
+
+def test_public_attestation_fixture_binds_candidate_facts_to_publisher_tag() -> None:
+    attestation = ReleaseAttestationV1.model_validate(_fixture("release-attestation.v1.json"))
+
+    assert attestation.release.identity == "releases/core-v2/42"
+    assert attestation.publisher_receipt.provider == "woodpecker"
+    assert attestation.tag.name == attestation.release.identity
+    assert attestation.tag.object_sha1 == "d" * 40
+    assert attestation.artifacts[0].sha256 == "c" * 64
+
+
+@pytest.mark.parametrize(
+    "fixture_name, model",
+    [
+        ("release-candidate.v1.json", ReleaseCandidateV1),
+        ("release-attestation.v1.json", ReleaseAttestationV1),
+    ],
+)
+def test_published_schema_accepts_the_public_fixture(
+    fixture_name: str, model: type[ReleaseCandidateV1] | type[ReleaseAttestationV1]
+) -> None:
+    fixture = _fixture(fixture_name)
+    schema_name = fixture_name.removesuffix(".json") + ".schema.json"
+    schema = json.loads((SCHEMAS / schema_name).read_text(encoding="utf-8"))
+
+    Draft202012Validator(schema).validate(fixture)
+    assert model.model_validate(fixture)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("branch", "main"),
+        ("ref", "refs/heads/main"),
+    ],
+)
+def test_candidate_rejects_mutable_ref_authority(field: str, value: str) -> None:
+    candidate = _fixture("release-candidate.v1.json")
+    candidate[field] = value
+
+    with pytest.raises(ValidationError):
+        ReleaseCandidateV1.model_validate(candidate)
+
+
+@pytest.mark.parametrize("field, value", [("branch", "main"), ("ref", "refs/heads/main")])
+def test_published_candidate_schema_rejects_mutable_ref_authority(field: str, value: str) -> None:
+    candidate = _fixture("release-candidate.v1.json")
+    candidate[field] = value
+    schema = json.loads((SCHEMAS / "release-candidate.v1.schema.json").read_text(encoding="utf-8"))
+
+    assert list(Draft202012Validator(schema).iter_errors(candidate))
+
+
+def test_candidate_rejects_release_identity_channel_or_sequence_mismatch() -> None:
+    candidate = _fixture("release-candidate.v1.json")
+    release = candidate["release"]
+    assert isinstance(release, dict)
+    release["sequence"] = 43
+
+    with pytest.raises(ValidationError, match="identity must encode channel and sequence"):
+        ReleaseCandidateV1.model_validate(candidate)
+
+
+def test_attestation_rejects_a_tag_for_another_release() -> None:
+    attestation = _fixture("release-attestation.v1.json")
+    tag = attestation["tag"]
+    assert isinstance(tag, dict)
+    tag["name"] = "releases/core-v2/43"
+
+    with pytest.raises(ValidationError, match="tag name must match release identity"):
+        ReleaseAttestationV1.model_validate(attestation)
+
+
+def test_merged_release_cli_accepts_public_producer_fixtures() -> None:
+    candidate = FIXTURES / "release-candidate.v1.json"
+    attestation = FIXTURES / "release-attestation.v1.json"
+
+    candidate_result = CliRunner().invoke(
+        cli, ["release", "validate-candidate", "--candidate", str(candidate)]
+    )
+    attestation_result = CliRunner().invoke(
+        cli, ["release", "inspect-attestation", "--attestation", str(attestation)]
+    )
+
+    assert candidate_result.exit_code == 0, candidate_result.output
+    assert attestation_result.exit_code == 0, attestation_result.output

--- a/tests/test_woodpecker_ci_policy.py
+++ b/tests/test_woodpecker_ci_policy.py
@@ -19,6 +19,7 @@ EXPECTED_COMMANDS = [
     "python -m mypy src scripts",
     "python -m pytest",
     "python scripts/generate_cli_schemas.py",
+    "python scripts/generate_release_schemas.py",
     "git diff --exit-code",
     'test -z "$(git ls-files --others --exclude-standard src/infralink/schemas)"',
     "python -m build",


### PR DESCRIPTION
Closes #38

## Summary
- publish typed release-candidate and release-attestation producer contracts with packaged schemas and sanitized fixtures
- keep the #37 flat v1 readers compatible while steering new registry CI to the explicit immutable nested contract
- expose attestation provenance, artifact digests, and tag object binding through the read-only CLI

## Validation
- independent review approved
- ruff format/check, mypy, and focused release/secret/CI policy tests pass

No signing, BWS, Woodpecker/Gitea configuration, tag publishing, or host action is included.