### PR TITLE
feat(release): add immutable publisher v2 contracts

### DIFF
--- a/examples/release/publisher-request.v2.json
+++ b/examples/release/publisher-request.v2.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "infralink.publisher-request.v2",
+  "release": {
+    "identity": "releases/core-v2/42",
+    "channel": "core-v2",
+    "sequence": 42
+  },
+  "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ci_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/registry",
+    "run": "576",
+    "source_identity": "woodpecker://example.com/registry/pipelines/576",
+    "source_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "artifacts": [
+    {
+      "path": "release/runtime-archive",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "source_identity": "woodpecker://example.com/registry/artifacts/runtime-archive",
+      "source_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  ],
+  "publisher": {
+    "identity": "infralink-release-publisher-woodpecker",
+    "image": "registry.example.com/infralink/publisher@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "mode": "dry-run",
+  "request_digest": "18352c07018a14bb764fffc9914ffe2ee051e90dd3bedbd0d57f6bad2440e784"
+}

--- a/examples/release/release-attestation.v2.json
+++ b/examples/release/release-attestation.v2.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "infralink.release-attestation.v2",
+  "request": {
+    "schema_version": "infralink.publisher-request.v2",
+    "release": {
+      "identity": "releases/core-v2/42",
+      "channel": "core-v2",
+      "sequence": 42
+    },
+    "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "ci_receipt": {
+      "provider": "woodpecker",
+      "repository": "example/registry",
+      "run": "576",
+      "source_identity": "woodpecker://example.com/registry/pipelines/576",
+      "source_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    },
+    "artifacts": [
+      {
+        "path": "release/runtime-archive",
+        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "source_identity": "woodpecker://example.com/registry/artifacts/runtime-archive",
+        "source_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      }
+    ],
+    "publisher": {
+      "identity": "infralink-release-publisher-woodpecker",
+      "image": "registry.example.com/infralink/publisher@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "mode": "dry-run",
+    "request_digest": "18352c07018a14bb764fffc9914ffe2ee051e90dd3bedbd0d57f6bad2440e784"
+  },
+  "request_digest": "18352c07018a14bb764fffc9914ffe2ee051e90dd3bedbd0d57f6bad2440e784",
+  "publisher_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/release-publisher",
+    "run": "600",
+    "source_identity": "woodpecker://example.com/release-publisher/pipelines/600",
+    "source_digest": "1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "result": "dry-run",
+  "tag": null
+}

--- a/scripts/generate_release_schemas.py
+++ b/scripts/generate_release_schemas.py
@@ -6,33 +6,44 @@ import json
 from pathlib import Path
 from typing import Any
 
-from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+from infralink.release.contracts import (
+    PublisherRequestV2,
+    ReleaseAttestationV1,
+    ReleaseAttestationV2,
+    ReleaseCandidateV1,
+)
 
 ROOT = Path(__file__).parents[1]
-OUTPUT = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
-MODELS: dict[str, Any] = {
+OUTPUT_ROOT = ROOT / "src" / "infralink" / "schemas" / "release"
+V1_MODELS: dict[str, Any] = {
     "release-candidate.v1.schema.json": ReleaseCandidateV1,
     "release-attestation.v1.schema.json": ReleaseAttestationV1,
 }
+V2_MODELS: dict[str, Any] = {
+    "publisher-request.v2.schema.json": PublisherRequestV2,
+    "release-attestation.v2.schema.json": ReleaseAttestationV2,
+}
 
 
-def render_schemas() -> dict[str, str]:
+def render_schemas(models: dict[str, Any] = V1_MODELS) -> dict[str, str]:
     rendered: dict[str, str] = {}
-    for filename, model in MODELS.items():
+    for filename, model in models.items():
         schema = model.model_json_schema()
         schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
         rendered[filename] = json.dumps(schema, indent=2, sort_keys=True) + "\n"
     return rendered
 
 
-def write_schemas(output: Path = OUTPUT) -> None:
-    output.mkdir(parents=True, exist_ok=True)
-    rendered = render_schemas()
-    for path in output.glob("*.json"):
-        if path.name not in rendered:
-            path.unlink()
-    for filename, body in rendered.items():
-        (output / filename).write_text(body, encoding="utf-8")
+def write_schemas(output_root: Path = OUTPUT_ROOT) -> None:
+    for version, models in (("v1", V1_MODELS), ("v2", V2_MODELS)):
+        output = output_root / version
+        output.mkdir(parents=True, exist_ok=True)
+        rendered = render_schemas(models)
+        for path in output.glob("*.json"):
+            if path.name not in rendered:
+                path.unlink()
+        for filename, body in rendered.items():
+            (output / filename).write_text(body, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import PurePath
 from typing import Annotated, Literal
 
@@ -11,6 +13,8 @@ _CHANNEL = r"^[a-z0-9][a-z0-9-]{0,62}$"
 _IDENTITY = r"^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$"
 _COMMIT = r"^[0-9a-f]{40}$"
 _SHA256 = r"^[0-9a-f]{64}$"
+_SOURCE_IDENTITY = r"^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$"
+_OCI_IMAGE_DIGEST = r"^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$"
 
 
 class _Contract(BaseModel):
@@ -102,4 +106,96 @@ class ReleaseAttestationV1(_ReleaseEvidenceV1):
     def tag_matches_release(self) -> ReleaseAttestationV1:
         if self.tag.name != self.release.identity:
             raise ValueError("tag name must match release identity")
+        return self
+
+
+class ImmutableSourceReceiptV2(_Contract):
+    """A receipt whose source cannot be silently retargeted."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    repository: str = Field(min_length=1, max_length=256)
+    run: str = Field(min_length=1, max_length=128)
+    source_identity: str = Field(pattern=_SOURCE_IDENTITY, max_length=512)
+    source_digest: str = Field(pattern=_SHA256)
+
+
+class ArtifactSourceBindingV2(ArtifactBindingV1):
+    """A release artifact and the immutable source from which it was obtained."""
+
+    source_identity: str = Field(pattern=_SOURCE_IDENTITY, max_length=512)
+    source_digest: str = Field(pattern=_SHA256)
+
+
+class PublisherIdentityV2(_Contract):
+    """The protected publisher identity and immutable runner image."""
+
+    identity: ConsumerId
+    image: str = Field(pattern=_OCI_IMAGE_DIGEST, max_length=512)
+
+
+class PublisherRequestV2(_Contract):
+    """Canonical input for one protected publisher invocation."""
+
+    schema_version: Literal["infralink.publisher-request.v2"]
+    release: ReleaseIdentityV1
+    registry_commit: str = Field(pattern=_COMMIT)
+    controller_commit: str = Field(pattern=_COMMIT)
+    ci_receipt: ImmutableSourceReceiptV2
+    artifacts: list[ArtifactSourceBindingV2] = Field(min_length=1, max_length=64)
+    publisher: PublisherIdentityV2
+    mode: Literal["dry-run", "publish"]
+    request_digest: str = Field(pattern=_SHA256)
+
+    @field_validator("artifacts")
+    @classmethod
+    def artifacts_have_unique_sources(
+        cls, value: list[ArtifactSourceBindingV2]
+    ) -> list[ArtifactSourceBindingV2]:
+        if len({artifact.path for artifact in value}) != len(value):
+            raise ValueError("artifact paths must be unique")
+        if len({artifact.source_identity for artifact in value}) != len(value):
+            raise ValueError("artifact source identities must be unique")
+        return value
+
+    def canonical_digest(self) -> str:
+        """Return the SHA-256 of the canonical request without its self-binding field."""
+        body = json.dumps(
+            self.model_dump(mode="json", exclude={"request_digest"}),
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        return hashlib.sha256(body).hexdigest()
+
+    @model_validator(mode="after")
+    def request_digest_matches_canonical_payload(self) -> PublisherRequestV2:
+        if self.request_digest != self.canonical_digest():
+            raise ValueError("request_digest must match the canonical request payload")
+        return self
+
+
+class ReleaseAttestationV2(_Contract):
+    """Immutable publisher result bound to the exact canonical v2 request."""
+
+    schema_version: Literal["infralink.release-attestation.v2"]
+    request: PublisherRequestV2
+    request_digest: str = Field(pattern=_SHA256)
+    publisher_receipt: ImmutableSourceReceiptV2
+    result: Literal["dry-run", "published"]
+    tag: ReleaseTagV1 | None = None
+
+    @model_validator(mode="after")
+    def result_matches_request(self) -> ReleaseAttestationV2:
+        if self.request_digest != self.request.canonical_digest():
+            raise ValueError("request_digest must match the canonical publisher request")
+        expected_result = "dry-run" if self.request.mode == "dry-run" else "published"
+        if self.result != expected_result:
+            raise ValueError("attestation result must match the requested mode")
+        if self.result == "published":
+            if self.tag is None:
+                raise ValueError("published attestation requires a tag")
+            if self.tag.name != self.request.release.identity:
+                raise ValueError("tag name must match release identity")
+        elif self.tag is not None:
+            raise ValueError("dry-run attestation must not include a tag")
         return self

--- a/src/infralink/schemas/release/v2/publisher-request.v2.schema.json
+++ b/src/infralink/schemas/release/v2/publisher-request.v2.schema.json
@@ -1,0 +1,201 @@
+{
+  "$defs": {
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Canonical input for one protected publisher invocation.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactSourceBindingV2"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Artifacts",
+      "type": "array"
+    },
+    "ci_receipt": {
+      "$ref": "#/$defs/ImmutableSourceReceiptV2"
+    },
+    "controller_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Controller Commit",
+      "type": "string"
+    },
+    "mode": {
+      "enum": [
+        "dry-run",
+        "publish"
+      ],
+      "title": "Mode",
+      "type": "string"
+    },
+    "publisher": {
+      "$ref": "#/$defs/PublisherIdentityV2"
+    },
+    "registry_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Registry Commit",
+      "type": "string"
+    },
+    "release": {
+      "$ref": "#/$defs/ReleaseIdentityV1"
+    },
+    "request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Request Digest",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "infralink.publisher-request.v2",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "release",
+    "registry_commit",
+    "controller_commit",
+    "ci_receipt",
+    "artifacts",
+    "publisher",
+    "mode",
+    "request_digest"
+  ],
+  "title": "PublisherRequestV2",
+  "type": "object"
+}

--- a/src/infralink/schemas/release/v2/release-attestation.v2.schema.json
+++ b/src/infralink/schemas/release/v2/release-attestation.v2.schema.json
@@ -1,0 +1,272 @@
+{
+  "$defs": {
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
+      "type": "object"
+    },
+    "PublisherRequestV2": {
+      "additionalProperties": false,
+      "description": "Canonical input for one protected publisher invocation.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v2",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest"
+      ],
+      "title": "PublisherRequestV2",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseTagV1": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "object_sha1": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Object Sha1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "object_sha1"
+      ],
+      "title": "ReleaseTagV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Immutable publisher result bound to the exact canonical v2 request.",
+  "properties": {
+    "publisher_receipt": {
+      "$ref": "#/$defs/ImmutableSourceReceiptV2"
+    },
+    "request": {
+      "$ref": "#/$defs/PublisherRequestV2"
+    },
+    "request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Request Digest",
+      "type": "string"
+    },
+    "result": {
+      "enum": [
+        "dry-run",
+        "published"
+      ],
+      "title": "Result",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "infralink.release-attestation.v2",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tag": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ReleaseTagV1"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "request",
+    "request_digest",
+    "publisher_receipt",
+    "result"
+  ],
+  "title": "ReleaseAttestationV2",
+  "type": "object"
+}

--- a/tests/test_public_data_boundary.py
+++ b/tests/test_public_data_boundary.py
@@ -93,6 +93,8 @@ SAFE_DOTTED_TOKENS = {
     "infralink-0.2.0.tar.gz",
     "infralink.cli",
     "infralink.release-attestation.v1",
+    "infralink.release-attestation.v2",
+    "infralink.publisher-request.v2",
     "infralink.release-candidate.v1",
     "agent-cli.response.v1",
     "infralink.observation",

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -9,11 +10,17 @@ from jsonschema import Draft202012Validator
 from pydantic import ValidationError
 
 from infralink.cli.main import cli
-from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+from infralink.release.contracts import (
+    PublisherRequestV2,
+    ReleaseAttestationV1,
+    ReleaseAttestationV2,
+    ReleaseCandidateV1,
+)
 
 ROOT = Path(__file__).parents[1]
 FIXTURES = ROOT / "examples" / "release"
 SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
+V2_SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v2"
 
 
 def _fixture(name: str) -> dict[str, object]:
@@ -117,3 +124,88 @@ def test_merged_release_cli_accepts_public_producer_fixtures() -> None:
 
     assert candidate_result.exit_code == 0, candidate_result.output
     assert attestation_result.exit_code == 0, attestation_result.output
+
+
+def test_v2_request_fixture_has_canonical_digest_and_immutable_sources() -> None:
+    request = PublisherRequestV2.model_validate(_fixture("publisher-request.v2.json"))
+
+    assert request.request_digest == request.canonical_digest()
+    assert request.ci_receipt.source_identity == "woodpecker://example.com/registry/pipelines/576"
+    assert request.artifacts[0].source_digest == "e" * 64
+    assert request.publisher.image.endswith("@sha256:" + "f" * 64)
+    assert request.mode == "dry-run"
+
+
+def test_v2_attestation_fixture_binds_the_canonical_request_digest() -> None:
+    attestation = ReleaseAttestationV2.model_validate(_fixture("release-attestation.v2.json"))
+
+    assert attestation.request_digest == attestation.request.canonical_digest()
+    assert attestation.result == "dry-run"
+    assert attestation.tag is None
+
+
+@pytest.mark.parametrize(
+    "fixture_name, model, schema_name",
+    [
+        ("publisher-request.v2.json", PublisherRequestV2, "publisher-request.v2.schema.json"),
+        ("release-attestation.v2.json", ReleaseAttestationV2, "release-attestation.v2.schema.json"),
+    ],
+)
+def test_published_v2_schema_accepts_public_fixture(
+    fixture_name: str,
+    model: type[PublisherRequestV2] | type[ReleaseAttestationV2],
+    schema_name: str,
+) -> None:
+    fixture = _fixture(fixture_name)
+    schema = json.loads((V2_SCHEMAS / schema_name).read_text(encoding="utf-8"))
+
+    Draft202012Validator(schema).validate(fixture)
+    assert model.model_validate(fixture)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("request_digest", "0" * 64),
+        ("registry_commit", "main"),
+        ("publisher", {"identity": "publisher", "image": "publisher:latest"}),
+    ],
+)
+def test_v2_request_rejects_noncanonical_mutable_or_unpinned_input(
+    field: str, value: object
+) -> None:
+    request = _fixture("publisher-request.v2.json")
+    request[field] = value
+
+    with pytest.raises(ValidationError):
+        PublisherRequestV2.model_validate(request)
+
+
+def test_v2_request_rejects_unknown_and_secret_bearing_source_fields() -> None:
+    request = _fixture("publisher-request.v2.json")
+    receipt = request["ci_receipt"]
+    assert isinstance(receipt, dict)
+    receipt["token"] = "not-a-secret"
+
+    with pytest.raises(ValidationError):
+        PublisherRequestV2.model_validate(request)
+
+
+def test_v2_attestation_requires_a_tag_only_when_published() -> None:
+    attestation = _fixture("release-attestation.v2.json")
+    request = attestation["request"]
+    assert isinstance(request, dict)
+    request["mode"] = "publish"
+    request_without_digest = {
+        key: value for key, value in request.items() if key != "request_digest"
+    }
+    request["request_digest"] = hashlib.sha256(
+        json.dumps(
+            request_without_digest, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        ).encode("ascii")
+    ).hexdigest()
+    attestation["request_digest"] = request["request_digest"]
+    attestation["result"] = "published"
+
+    with pytest.raises(ValidationError, match="published attestation requires a tag"):
+        ReleaseAttestationV2.model_validate(attestation)


### PR DESCRIPTION
Closes #41.

Adds strict, additive public contracts for `infralink.publisher-request.v2` and `infralink.release-attestation.v2`, plus fixtures and deterministic generated JSON schemas.

- v1 contracts and generated schemas remain unchanged.
- v2 binds immutable source/image/artifact/receipt metadata and validates canonical self-digests with bounded fields.
- No BWS, Gitea, registry mutation, tag publication, or publisher runner changes.

Verification: 20 focused producer-contract tests, Ruff format/check, mypy, deterministic schema generation, and independent review all pass. The full suite was not used as a completion claim because its prior review run did not return a final result.