### PR TITLE
fix(release): reject duplicate keys in publisher v2 JSON

### DIFF
--- a/src/infralink/release/__init__.py
+++ b/src/infralink/release/__init__.py
@@ -1,5 +1,19 @@
 """Public, versioned release producer contracts."""
 
-from infralink.release.contracts import ReleaseAttestationV1, ReleaseCandidateV1
+from infralink.release.contracts import (
+    PublisherRequestV2,
+    ReleaseAttestationV1,
+    ReleaseAttestationV2,
+    ReleaseCandidateV1,
+    parse_publisher_request_v2_json,
+    parse_release_attestation_v2_json,
+)
 
-__all__ = ["ReleaseAttestationV1", "ReleaseCandidateV1"]
+__all__ = [
+    "PublisherRequestV2",
+    "ReleaseAttestationV1",
+    "ReleaseAttestationV2",
+    "ReleaseCandidateV1",
+    "parse_publisher_request_v2_json",
+    "parse_release_attestation_v2_json",
+]

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -17,6 +17,24 @@ _SOURCE_IDENTITY = r"^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$"
 _OCI_IMAGE_DIGEST = r"^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$"
 
 
+class DuplicateJsonKeyError(ValueError):
+    """Raised when a strict v2 contract document repeats an object member."""
+
+
+def _reject_duplicate_object_members(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, member in pairs:
+        if key in value:
+            raise DuplicateJsonKeyError(f"duplicate JSON object key: {key!r}")
+        value[key] = member
+    return value
+
+
+def _load_strict_v2_json(document: str | bytes | bytearray) -> object:
+    """Decode a v2 contract document without silently resolving duplicate keys."""
+    return json.loads(document, object_pairs_hook=_reject_duplicate_object_members)
+
+
 class _Contract(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
@@ -199,3 +217,13 @@ class ReleaseAttestationV2(_Contract):
         elif self.tag is not None:
             raise ValueError("dry-run attestation must not include a tag")
         return self
+
+
+def parse_publisher_request_v2_json(document: str | bytes | bytearray) -> PublisherRequestV2:
+    """Parse one publisher request through the strict v2 JSON boundary."""
+    return PublisherRequestV2.model_validate(_load_strict_v2_json(document))
+
+
+def parse_release_attestation_v2_json(document: str | bytes | bytearray) -> ReleaseAttestationV2:
+    """Parse one publisher attestation through the strict v2 JSON boundary."""
+    return ReleaseAttestationV2.model_validate(_load_strict_v2_json(document))

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -15,12 +16,15 @@ from infralink.release.contracts import (
     ReleaseAttestationV1,
     ReleaseAttestationV2,
     ReleaseCandidateV1,
+    parse_publisher_request_v2_json,
+    parse_release_attestation_v2_json,
 )
 
 ROOT = Path(__file__).parents[1]
 FIXTURES = ROOT / "examples" / "release"
 SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
 V2_SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v2"
+V2JsonParser = Callable[[str], PublisherRequestV2 | ReleaseAttestationV2]
 
 
 def _fixture(name: str) -> dict[str, object]:
@@ -142,6 +146,54 @@ def test_v2_attestation_fixture_binds_the_canonical_request_digest() -> None:
     assert attestation.request_digest == attestation.request.canonical_digest()
     assert attestation.result == "dry-run"
     assert attestation.tag is None
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "parser"),
+    [
+        ("publisher-request.v2.json", parse_publisher_request_v2_json),
+        ("release-attestation.v2.json", parse_release_attestation_v2_json),
+    ],
+)
+def test_v2_json_parsers_accept_public_fixtures(fixture_name: str, parser: V2JsonParser) -> None:
+    assert parser((FIXTURES / fixture_name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "parser", "duplicate_member"),
+    [
+        (
+            "publisher-request.v2.json",
+            parse_publisher_request_v2_json,
+            '  "schema_version": "infralink.publisher-request.v2",\n',
+        ),
+        (
+            "publisher-request.v2.json",
+            parse_publisher_request_v2_json,
+            '    "identity": "infralink-release-publisher-woodpecker",\n',
+        ),
+        (
+            "release-attestation.v2.json",
+            parse_release_attestation_v2_json,
+            '  "schema_version": "infralink.release-attestation.v2",\n',
+        ),
+        (
+            "release-attestation.v2.json",
+            parse_release_attestation_v2_json,
+            '      "identity": "infralink-release-publisher-woodpecker",\n',
+        ),
+    ],
+)
+def test_v2_json_parsers_reject_duplicate_object_members(
+    fixture_name: str,
+    parser: V2JsonParser,
+    duplicate_member: str,
+) -> None:
+    document = (FIXTURES / fixture_name).read_text(encoding="utf-8")
+    duplicate_document = document.replace(duplicate_member, duplicate_member * 2, 1)
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        parser(duplicate_document)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #44.

Adds explicit strict v2 JSON parse boundaries for publisher requests and attestations. Duplicate keys are rejected recursively before Pydantic validation.

V1 and direct Pydantic model APIs are unchanged.

Verification: 1,229 passed, 1 skipped; Ruff, mypy, diff check, and independent review pass.