### PR TITLE
feat(release): bind immutable publisher tag signer policy

### DIFF
--- a/examples/release/publisher-request.v3.json
+++ b/examples/release/publisher-request.v3.json
@@ -29,9 +29,9 @@
   "mode": "dry-run",
   "tag_signer_policy": {
     "selector": {
-      "repository": "gitea://gitea.i.cyberstorm.dev/cyberstorm/infralink-release-publisher",
+      "repository": "gitea://example.com/example/infralink-release-publisher",
       "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "path": "release-publisher/allowed-signers.json",
+      "path": "release-publisher/tag-signer-policy",
       "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     },
     "signer": {
@@ -43,5 +43,5 @@
     "principal": "infralink-release-publisher",
     "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   },
-  "request_digest": "cb430f4d36f7acb1538863d7c297856194d9fa7057544eeb78747034125e7165"
+  "request_digest": "cc8abef32517b7174a7b53d5dac204c8151404a5191f04b841678dd70b3f0ce7"
 }

--- a/examples/release/publisher-request.v3.json
+++ b/examples/release/publisher-request.v3.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "infralink.publisher-request.v3",
+  "release": {
+    "identity": "releases/core-v2/42",
+    "channel": "core-v2",
+    "sequence": 42
+  },
+  "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ci_receipt": {
+    "provider": "woodpecker",
+    "repository": "example/registry",
+    "run": "576",
+    "source_identity": "woodpecker://example.com/registry/pipelines/576",
+    "source_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "artifacts": [
+    {
+      "path": "release/runtime-archive",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "source_identity": "woodpecker://example.com/registry/artifacts/runtime-archive",
+      "source_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  ],
+  "publisher": {
+    "identity": "infralink-release-publisher-woodpecker",
+    "image": "registry.example.com/infralink/publisher@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "mode": "dry-run",
+  "tag_signer_policy": {
+    "selector": {
+      "repository": "gitea://gitea.i.cyberstorm.dev/cyberstorm/infralink-release-publisher",
+      "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "path": "release-publisher/allowed-signers.json",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "signer": {
+      "principal": "infralink-release-publisher",
+      "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    }
+  },
+  "manifest_signer": {
+    "principal": "infralink-release-publisher",
+    "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "request_digest": "46e2030b8d42e4f61ee788f543621c5b45700aff056f7bf564d72c3460b1c844"
+}

--- a/examples/release/publisher-request.v3.json
+++ b/examples/release/publisher-request.v3.json
@@ -36,12 +36,12 @@
     },
     "signer": {
       "principal": "infralink-release-publisher",
-      "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     }
   },
   "manifest_signer": {
     "principal": "infralink-release-publisher",
-    "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   },
-  "request_digest": "46e2030b8d42e4f61ee788f543621c5b45700aff056f7bf564d72c3460b1c844"
+  "request_digest": "cb430f4d36f7acb1538863d7c297856194d9fa7057544eeb78747034125e7165"
 }

--- a/scripts/generate_release_schemas.py
+++ b/scripts/generate_release_schemas.py
@@ -8,8 +8,10 @@ from typing import Any
 
 from infralink.release.contracts import (
     PublisherRequestV2,
+    PublisherRequestV3,
     ReleaseAttestationV1,
     ReleaseAttestationV2,
+    ReleaseAttestationV3,
     ReleaseCandidateV1,
 )
 
@@ -23,6 +25,10 @@ V2_MODELS: dict[str, Any] = {
     "publisher-request.v2.schema.json": PublisherRequestV2,
     "release-attestation.v2.schema.json": ReleaseAttestationV2,
 }
+V3_MODELS: dict[str, Any] = {
+    "publisher-request.v3.schema.json": PublisherRequestV3,
+    "release-attestation.v3.schema.json": ReleaseAttestationV3,
+}
 
 
 def render_schemas(models: dict[str, Any] = V1_MODELS) -> dict[str, str]:
@@ -35,7 +41,7 @@ def render_schemas(models: dict[str, Any] = V1_MODELS) -> dict[str, str]:
 
 
 def write_schemas(output_root: Path = OUTPUT_ROOT) -> None:
-    for version, models in (("v1", V1_MODELS), ("v2", V2_MODELS)):
+    for version, models in (("v1", V1_MODELS), ("v2", V2_MODELS), ("v3", V3_MODELS)):
         output = output_root / version
         output.mkdir(parents=True, exist_ok=True)
         rendered = render_schemas(models)

--- a/src/infralink/release/__init__.py
+++ b/src/infralink/release/__init__.py
@@ -2,18 +2,26 @@
 
 from infralink.release.contracts import (
     PublisherRequestV2,
+    PublisherRequestV3,
     ReleaseAttestationV1,
     ReleaseAttestationV2,
+    ReleaseAttestationV3,
     ReleaseCandidateV1,
     parse_publisher_request_v2_json,
+    parse_publisher_request_v3_json,
     parse_release_attestation_v2_json,
+    parse_release_attestation_v3_json,
 )
 
 __all__ = [
     "PublisherRequestV2",
+    "PublisherRequestV3",
     "ReleaseAttestationV1",
     "ReleaseAttestationV2",
+    "ReleaseAttestationV3",
     "ReleaseCandidateV1",
     "parse_publisher_request_v2_json",
+    "parse_publisher_request_v3_json",
     "parse_release_attestation_v2_json",
+    "parse_release_attestation_v3_json",
 ]

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -15,7 +15,7 @@ _COMMIT = r"^[0-9a-f]{40}$"
 _SHA256 = r"^[0-9a-f]{64}$"
 _SOURCE_IDENTITY = r"^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$"
 _OCI_IMAGE_DIGEST = r"^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$"
-_SSH_FINGERPRINT = r"^SHA256:[A-Za-z0-9+/]{43}=$"
+_SSH_FINGERPRINT = r"^SHA256:[A-Za-z0-9+/]{43}$"
 
 
 class DuplicateJsonKeyError(ValueError):

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -214,12 +214,47 @@ class PublisherRequestV2(_Contract):
         return self
 
 
-class PublisherRequestV3(PublisherRequestV2):
+class PublisherRequestV3(_Contract):
     """V2 request facts plus immutable tag-signer policy provenance."""
 
     schema_version: Literal["infralink.publisher-request.v3"]
+    release: ReleaseIdentityV1
+    registry_commit: str = Field(pattern=_COMMIT)
+    controller_commit: str = Field(pattern=_COMMIT)
+    ci_receipt: ImmutableSourceReceiptV2
+    artifacts: list[ArtifactSourceBindingV2] = Field(min_length=1, max_length=64)
+    publisher: PublisherIdentityV2
+    mode: Literal["dry-run", "publish"]
+    request_digest: str = Field(pattern=_SHA256)
     tag_signer_policy: PublisherTagSignerPolicyV1
     manifest_signer: ReleaseManifestSignerV1
+
+    @field_validator("artifacts")
+    @classmethod
+    def artifacts_have_unique_sources(
+        cls, value: list[ArtifactSourceBindingV2]
+    ) -> list[ArtifactSourceBindingV2]:
+        if len({artifact.path for artifact in value}) != len(value):
+            raise ValueError("artifact paths must be unique")
+        if len({artifact.source_identity for artifact in value}) != len(value):
+            raise ValueError("artifact source identities must be unique")
+        return value
+
+    def canonical_digest(self) -> str:
+        """Return the SHA-256 of the canonical request without its self-binding field."""
+        body = json.dumps(
+            self.model_dump(mode="json", exclude={"request_digest"}),
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        return hashlib.sha256(body).hexdigest()
+
+    @model_validator(mode="after")
+    def request_digest_matches_canonical_payload(self) -> PublisherRequestV3:
+        if self.request_digest != self.canonical_digest():
+            raise ValueError("request_digest must match the canonical request payload")
+        return self
 
     @model_validator(mode="after")
     def manifest_signer_matches_policy(self) -> PublisherRequestV3:
@@ -255,11 +290,31 @@ class ReleaseAttestationV2(_Contract):
         return self
 
 
-class ReleaseAttestationV3(ReleaseAttestationV2):
+class ReleaseAttestationV3(_Contract):
     """Immutable publisher result bound to one canonical v3 request."""
 
     schema_version: Literal["infralink.release-attestation.v3"]
     request: PublisherRequestV3
+    request_digest: str = Field(pattern=_SHA256)
+    publisher_receipt: ImmutableSourceReceiptV2
+    result: Literal["dry-run", "published"]
+    tag: ReleaseTagV1 | None = None
+
+    @model_validator(mode="after")
+    def result_matches_request(self) -> ReleaseAttestationV3:
+        if self.request_digest != self.request.canonical_digest():
+            raise ValueError("request_digest must match the canonical publisher request")
+        expected_result = "dry-run" if self.request.mode == "dry-run" else "published"
+        if self.result != expected_result:
+            raise ValueError("attestation result must match the requested mode")
+        if self.result == "published":
+            if self.tag is None:
+                raise ValueError("published attestation requires a tag")
+            if self.tag.name != self.request.release.identity:
+                raise ValueError("tag name must match release identity")
+        elif self.tag is not None:
+            raise ValueError("dry-run attestation must not include a tag")
+        return self
 
 
 def parse_publisher_request_v2_json(document: str | bytes | bytearray) -> PublisherRequestV2:

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -15,6 +15,7 @@ _COMMIT = r"^[0-9a-f]{40}$"
 _SHA256 = r"^[0-9a-f]{64}$"
 _SOURCE_IDENTITY = r"^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$"
 _OCI_IMAGE_DIGEST = r"^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$"
+_SSH_FINGERPRINT = r"^SHA256:[A-Za-z0-9+/]{43}=$"
 
 
 class DuplicateJsonKeyError(ValueError):
@@ -151,6 +152,27 @@ class PublisherIdentityV2(_Contract):
     image: str = Field(pattern=_OCI_IMAGE_DIGEST, max_length=512)
 
 
+class ReleaseManifestSignerV1(_Contract):
+    """Public SSH signer identity named by a release manifest."""
+
+    principal: ConsumerId
+    fingerprint: str = Field(pattern=_SSH_FINGERPRINT)
+
+
+class ImmutablePolicySelectorV1(ArtifactBindingV1):
+    """Exact registry blob containing a public tag-signer policy."""
+
+    repository: str = Field(pattern=_SOURCE_IDENTITY, max_length=512)
+    commit: str = Field(pattern=_COMMIT)
+
+
+class PublisherTagSignerPolicyV1(_Contract):
+    """Immutable policy location and the one public signer it authorizes."""
+
+    selector: ImmutablePolicySelectorV1
+    signer: ReleaseManifestSignerV1
+
+
 class PublisherRequestV2(_Contract):
     """Canonical input for one protected publisher invocation."""
 
@@ -192,6 +214,20 @@ class PublisherRequestV2(_Contract):
         return self
 
 
+class PublisherRequestV3(PublisherRequestV2):
+    """V2 request facts plus immutable tag-signer policy provenance."""
+
+    schema_version: Literal["infralink.publisher-request.v3"]
+    tag_signer_policy: PublisherTagSignerPolicyV1
+    manifest_signer: ReleaseManifestSignerV1
+
+    @model_validator(mode="after")
+    def manifest_signer_matches_policy(self) -> PublisherRequestV3:
+        if self.manifest_signer != self.tag_signer_policy.signer:
+            raise ValueError("manifest signer must match tag signer policy")
+        return self
+
+
 class ReleaseAttestationV2(_Contract):
     """Immutable publisher result bound to the exact canonical v2 request."""
 
@@ -219,6 +255,13 @@ class ReleaseAttestationV2(_Contract):
         return self
 
 
+class ReleaseAttestationV3(ReleaseAttestationV2):
+    """Immutable publisher result bound to one canonical v3 request."""
+
+    schema_version: Literal["infralink.release-attestation.v3"]
+    request: PublisherRequestV3
+
+
 def parse_publisher_request_v2_json(document: str | bytes | bytearray) -> PublisherRequestV2:
     """Parse one publisher request through the strict v2 JSON boundary."""
     return PublisherRequestV2.model_validate(_load_strict_v2_json(document))
@@ -227,3 +270,13 @@ def parse_publisher_request_v2_json(document: str | bytes | bytearray) -> Publis
 def parse_release_attestation_v2_json(document: str | bytes | bytearray) -> ReleaseAttestationV2:
     """Parse one publisher attestation through the strict v2 JSON boundary."""
     return ReleaseAttestationV2.model_validate(_load_strict_v2_json(document))
+
+
+def parse_publisher_request_v3_json(document: str | bytes | bytearray) -> PublisherRequestV3:
+    """Parse one publisher request through the strict v3 JSON boundary."""
+    return PublisherRequestV3.model_validate(_load_strict_v2_json(document))
+
+
+def parse_release_attestation_v3_json(document: str | bytes | bytearray) -> ReleaseAttestationV3:
+    """Parse one publisher attestation through the strict v3 JSON boundary."""
+    return ReleaseAttestationV3.model_validate(_load_strict_v2_json(document))

--- a/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
+++ b/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
@@ -192,7 +192,7 @@
       "description": "Public SSH signer identity named by a release manifest.",
       "properties": {
         "fingerprint": {
-          "pattern": "^SHA256:[A-Za-z0-9+/]{43}=$",
+          "pattern": "^SHA256:[A-Za-z0-9+/]{43}$",
           "title": "Fingerprint",
           "type": "string"
         },

--- a/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
+++ b/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
@@ -1,0 +1,287 @@
+{
+  "$defs": {
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
+    "ImmutablePolicySelectorV1": {
+      "additionalProperties": false,
+      "description": "Exact registry blob containing a public tag-signer policy.",
+      "properties": {
+        "commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Commit",
+          "type": "string"
+        },
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "repository",
+        "commit"
+      ],
+      "title": "ImmutablePolicySelectorV1",
+      "type": "object"
+    },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
+      "type": "object"
+    },
+    "PublisherTagSignerPolicyV1": {
+      "additionalProperties": false,
+      "description": "Immutable policy location and the one public signer it authorizes.",
+      "properties": {
+        "selector": {
+          "$ref": "#/$defs/ImmutablePolicySelectorV1"
+        },
+        "signer": {
+          "$ref": "#/$defs/ReleaseManifestSignerV1"
+        }
+      },
+      "required": [
+        "selector",
+        "signer"
+      ],
+      "title": "PublisherTagSignerPolicyV1",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseManifestSignerV1": {
+      "additionalProperties": false,
+      "description": "Public SSH signer identity named by a release manifest.",
+      "properties": {
+        "fingerprint": {
+          "pattern": "^SHA256:[A-Za-z0-9+/]{43}=$",
+          "title": "Fingerprint",
+          "type": "string"
+        },
+        "principal": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Principal",
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal",
+        "fingerprint"
+      ],
+      "title": "ReleaseManifestSignerV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "V2 request facts plus immutable tag-signer policy provenance.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactSourceBindingV2"
+      },
+      "maxItems": 64,
+      "minItems": 1,
+      "title": "Artifacts",
+      "type": "array"
+    },
+    "ci_receipt": {
+      "$ref": "#/$defs/ImmutableSourceReceiptV2"
+    },
+    "controller_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Controller Commit",
+      "type": "string"
+    },
+    "manifest_signer": {
+      "$ref": "#/$defs/ReleaseManifestSignerV1"
+    },
+    "mode": {
+      "enum": [
+        "dry-run",
+        "publish"
+      ],
+      "title": "Mode",
+      "type": "string"
+    },
+    "publisher": {
+      "$ref": "#/$defs/PublisherIdentityV2"
+    },
+    "registry_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Registry Commit",
+      "type": "string"
+    },
+    "release": {
+      "$ref": "#/$defs/ReleaseIdentityV1"
+    },
+    "request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Request Digest",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "infralink.publisher-request.v3",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tag_signer_policy": {
+      "$ref": "#/$defs/PublisherTagSignerPolicyV1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "release",
+    "registry_commit",
+    "controller_commit",
+    "ci_receipt",
+    "artifacts",
+    "publisher",
+    "mode",
+    "request_digest",
+    "tag_signer_policy",
+    "manifest_signer"
+  ],
+  "title": "PublisherRequestV3",
+  "type": "object"
+}

--- a/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
+++ b/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
@@ -265,7 +265,7 @@
       "description": "Public SSH signer identity named by a release manifest.",
       "properties": {
         "fingerprint": {
-          "pattern": "^SHA256:[A-Za-z0-9+/]{43}=$",
+          "pattern": "^SHA256:[A-Za-z0-9+/]{43}$",
           "title": "Fingerprint",
           "type": "string"
         },

--- a/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
+++ b/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
@@ -1,0 +1,358 @@
+{
+  "$defs": {
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
+    "ImmutablePolicySelectorV1": {
+      "additionalProperties": false,
+      "description": "Exact registry blob containing a public tag-signer policy.",
+      "properties": {
+        "commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Commit",
+          "type": "string"
+        },
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "repository",
+        "commit"
+      ],
+      "title": "ImmutablePolicySelectorV1",
+      "type": "object"
+    },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
+      "type": "object"
+    },
+    "PublisherRequestV3": {
+      "additionalProperties": false,
+      "description": "V2 request facts plus immutable tag-signer policy provenance.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "manifest_signer": {
+          "$ref": "#/$defs/ReleaseManifestSignerV1"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v3",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "tag_signer_policy": {
+          "$ref": "#/$defs/PublisherTagSignerPolicyV1"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest",
+        "tag_signer_policy",
+        "manifest_signer"
+      ],
+      "title": "PublisherRequestV3",
+      "type": "object"
+    },
+    "PublisherTagSignerPolicyV1": {
+      "additionalProperties": false,
+      "description": "Immutable policy location and the one public signer it authorizes.",
+      "properties": {
+        "selector": {
+          "$ref": "#/$defs/ImmutablePolicySelectorV1"
+        },
+        "signer": {
+          "$ref": "#/$defs/ReleaseManifestSignerV1"
+        }
+      },
+      "required": [
+        "selector",
+        "signer"
+      ],
+      "title": "PublisherTagSignerPolicyV1",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseManifestSignerV1": {
+      "additionalProperties": false,
+      "description": "Public SSH signer identity named by a release manifest.",
+      "properties": {
+        "fingerprint": {
+          "pattern": "^SHA256:[A-Za-z0-9+/]{43}=$",
+          "title": "Fingerprint",
+          "type": "string"
+        },
+        "principal": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Principal",
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal",
+        "fingerprint"
+      ],
+      "title": "ReleaseManifestSignerV1",
+      "type": "object"
+    },
+    "ReleaseTagV1": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "object_sha1": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Object Sha1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "object_sha1"
+      ],
+      "title": "ReleaseTagV1",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Immutable publisher result bound to one canonical v3 request.",
+  "properties": {
+    "publisher_receipt": {
+      "$ref": "#/$defs/ImmutableSourceReceiptV2"
+    },
+    "request": {
+      "$ref": "#/$defs/PublisherRequestV3"
+    },
+    "request_digest": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Request Digest",
+      "type": "string"
+    },
+    "result": {
+      "enum": [
+        "dry-run",
+        "published"
+      ],
+      "title": "Result",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "infralink.release-attestation.v3",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tag": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ReleaseTagV1"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "request",
+    "request_digest",
+    "publisher_receipt",
+    "result"
+  ],
+  "title": "ReleaseAttestationV3",
+  "type": "object"
+}

--- a/tests/test_public_data_boundary.py
+++ b/tests/test_public_data_boundary.py
@@ -832,9 +832,9 @@ def test_boundary_detector_allows_public_examples_and_domain_uuids() -> None:
 
 
 def test_boundary_detector_allows_canonical_public_ssh_fingerprints() -> None:
-    assert boundary_violations(
-        "fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    ) == []
+    assert (
+        boundary_violations("fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") == []
+    )
 
 
 def test_boundary_detector_rejects_padded_ssh_fingerprints() -> None:

--- a/tests/test_public_data_boundary.py
+++ b/tests/test_public_data_boundary.py
@@ -37,6 +37,7 @@ PORT_AUTHORITY_TOKEN = re.compile(
 URL = re.compile(r"[a-z][a-z0-9+.-]*://[^\s`\"'<>]+", re.IGNORECASE)
 PROTOCOL_RELATIVE_AUTHORITY = re.compile(r"//[^\s`\"'<>]+")
 SECRET_TEMPLATE = re.compile(r"\$\{secret:[^}\s]+\}")
+SSH_FINGERPRINT = re.compile(r"(?<![A-Za-z0-9+/])SHA256:[A-Za-z0-9+/]{43}(?![A-Za-z0-9+/])")
 PERCENT_ESCAPE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
 BRACKET_AUTHORITY_TOKEN = re.compile(r"\[[^\]\s`\"'<>]*\]|\[[^\s`\"'<>]+")
 UUID = re.compile(
@@ -95,6 +96,7 @@ SAFE_DOTTED_TOKENS = {
     "infralink.release-attestation.v1",
     "infralink.release-attestation.v2",
     "infralink.publisher-request.v2",
+    "infralink.publisher-request.v3",
     "infralink.release-candidate.v1",
     "agent-cli.response.v1",
     "infralink.observation",
@@ -378,6 +380,7 @@ def boundary_violations(
     violations = [] if _violations is None else _violations
     seen_findings = set() if _seen_findings is None else _seen_findings
     authority_spans: list[tuple[int, int]] = []
+    ssh_fingerprint_spans = [match.span() for match in SSH_FINGERPRINT.finditer(text)]
     bracket_spans: list[tuple[int, int]] = []
     balanced_bracket_spans: list[tuple[int, int]] = []
     generic_bracket_spans: list[tuple[int, int]] = []
@@ -414,6 +417,9 @@ def boundary_violations(
 
     def starts_in_authority_span(span: tuple[int, int]) -> bool:
         return any(start <= span[0] < end for start, end in authority_spans)
+
+    def inside_ssh_fingerprint(span: tuple[int, int]) -> bool:
+        return any(start <= span[0] < end for start, end in ssh_fingerprint_spans)
 
     def inside_bracket_span(span: tuple[int, int]) -> bool:
         return any(start <= span[0] < end for start, end in bracket_spans)
@@ -561,7 +567,8 @@ def boundary_violations(
 
     for match in PORT_AUTHORITY_TOKEN.finditer(text):
         if (
-            not inside_bracket_span(match.span())
+            not inside_ssh_fingerprint(match.span())
+            and not inside_bracket_span(match.span())
             and not inside_balanced_bracket_span(match.span())
             and not inside_generic_bracket_span(match.span())
         ):
@@ -822,6 +829,12 @@ def test_boundary_detector_allows_public_examples_and_domain_uuids() -> None:
     punctuation: docs/reference.md...);!? Release v0.2.0...,"\']
     """
     assert boundary_violations(text) == []
+
+
+def test_boundary_detector_allows_canonical_public_ssh_fingerprints() -> None:
+    assert boundary_violations(
+        "fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    ) == []
 
 
 def test_boundary_detector_reports_atomic_authority_findings() -> None:

--- a/tests/test_public_data_boundary.py
+++ b/tests/test_public_data_boundary.py
@@ -37,7 +37,7 @@ PORT_AUTHORITY_TOKEN = re.compile(
 URL = re.compile(r"[a-z][a-z0-9+.-]*://[^\s`\"'<>]+", re.IGNORECASE)
 PROTOCOL_RELATIVE_AUTHORITY = re.compile(r"//[^\s`\"'<>]+")
 SECRET_TEMPLATE = re.compile(r"\$\{secret:[^}\s]+\}")
-SSH_FINGERPRINT = re.compile(r"(?<![A-Za-z0-9+/])SHA256:[A-Za-z0-9+/]{43}(?![A-Za-z0-9+/])")
+SSH_FINGERPRINT = re.compile(r"(?<![A-Za-z0-9+/])SHA256:[A-Za-z0-9+/]{43}(?![A-Za-z0-9+/=])")
 PERCENT_ESCAPE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
 BRACKET_AUTHORITY_TOKEN = re.compile(r"\[[^\]\s`\"'<>]*\]|\[[^\s`\"'<>]+")
 UUID = re.compile(
@@ -835,6 +835,12 @@ def test_boundary_detector_allows_canonical_public_ssh_fingerprints() -> None:
     assert boundary_violations(
         "fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     ) == []
+
+
+def test_boundary_detector_rejects_padded_ssh_fingerprints() -> None:
+    assert boundary_violations(
+        "fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    ) == ["invalid endpoint authority"]
 
 
 def test_boundary_detector_reports_atomic_authority_findings() -> None:

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -198,9 +198,7 @@ def test_v3_published_schema_and_strict_parser_accept_the_public_fixture() -> No
     fixture_path = FIXTURES / "publisher-request.v3.json"
     fixture = _fixture(fixture_path.name)
     schema = json.loads(
-        (V2_SCHEMAS.parent / "v3" / "publisher-request.v3.schema.json").read_text(
-            encoding="utf-8"
-        )
+        (V2_SCHEMAS.parent / "v3" / "publisher-request.v3.schema.json").read_text(encoding="utf-8")
     )
 
     Draft202012Validator(schema).validate(fixture)
@@ -217,9 +215,7 @@ def test_v3_attestation_carries_the_bound_v3_request() -> None:
     parsed = ReleaseAttestationV3.model_validate(attestation)
 
     assert parsed.request.manifest_signer == parsed.request.tag_signer_policy.signer
-    assert parse_release_attestation_v3_json(
-        json.dumps(attestation, separators=(",", ":"))
-    )
+    assert parse_release_attestation_v3_json(json.dumps(attestation, separators=(",", ":")))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -13,11 +13,15 @@ from pydantic import ValidationError
 from infralink.cli.main import cli
 from infralink.release.contracts import (
     PublisherRequestV2,
+    PublisherRequestV3,
     ReleaseAttestationV1,
     ReleaseAttestationV2,
+    ReleaseAttestationV3,
     ReleaseCandidateV1,
     parse_publisher_request_v2_json,
+    parse_publisher_request_v3_json,
     parse_release_attestation_v2_json,
+    parse_release_attestation_v3_json,
 )
 
 ROOT = Path(__file__).parents[1]
@@ -25,10 +29,43 @@ FIXTURES = ROOT / "examples" / "release"
 SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v1"
 V2_SCHEMAS = ROOT / "src" / "infralink" / "schemas" / "release" / "v2"
 V2JsonParser = Callable[[str], PublisherRequestV2 | ReleaseAttestationV2]
+V3JsonParser = Callable[[str], PublisherRequestV3 | ReleaseAttestationV3]
 
 
 def _fixture(name: str) -> dict[str, object]:
     return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _bind_request_digest(request: dict[str, object]) -> None:
+    request_without_digest = {
+        key: value for key, value in request.items() if key != "request_digest"
+    }
+    request["request_digest"] = hashlib.sha256(
+        json.dumps(
+            request_without_digest, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        ).encode("ascii")
+    ).hexdigest()
+
+
+def _v3_request() -> dict[str, object]:
+    request = _fixture("publisher-request.v2.json")
+    request["schema_version"] = "infralink.publisher-request.v3"
+    signer = {
+        "principal": "infralink-release-publisher",
+        "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    }
+    request["tag_signer_policy"] = {
+        "selector": {
+            "repository": "gitea://gitea.i.cyberstorm.dev/cyberstorm/infralink-release-publisher",
+            "commit": "a" * 40,
+            "path": "release-publisher/allowed-signers.json",
+            "sha256": "b" * 64,
+        },
+        "signer": signer,
+    }
+    request["manifest_signer"] = dict(signer)
+    _bind_request_digest(request)
+    return request
 
 
 def test_public_candidate_fixture_has_explicit_immutable_release_bindings() -> None:
@@ -146,6 +183,91 @@ def test_v2_attestation_fixture_binds_the_canonical_request_digest() -> None:
     assert attestation.request_digest == attestation.request.canonical_digest()
     assert attestation.result == "dry-run"
     assert attestation.tag is None
+
+
+def test_v3_request_binds_manifest_signer_to_an_immutable_tag_policy() -> None:
+    request = PublisherRequestV3.model_validate(_v3_request())
+
+    assert request.request_digest == request.canonical_digest()
+    assert request.tag_signer_policy.selector.commit == "a" * 40
+    assert request.tag_signer_policy.selector.sha256 == "b" * 64
+    assert request.tag_signer_policy.signer == request.manifest_signer
+
+
+def test_v3_published_schema_and_strict_parser_accept_the_public_fixture() -> None:
+    fixture_path = FIXTURES / "publisher-request.v3.json"
+    fixture = _fixture(fixture_path.name)
+    schema = json.loads(
+        (V2_SCHEMAS.parent / "v3" / "publisher-request.v3.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    Draft202012Validator(schema).validate(fixture)
+    assert parse_publisher_request_v3_json(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_v3_attestation_carries_the_bound_v3_request() -> None:
+    attestation = _fixture("release-attestation.v2.json")
+    request = _v3_request()
+    attestation["schema_version"] = "infralink.release-attestation.v3"
+    attestation["request"] = request
+    attestation["request_digest"] = request["request_digest"]
+
+    parsed = ReleaseAttestationV3.model_validate(attestation)
+
+    assert parsed.request.manifest_signer == parsed.request.tag_signer_policy.signer
+    assert parse_release_attestation_v3_json(
+        json.dumps(attestation, separators=(",", ":"))
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("commit", "main", "commit"),
+        ("path", "../allowed-signers.json", "safe and relative"),
+        ("sha256", "0" * 63, "sha256"),
+    ],
+)
+def test_v3_request_rejects_mutable_or_unsafe_signer_policy_selector(
+    field: str, value: str, match: str
+) -> None:
+    request = _v3_request()
+    policy = request["tag_signer_policy"]
+    assert isinstance(policy, dict)
+    selector = policy["selector"]
+    assert isinstance(selector, dict)
+    selector[field] = value
+
+    with pytest.raises(ValidationError, match=match):
+        PublisherRequestV3.model_validate(request)
+
+
+def test_v3_request_rejects_a_manifest_signer_that_differs_from_policy() -> None:
+    request = _v3_request()
+    manifest_signer = request["manifest_signer"]
+    assert isinstance(manifest_signer, dict)
+    manifest_signer["principal"] = "another-publisher"
+    _bind_request_digest(request)
+
+    with pytest.raises(ValidationError, match="manifest signer must match tag signer policy"):
+        PublisherRequestV3.model_validate(request)
+
+
+def test_v3_request_rejects_a_missing_tag_signer_policy_binding() -> None:
+    request = _v3_request()
+    request.pop("tag_signer_policy")
+    _bind_request_digest(request)
+
+    with pytest.raises(ValidationError, match="tag_signer_policy"):
+        PublisherRequestV3.model_validate(request)
+
+
+def test_v2_request_remains_compatible_without_signer_policy_binding() -> None:
+    request = PublisherRequestV2.model_validate(_fixture("publisher-request.v2.json"))
+
+    assert request.schema_version == "infralink.publisher-request.v2"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -52,7 +52,7 @@ def _v3_request() -> dict[str, object]:
     request["schema_version"] = "infralink.publisher-request.v3"
     signer = {
         "principal": "infralink-release-publisher",
-        "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     }
     request["tag_signer_policy"] = {
         "selector": {
@@ -192,6 +192,37 @@ def test_v3_request_binds_manifest_signer_to_an_immutable_tag_policy() -> None:
     assert request.tag_signer_policy.selector.commit == "a" * 40
     assert request.tag_signer_policy.selector.sha256 == "b" * 64
     assert request.tag_signer_policy.signer == request.manifest_signer
+
+
+def test_v3_request_accepts_the_canonical_unpadded_ssh_fingerprint() -> None:
+    request = PublisherRequestV3.model_validate(_v3_request())
+
+    assert request.manifest_signer.fingerprint == (
+        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    )
+
+
+@pytest.mark.parametrize(
+    "fingerprint",
+    [
+        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    ],
+)
+def test_v3_request_rejects_noncanonical_ssh_fingerprint(fingerprint: str) -> None:
+    request = _v3_request()
+    policy = request["tag_signer_policy"]
+    assert isinstance(policy, dict)
+    policy_signer = policy["signer"]
+    assert isinstance(policy_signer, dict)
+    policy_signer["fingerprint"] = fingerprint
+    manifest_signer = request["manifest_signer"]
+    assert isinstance(manifest_signer, dict)
+    manifest_signer["fingerprint"] = fingerprint
+    _bind_request_digest(request)
+
+    with pytest.raises(ValidationError, match="fingerprint"):
+        PublisherRequestV3.model_validate(request)
 
 
 def test_v3_published_schema_and_strict_parser_accept_the_public_fixture() -> None:


### PR DESCRIPTION
Closes #47

## Summary
- add backward-compatible `infralink.publisher-request.v3` and `infralink.release-attestation.v3` public contracts
- bind an exact registry policy blob selector and digest to a typed SSH tag-signer identity
- require the canonical release manifest signer identity to equal the policy signer
- package generated v3 schemas and a sanitized v3 request example

## Compatibility
V1 and V2 models, strict parsers, schemas, and fixtures remain unchanged. Consumers choose V3 only when they require explicit signer-policy binding.

## Non-goals
No BWS, private key, bot, CI, tag-push, or deployment behavior.

## Validation
`python3 -m pytest --no-cov tests/test_release_producer_contract.py tests/test_release_manifest.py tests/test_release_workflow_policy.py tests/test_cli_release.py -q`
`python3 -m ruff check src/infralink/release tests/test_release_producer_contract.py scripts/generate_release_schemas.py`