### PR TITLE
feat(cli): adapt release workflow to v2 evidence

### DIFF
--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -15,6 +15,8 @@ from pydantic import (
     model_validator,
 )
 
+from infralink.release.contracts import PublisherRequestV2, ReleaseAttestationV2
+
 T = TypeVar("T")
 
 
@@ -290,7 +292,7 @@ class PublisherRequest(ContractModel):
 
 
 class PublisherRequestResult(ContractModel):
-    publisher_request: PublisherRequest
+    publisher_request: PublisherRequest | PublisherRequestV2
 
 
 class ReleasePublisherReceipt(ContractModel):
@@ -318,7 +320,7 @@ class ReleaseAttestation(ContractModel):
 
 
 class ReleaseAttestationResult(ContractModel):
-    attestation: ReleaseAttestation
+    attestation: ReleaseAttestation | ReleaseAttestationV2
 
 
 class CommandDescriptor(ContractModel):

--- a/src/infralink/cli/errors.py
+++ b/src/infralink/cli/errors.py
@@ -53,6 +53,7 @@ class ErrorCode(str, Enum):
     RELEASE_VALIDATION_INVALID = "release_validation_invalid"
     RELEASE_ADMISSION_REJECTED = "release_admission_rejected"
     RELEASE_CANDIDATE_INVALID = "release_candidate_invalid"
+    RELEASE_PUBLISHER_REQUEST_INVALID = "release_publisher_request_invalid"
     RELEASE_PUBLISHER_UNAVAILABLE = "release_publisher_unavailable"
     RELEASE_ATTESTATION_INVALID = "release_attestation_invalid"
     INTERNAL_ERROR = "internal_error"

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -326,14 +326,16 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         "examples": ["infralink release validate-candidate --candidate candidate.json"],
     },
     ("release", "render-publisher-request"): {
-        "description": "Render, but never invoke, an immutable trusted-publisher request.",
+        "description": "Inspect a registry-rendered v2 publisher request without invoking it.",
         "arguments": [],
         "options": [
-            {"name": "candidate", "type": "path", "required": True},
-            {"name": "admission", "type": "path", "required": True},
+            {"name": "publisher_request", "type": "path", "required": False},
+            {"name": "candidate", "type": "path", "required": False},
+            {"name": "admission", "type": "path", "required": False},
         ],
         "examples": [
-            "infralink release render-publisher-request --candidate candidate.json --admission admission.yml"
+            "infralink release render-publisher-request --publisher-request publisher-request.v2.json",
+            "infralink release render-publisher-request --candidate candidate.json --admission admission.yml",
         ],
     },
     ("release", "inspect-attestation"): {

--- a/src/infralink/cli/release.py
+++ b/src/infralink/cli/release.py
@@ -51,8 +51,12 @@ from infralink.cli.output import ok_envelope
 from infralink.release.contracts import (
     ArtifactBindingV1,
     CiReceiptV1,
+    PublisherRequestV2,
     ReleaseAttestationV1,
+    ReleaseAttestationV2,
     ReleaseCandidateV1,
+    parse_publisher_request_v2_json,
+    parse_release_attestation_v2_json,
 )
 
 _IDENTITY = re.compile(r"^releases/([a-z0-9][a-z0-9-]{0,62})/([1-9][0-9]*)$")
@@ -185,6 +189,7 @@ def _invalid(kind: str, message: str, details: dict[str, Any]) -> CliFailure:
         "validation": ErrorCode.RELEASE_VALIDATION_INVALID,
         "admission": ErrorCode.RELEASE_ADMISSION_REJECTED,
         "candidate": ErrorCode.RELEASE_CANDIDATE_INVALID,
+        "publisher-request": ErrorCode.RELEASE_PUBLISHER_REQUEST_INVALID,
         "attestation": ErrorCode.RELEASE_ATTESTATION_INVALID,
     }[kind]
     return CliFailure(
@@ -242,7 +247,38 @@ def _parse_candidate(path: Path) -> _CandidateDocument | _LegacyCandidateDocumen
             ) from error
 
 
-def _parse_attestation(path: Path) -> _AttestationDocument | _LegacyAttestationDocument:
+def _parse_publisher_request_v2(path: Path) -> PublisherRequestV2:
+    try:
+        return parse_publisher_request_v2_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, ValidationError) as error:
+        raise _invalid(
+            "publisher-request",
+            "does not match infralink.publisher-request.v2",
+            {"path": str(path)},
+        ) from error
+
+
+def _parse_attestation(
+    path: Path,
+) -> _AttestationDocument | _LegacyAttestationDocument | ReleaseAttestationV2:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        discriminator = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        raw = None
+        discriminator = None
+    if isinstance(discriminator, dict) and discriminator.get("schema_version") == (
+        "infralink.release-attestation.v2"
+    ):
+        try:
+            assert raw is not None
+            return parse_release_attestation_v2_json(raw)
+        except (ValueError, ValidationError) as error:
+            raise _invalid(
+                "attestation",
+                "does not match infralink.release-attestation.v2",
+                {"path": str(path)},
+            ) from error
     try:
         return _AttestationDocument.model_validate(_load(path, kind="attestation"))
     except (ValidationError, TypeError) as error:
@@ -411,14 +447,55 @@ def validate_candidate(candidate: Path) -> None:
 
 
 @release.command(name="render-publisher-request")
-@click.option(
-    "--candidate", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True
-)
-@click.option(
-    "--admission", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True
-)
-def render_publisher_request(candidate: Path, admission: Path) -> None:
-    """Render, but never invoke, an immutable trusted-publisher request."""
+@click.option("--candidate", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--admission", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--publisher-request", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+def render_publisher_request(
+    candidate: Path | None, admission: Path | None, publisher_request: Path | None
+) -> None:
+    """Inspect a registry-rendered v2 request, or render legacy v1 evidence only."""
+    if publisher_request is not None:
+        if candidate is not None or admission is not None:
+            raise _invalid(
+                "publisher-request",
+                "must be supplied without legacy candidate or admission inputs",
+                {"path": str(publisher_request)},
+            )
+        _emit(
+            ok_envelope(
+                _context_for(path=["release", "render-publisher-request"]),
+                PublisherRequestResult(
+                    publisher_request=_parse_publisher_request_v2(publisher_request)
+                ),
+                [
+                    action(
+                        "inspect-attestation",
+                        [
+                            "infralink",
+                            "release",
+                            "inspect-attestation",
+                            "--attestation",
+                            "{attestation}",
+                        ],
+                        "Inspect the immutable publisher attestation after the trusted publisher completes",
+                        bindings={
+                            "attestation": Binding(
+                                type="string",
+                                required=True,
+                                source="trusted publisher completion record path",
+                            )
+                        },
+                    )
+                ],
+            )
+        )
+        return
+    if candidate is None or admission is None:
+        raise _invalid(
+            "publisher-request",
+            "requires --publisher-request or both legacy --candidate and --admission inputs",
+            {},
+        )
     candidate_document = _parse_candidate(candidate)
     try:
         admission_document = _AdmissionDocument.model_validate(_load(admission, kind="admission"))
@@ -499,7 +576,9 @@ def render_publisher_request(candidate: Path, admission: Path) -> None:
 def inspect_attestation(attestation: Path) -> None:
     """Inspect a publisher completion record without contacting a provider."""
     value = _parse_attestation(attestation)
-    if isinstance(value, _LegacyAttestationDocument):
+    if isinstance(value, ReleaseAttestationV2):
+        output: ReleaseAttestation | ReleaseAttestationV2 = value
+    elif isinstance(value, _LegacyAttestationDocument):
         output = ReleaseAttestation(
             release_identity=value.release_identity,
             registry_commit=value.registry_commit,

--- a/src/infralink/schemas/cli/v1/release-inspect-attestation.json
+++ b/src/infralink/schemas/cli/v1/release-inspect-attestation.json
@@ -49,6 +49,42 @@
       "title": "Action",
       "type": "object"
     },
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
     "Binding": {
       "additionalProperties": false,
       "properties": {
@@ -128,6 +164,50 @@
       "title": "ErrorDetail",
       "type": "object"
     },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
     "Meta": {
       "additionalProperties": false,
       "properties": {
@@ -138,6 +218,96 @@
         }
       },
       "title": "Meta",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
+      "type": "object"
+    },
+    "PublisherRequestV2": {
+      "additionalProperties": false,
+      "description": "Canonical input for one protected publisher invocation.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v2",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest"
+      ],
+      "title": "PublisherRequestV2",
       "type": "object"
     },
     "ReleaseArtifactBinding": {
@@ -247,13 +417,71 @@
       "additionalProperties": false,
       "properties": {
         "attestation": {
-          "$ref": "#/$defs/ReleaseAttestation"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReleaseAttestation"
+            },
+            {
+              "$ref": "#/$defs/ReleaseAttestationV2"
+            }
+          ],
+          "title": "Attestation"
         }
       },
       "required": [
         "attestation"
       ],
       "title": "ReleaseAttestationResult",
+      "type": "object"
+    },
+    "ReleaseAttestationV2": {
+      "additionalProperties": false,
+      "description": "Immutable publisher result bound to the exact canonical v2 request.",
+      "properties": {
+        "publisher_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "request": {
+          "$ref": "#/$defs/PublisherRequestV2"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "result": {
+          "enum": [
+            "dry-run",
+            "published"
+          ],
+          "title": "Result",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.release-attestation.v2",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "tag": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReleaseTagV1"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "request",
+        "request_digest",
+        "publisher_receipt",
+        "result"
+      ],
+      "title": "ReleaseAttestationV2",
       "type": "object"
     },
     "ReleaseCiReceipt": {
@@ -284,6 +512,34 @@
         "run"
       ],
       "title": "ReleaseCiReceipt",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
       "type": "object"
     },
     "ReleasePublisherReceipt": {
@@ -321,6 +577,27 @@
         "run"
       ],
       "title": "ReleasePublisherReceipt",
+      "type": "object"
+    },
+    "ReleaseTagV1": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "object_sha1": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Object Sha1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "object_sha1"
+      ],
+      "title": "ReleaseTagV1",
       "type": "object"
     }
   },

--- a/src/infralink/schemas/cli/v1/release-render-publisher-request.json
+++ b/src/infralink/schemas/cli/v1/release-render-publisher-request.json
@@ -49,6 +49,42 @@
       "title": "Action",
       "type": "object"
     },
+    "ArtifactSourceBindingV2": {
+      "additionalProperties": false,
+      "description": "A release artifact and the immutable source from which it was obtained.",
+      "properties": {
+        "path": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ArtifactSourceBindingV2",
+      "type": "object"
+    },
     "Binding": {
       "additionalProperties": false,
       "properties": {
@@ -128,6 +164,50 @@
       "title": "ErrorDetail",
       "type": "object"
     },
+    "ImmutableSourceReceiptV2": {
+      "additionalProperties": false,
+      "description": "A receipt whose source cannot be silently retargeted.",
+      "properties": {
+        "provider": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Provider",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        },
+        "run": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Run",
+          "type": "string"
+        },
+        "source_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Digest",
+          "type": "string"
+        },
+        "source_identity": {
+          "maxLength": 512,
+          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
+          "title": "Source Identity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repository",
+        "run",
+        "source_identity",
+        "source_digest"
+      ],
+      "title": "ImmutableSourceReceiptV2",
+      "type": "object"
+    },
     "Meta": {
       "additionalProperties": false,
       "properties": {
@@ -138,6 +218,31 @@
         }
       },
       "title": "Meta",
+      "type": "object"
+    },
+    "PublisherIdentityV2": {
+      "additionalProperties": false,
+      "description": "The protected publisher identity and immutable runner image.",
+      "properties": {
+        "identity": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "image": {
+          "maxLength": 512,
+          "pattern": "^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$",
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity",
+        "image"
+      ],
+      "title": "PublisherIdentityV2",
       "type": "object"
     },
     "PublisherRequest": {
@@ -215,13 +320,86 @@
       "additionalProperties": false,
       "properties": {
         "publisher_request": {
-          "$ref": "#/$defs/PublisherRequest"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PublisherRequest"
+            },
+            {
+              "$ref": "#/$defs/PublisherRequestV2"
+            }
+          ],
+          "title": "Publisher Request"
         }
       },
       "required": [
         "publisher_request"
       ],
       "title": "PublisherRequestResult",
+      "type": "object"
+    },
+    "PublisherRequestV2": {
+      "additionalProperties": false,
+      "description": "Canonical input for one protected publisher invocation.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v2",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest"
+      ],
+      "title": "PublisherRequestV2",
       "type": "object"
     },
     "ReleaseArtifactBinding": {
@@ -274,6 +452,34 @@
         "run"
       ],
       "title": "ReleaseCiReceipt",
+      "type": "object"
+    },
+    "ReleaseIdentityV1": {
+      "additionalProperties": false,
+      "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
+      "properties": {
+        "channel": {
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "title": "Channel",
+          "type": "string"
+        },
+        "identity": {
+          "pattern": "^releases/[a-z0-9][a-z0-9-]{0,62}/[1-9][0-9]*$",
+          "title": "Identity",
+          "type": "string"
+        },
+        "sequence": {
+          "minimum": 1,
+          "title": "Sequence",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "identity",
+        "channel",
+        "sequence"
+      ],
+      "title": "ReleaseIdentityV1",
       "type": "object"
     }
   },

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -64,6 +64,7 @@ def test_error_codes_are_stable_strings() -> None:
         "RELEASE_VALIDATION_INVALID": "release_validation_invalid",
         "RELEASE_ADMISSION_REJECTED": "release_admission_rejected",
         "RELEASE_CANDIDATE_INVALID": "release_candidate_invalid",
+        "RELEASE_PUBLISHER_REQUEST_INVALID": "release_publisher_request_invalid",
         "RELEASE_PUBLISHER_UNAVAILABLE": "release_publisher_unavailable",
         "RELEASE_ATTESTATION_INVALID": "release_attestation_invalid",
         "INTERNAL_ERROR": "internal_error",

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -104,6 +104,18 @@ def _attestation(path: Path, **overrides: object) -> Path:
     return path
 
 
+def _publisher_request_v2(path: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "examples/release/publisher-request.v2.json"
+    path.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def _attestation_v2(path: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "examples/release/release-attestation.v2.json"
+    path.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
 def _payload(result) -> dict[str, object]:
     assert result.stderr == ""
     assert result.output.count("\n") == 1
@@ -206,6 +218,56 @@ def test_release_render_publisher_request_binds_only_immutable_candidate_inputs(
     }
 
 
+def test_release_render_publisher_request_accepts_the_registry_rendered_v2_request(
+    tmp_path: Path,
+) -> None:
+    request = _publisher_request_v2(tmp_path / "publisher-request.v2.json")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "release",
+            "render-publisher-request",
+            "--publisher-request",
+            str(request),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _payload(result)
+    assert_schema(payload, "release-render-publisher-request")
+    rendered = payload["result"]["publisher_request"]
+    assert rendered["schema_version"] == "infralink.publisher-request.v2"
+    assert (
+        rendered["request_digest"]
+        == "18352c07018a14bb764fffc9914ffe2ee051e90dd3bedbd0d57f6bad2440e784"
+    )
+    assert rendered["ci_receipt"]["source_identity"].startswith("woodpecker://")
+    assert [item["rel"] for item in payload["next_actions"]] == ["inspect-attestation"]
+
+
+def test_release_render_publisher_request_rejects_noncanonical_v2_request_digest(
+    tmp_path: Path,
+) -> None:
+    request = _publisher_request_v2(tmp_path / "publisher-request.v2.json")
+    payload = json.loads(request.read_text(encoding="utf-8"))
+    payload["request_digest"] = "0" * 64
+    request.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "release",
+            "render-publisher-request",
+            "--publisher-request",
+            str(request),
+        ],
+    )
+
+    assert result.exit_code == 3
+    assert _payload(result)["error"]["code"] == "release_publisher_request_invalid"
+
+
 def test_release_render_publisher_request_is_clear_no_go_when_publisher_is_unavailable(
     tmp_path: Path,
 ) -> None:
@@ -251,6 +313,23 @@ def test_release_inspect_attestation_reports_consumer_shadow_actions(tmp_path: P
     )
     assert payload["result"]["attestation"]["consumers"] == ["citadel", "watchtower"]
     assert payload["next_actions"] == []
+
+
+def test_release_inspect_attestation_reads_the_strict_v2_completion_record(tmp_path: Path) -> None:
+    attestation = _attestation_v2(tmp_path / "release-attestation.v2.json")
+
+    result = CliRunner().invoke(
+        cli, ["release", "inspect-attestation", "--attestation", str(attestation)]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _payload(result)
+    assert_schema(payload, "release-inspect-attestation")
+    output = payload["result"]["attestation"]
+    assert output["schema_version"] == "infralink.release-attestation.v2"
+    assert output["request"]["schema_version"] == "infralink.publisher-request.v2"
+    assert output["result"] == "dry-run"
+    assert output["tag"] is None
 
 
 def test_release_validate_candidate_rejects_mutable_branch_authority(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #37

## Scope
- accepts strict registry-rendered `infralink.publisher-request.v2` evidence through the existing read-only publisher-request command
- reads strict `infralink.release-attestation.v2` completion evidence
- preserves V1 candidate/request/attestation reads for historical evidence

The CLI does not render Git provenance, access secrets, verify private admission, call CI, sign, publish, or mutate hosts. Registry CI remains the owner of exact-commit V2 request rendering.

## Verification
- `ruff check` on changed Python files
- `pytest --no-cov -q tests/test_cli_release.py tests/test_cli_contracts.py tests/test_cli_discovery.py tests/test_release_producer_contract.py` (193 passed)