### PR TITLE
feat(cli): link inspection to direct health checks

### DIFF
--- a/src/infralink/cli/check.py
+++ b/src/infralink/cli/check.py
@@ -6,6 +6,7 @@ import json
 
 import click
 
+from infralink.cli.actions import action
 from infralink.cli.contracts import CheckCommandResult, CheckResult, CheckSummary
 from infralink.cli.main import (
     Context,
@@ -14,6 +15,7 @@ from infralink.cli.main import (
     _emit_query_result,
     _page_offset,
     _page_options,
+    _root_source_argv,
     _topology_fingerprint,
     pass_context,
 )
@@ -165,6 +167,21 @@ def check(
         limit=limit,
         fingerprint=fingerprint,
     )
+    failed = next((item for item in command_result.checks.items if not item.healthy), None)
+    repairs = []
+    if failed is not None:
+        repairs = [
+            action(
+                "show",
+                [*_root_source_argv(ctx), "edge", "show", failed.edge_id],
+                "Inspect the failed edge",
+            ),
+            action(
+                "resolve",
+                [*_root_source_argv(ctx), "resolve", failed.edge_id],
+                "Resolve the failed edge target",
+            ),
+        ]
     command_argv = ["check"]
     for edge_id in edge_ids:
         command_argv.extend(["--edge", edge_id])
@@ -181,5 +198,6 @@ def check(
         command_argv=command_argv,
         result=command_result,
         limit=limit,
+        extra_actions=repairs,
     )
     return 0 if command_result.healthy else 1

--- a/src/infralink/cli/check.py
+++ b/src/infralink/cli/check.py
@@ -167,7 +167,7 @@ def check(
         limit=limit,
         fingerprint=fingerprint,
     )
-    failed = next((item for item in command_result.checks.items if not item.healthy), None)
+    failed = next((item for item in checks if not item.healthy), None)
     repairs = []
     if failed is not None:
         repairs = [

--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -426,6 +426,7 @@ class ServiceShowResult(ContractModel):
     hosts: Page[str]
     ports: Page[int]
     protocols: Page[str]
+    edges: Page[EdgeSummary]
 
 
 class EdgeListResult(ContractModel):

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1393,7 +1393,7 @@ def service_show(
 ) -> None:
     from infralink.cli.queries import show_service
 
-    collections = ("hosts", "ports", "protocols")
+    collections = ("hosts", "ports", "protocols", "edges")
     selected = _active_collection(collection, cursor, collections)
     identifiers = {"service_id": service_id}
     if app_id is not None:
@@ -1428,6 +1428,20 @@ def service_show(
         limit=limit,
         fingerprint=fingerprint,
     )
+    health_edges = [edge.id for edge in result.edges.items]
+    actions = []
+    if health_edges:
+        actions.append(
+            action(
+                "check",
+                [
+                    *_root_source_argv(ctx),
+                    "check",
+                    *[argument for edge_id in health_edges for argument in ("--edge", edge_id)],
+                ],
+                "Run direct health checks for these related edges",
+            )
+        )
     _emit_query_result(
         ctx=ctx,
         path=["service", "show"],
@@ -1439,6 +1453,7 @@ def service_show(
         ],
         result=result,
         limit=limit,
+        extra_actions=actions,
     )
 
 
@@ -1494,6 +1509,13 @@ def edge_show(
         command_argv=["edge", "show", edge_id],
         result=result,
         limit=limit,
+        extra_actions=[
+            action(
+                "check",
+                [*_root_source_argv(ctx), "check", "--edge", edge_id],
+                "Run a direct health check for this edge",
+            )
+        ],
     )
 
 

--- a/src/infralink/cli/queries.py
+++ b/src/infralink/cli/queries.py
@@ -274,12 +274,14 @@ def show_service(
 ) -> ServiceShowResult:
     if app_id is None:
         identities = _service_identities(registry, edges)
+        related_edge_set = list(edges)
     else:
         application = registry.applications.get_application(app_id)
         if application is None:
             raise entity_not_found("app", app_id)
         app_edges = _app_edges(application, registry, edges)
         identities = _app_service_identities(application, registry, app_edges)
+        related_edge_set = app_edges
     identity = identities.get(service_id)
     if identity is None:
         raise entity_not_found("service", service_id)
@@ -287,6 +289,14 @@ def show_service(
     hosts = sorted(identity.hosts)
     ports = sorted(identity.ports)
     protocols = sorted(identity.protocols)
+    related_edges = sorted(
+        (
+            edge
+            for edge in related_edge_set
+            if edge.source_service == service_id or edge.target_service == service_id
+        ),
+        key=lambda edge: edge.id,
+    )
     cursors = next_cursors or {}
     return ServiceShowResult(
         service=service_summary(service_id, identity),
@@ -307,6 +317,12 @@ def show_service(
             limit=limit,
             offset=offset if selected == "protocols" else 0,
             next_cursor=cursors.get("protocols", next_cursor if selected == "protocols" else None),
+        ),
+        edges=page_items(
+            [edge_summary(edge) for edge in related_edges],
+            limit=limit,
+            offset=offset if selected == "edges" else 0,
+            next_cursor=cursors.get("edges", next_cursor if selected == "edges" else None),
         ),
     )
 

--- a/src/infralink/schemas/cli/v1/service-show.json
+++ b/src/infralink/schemas/cli/v1/service-show.json
@@ -104,6 +104,68 @@
       "title": "CommandContext",
       "type": "object"
     },
+    "EdgeSummary": {
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "additionalProperties": true,
+          "title": "From",
+          "type": "object"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "protocol": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Protocol"
+        },
+        "secret_ref_count": {
+          "title": "Secret Ref Count",
+          "type": "integer"
+        },
+        "secret_refs": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 32,
+          "title": "Secret Refs",
+          "type": "array"
+        },
+        "secret_refs_truncated": {
+          "title": "Secret Refs Truncated",
+          "type": "boolean"
+        },
+        "to": {
+          "additionalProperties": true,
+          "title": "To",
+          "type": "object"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "from",
+        "to",
+        "protocol",
+        "secret_ref_count",
+        "secret_refs",
+        "secret_refs_truncated"
+      ],
+      "title": "EdgeSummary",
+      "type": "object"
+    },
     "ErrorDetail": {
       "additionalProperties": false,
       "properties": {
@@ -187,6 +249,27 @@
       "title": "PageInfo",
       "type": "object"
     },
+    "Page_EdgeSummary_": {
+      "additionalProperties": false,
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/$defs/EdgeSummary"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "page": {
+          "$ref": "#/$defs/PageInfo"
+        }
+      },
+      "required": [
+        "items",
+        "page"
+      ],
+      "title": "Page[EdgeSummary]",
+      "type": "object"
+    },
     "Page_int_": {
       "additionalProperties": false,
       "properties": {
@@ -232,6 +315,9 @@
     "ServiceShowResult": {
       "additionalProperties": false,
       "properties": {
+        "edges": {
+          "$ref": "#/$defs/Page_EdgeSummary_"
+        },
         "hosts": {
           "$ref": "#/$defs/Page_str_"
         },
@@ -249,7 +335,8 @@
         "service",
         "hosts",
         "ports",
-        "protocols"
+        "protocols",
+        "edges"
       ],
       "title": "ServiceShowResult",
       "type": "object"

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -161,6 +161,28 @@ def test_check_empty_filters_are_healthy_typed_result() -> None:
     _schema_validate(payload)
 
 
+def test_failed_check_advertises_edge_inspection_and_resolution_repairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    edge_id = "058e29ff-57b9-47c8-b6fa-0914ac03e25c"
+    monkeypatch.setattr(
+        "infralink.cli.check.check_edge_health",
+        lambda edge, resolver, timeout: _health(
+            edge.id,
+            healthy=False,
+            error_code="timeout",
+        ),
+    )
+
+    result = _invoke("--edge", edge_id)
+    payload = json.loads(result.output)
+    actions = {item["rel"]: item["argv"] for item in payload["next_actions"]}
+
+    assert result.exit_code == 1
+    assert actions["show"][-3:] == ["edge", "show", edge_id]
+    assert actions["resolve"][-2:] == ["resolve", edge_id]
+
+
 def test_check_filters_and_repeated_edges_are_preserved_in_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -183,6 +183,32 @@ def test_failed_check_advertises_edge_inspection_and_resolution_repairs(
     assert actions["resolve"][-2:] == ["resolve", edge_id]
 
 
+def test_failed_check_repair_actions_survive_a_healthy_first_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    edge_ids = sorted(
+        item["id"] for item in yaml.safe_load((EXAMPLES / "edges.yml").read_text())["edges"]
+    )
+    failed_id = edge_ids[1]
+    monkeypatch.setattr(
+        "infralink.cli.check.check_edge_health",
+        lambda edge, resolver, timeout: _health(
+            edge.id,
+            healthy=edge.id != failed_id,
+            error_code=None if edge.id != failed_id else "timeout",
+        ),
+    )
+
+    result = _invoke("--limit", "1")
+    payload = json.loads(result.output)
+    actions = {item["rel"]: item["argv"] for item in payload["next_actions"]}
+
+    assert result.exit_code == 1
+    assert payload["result"]["checks"]["items"][0]["healthy"] is True
+    assert actions["show"][-3:] == ["edge", "show", failed_id]
+    assert actions["resolve"][-2:] == ["resolve", failed_id]
+
+
 def test_check_filters_and_repeated_edges_are_preserved_in_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -387,6 +387,7 @@ def test_all_command_result_contracts_have_typed_minimum_shapes() -> None:
             hosts=page(["host-1"]),
             ports=page([443]),
             protocols=page(["https"]),
+            edges=page([edge()]),
         ),
         EdgeListResult(items=[edge()], page=PageInfo(limit=100, returned=1, total=1)),
         EdgeShowResult(edge=edge(), secret_refs=page(["secret://api"])),

--- a/tests/test_cli_queries.py
+++ b/tests/test_cli_queries.py
@@ -203,6 +203,7 @@ def test_detail_queries_return_complete_typed_pages(registry: Registry, edges: E
     assert host.services.page.total == 2
     assert service.service.id == "api"
     assert service.hosts.items == [HOST_B, HOST_C, HOST_D]
+    assert [item.id for item in service.edges.items] == [EDGE_A, EDGE_B, EDGE_C, EDGE_D]
     assert edge.edge.id == EDGE_A
     assert edge.secret_refs.items == ["safe-ref-name"]
     assert app.app.edge_count == 3
@@ -350,6 +351,54 @@ def test_cli_edge_detail_matches_existing_schema(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     Draft202012Validator(schema).validate(payload)
+
+
+def test_cli_inspection_advertises_scoped_direct_health_actions(tmp_path: Path) -> None:
+    registry_path, edges_path = _write_cli_inputs(tmp_path, with_edge=True)
+
+    edge_payload = _payload(_invoke(registry_path, edges_path, "edge", "show", EDGE_A))
+    service_payload = _payload(
+        _invoke(registry_path, edges_path, "service", "show", "service-0001")
+    )
+
+    edge_action = next(
+        item
+        for item in edge_payload["next_actions"]
+        if item["rel"] == "check" and item["argv"][-2:] == ["--edge", EDGE_A]
+    )
+    service_action = next(
+        item for item in service_payload["next_actions"] if item["rel"] == "check"
+    )
+    assert edge_action["argv"] == [
+        "infralink",
+        "--registry",
+        str(registry_path),
+        "--edges",
+        str(edges_path),
+        "check",
+        "--edge",
+        EDGE_A,
+    ]
+    assert service_payload["result"]["edges"]["items"] == [
+        {
+            "id": EDGE_A,
+            "type": "api",
+            "from": {
+                "hosts": ["00000000-0000-4000-8000-000000000000"],
+                "service": "service-0000",
+            },
+            "to": {
+                "host": "00000000-0000-4000-8000-000000000001",
+                "service": "service-0001",
+                "port": 443,
+            },
+            "protocol": "https",
+            "secret_ref_count": 0,
+            "secret_refs": [],
+            "secret_refs_truncated": False,
+        }
+    ]
+    assert service_action["argv"] == edge_action["argv"]
 
 
 def test_cli_cursor_resumes_without_duplicates_and_exposes_exact_binding(


### PR DESCRIPTION
Closes #50.

Adds typed related-edge pages to `service show`, machine-executable scoped `check --edge` actions from service and edge inspection, and bounded inspect/resolve repair actions for failed direct checks.

No provider queries, registry mutation, SSH, remediation, or release changes.

Verification:
- `PYTHONPATH=src python3 -m pytest -q` (1260 passed, 1 skipped)
- `PYTHONPATH=src python3 -m pytest --no-cov -q tests/test_cli_queries.py tests/test_cli_check.py tests/test_cli_contracts.py tests/test_cli_commands_json.py` (139 passed)
- `PYTHONPATH=src python3 -m mypy src scripts`
- `PYTHONPATH=src python3 -m ruff check src/infralink/cli tests/test_cli_queries.py tests/test_cli_check.py tests/test_cli_contracts.py`