### PR TITLE
feat(release): bind v3 requests to immutable manifests

### DIFF
--- a/examples/release/publisher-request.v3.json
+++ b/examples/release/publisher-request.v3.json
@@ -9,7 +9,7 @@
   "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "ci_receipt": {
     "provider": "woodpecker",
-    "repository": "example/registry",
+    "repository": "https://example.com/relaxgg/infra-registry",
     "run": "576",
     "source_identity": "woodpecker://example.com/registry/pipelines/576",
     "source_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
@@ -27,21 +27,38 @@
     "image": "registry.example.com/infralink/publisher@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   },
   "mode": "dry-run",
-  "tag_signer_policy": {
-    "selector": {
-      "repository": "gitea://example.com/example/infralink-release-publisher",
-      "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "path": "release-publisher/tag-signer-policy",
-      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    },
-    "signer": {
-      "principal": "infralink-release-publisher",
-      "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  "release_manifest": {
+    "repository": "https://example.com/relaxgg/infra-registry",
+    "blob_identity": "https://example.com/relaxgg/infra-registry/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "authority": {
+      "release": {
+        "identity": "releases/core-v2/42",
+        "channel": "core-v2",
+        "sequence": 42
+      },
+      "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "controller_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "ci_receipt": {
+        "provider": "woodpecker",
+        "repository": "https://example.com/relaxgg/infra-registry",
+        "run": "576",
+        "source_identity": "woodpecker://example.com/registry/pipelines/576",
+        "source_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "artifacts": [
+        {
+          "path": "release/runtime-archive",
+          "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "source_identity": "woodpecker://example.com/registry/artifacts/runtime-archive",
+          "source_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        }
+      ],
+      "publisher": {
+        "identity": "infralink-release-publisher-woodpecker",
+        "image": "registry.example.com/infralink/publisher@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
     }
   },
-  "manifest_signer": {
-    "principal": "infralink-release-publisher",
-    "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-  },
-  "request_digest": "cc8abef32517b7174a7b53d5dac204c8151404a5191f04b841678dd70b3f0ce7"
+  "request_digest": "2ec645e216c51f0bffb701db1deab581d50e8882846df53ddfcb027d8240cb0f"
 }

--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -15,7 +15,12 @@ from pydantic import (
     model_validator,
 )
 
-from infralink.release.contracts import PublisherRequestV2, ReleaseAttestationV2
+from infralink.release.contracts import (
+    PublisherRequestV2,
+    PublisherRequestV3,
+    ReleaseAttestationV2,
+    ReleaseAttestationV3,
+)
 
 T = TypeVar("T")
 
@@ -292,7 +297,7 @@ class PublisherRequest(ContractModel):
 
 
 class PublisherRequestResult(ContractModel):
-    publisher_request: PublisherRequest | PublisherRequestV2
+    publisher_request: PublisherRequest | PublisherRequestV2 | PublisherRequestV3
 
 
 class ReleasePublisherReceipt(ContractModel):
@@ -320,7 +325,7 @@ class ReleaseAttestation(ContractModel):
 
 
 class ReleaseAttestationResult(ContractModel):
-    attestation: ReleaseAttestation | ReleaseAttestationV2
+    attestation: ReleaseAttestation | ReleaseAttestationV2 | ReleaseAttestationV3
 
 
 class CommandDescriptor(ContractModel):

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -326,7 +326,7 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         "examples": ["infralink release validate-candidate --candidate candidate.json"],
     },
     ("release", "render-publisher-request"): {
-        "description": "Inspect a registry-rendered v2 publisher request without invoking it.",
+        "description": "Inspect a registry-rendered immutable publisher request without invoking it.",
         "arguments": [],
         "options": [
             {"name": "publisher_request", "type": "path", "required": False},

--- a/src/infralink/cli/release.py
+++ b/src/infralink/cli/release.py
@@ -255,7 +255,10 @@ def _parse_publisher_request(path: Path) -> PublisherRequestV2 | PublisherReques
     try:
         raw = path.read_text(encoding="utf-8")
         document = json.loads(raw)
-        if isinstance(document, dict) and document.get("schema_version") == "infralink.publisher-request.v3":
+        if (
+            isinstance(document, dict)
+            and document.get("schema_version") == "infralink.publisher-request.v3"
+        ):
             return parse_publisher_request_v3_json(raw)
         return parse_publisher_request_v2_json(raw)
     except (OSError, ValueError, ValidationError) as error:
@@ -268,7 +271,9 @@ def _parse_publisher_request(path: Path) -> PublisherRequestV2 | PublisherReques
 
 def _parse_attestation(
     path: Path,
-) -> _AttestationDocument | _LegacyAttestationDocument | ReleaseAttestationV2 | ReleaseAttestationV3:
+) -> (
+    _AttestationDocument | _LegacyAttestationDocument | ReleaseAttestationV2 | ReleaseAttestationV3
+):
     try:
         raw = path.read_text(encoding="utf-8")
         discriminator = json.loads(raw)

--- a/src/infralink/cli/release.py
+++ b/src/infralink/cli/release.py
@@ -52,11 +52,15 @@ from infralink.release.contracts import (
     ArtifactBindingV1,
     CiReceiptV1,
     PublisherRequestV2,
+    PublisherRequestV3,
     ReleaseAttestationV1,
     ReleaseAttestationV2,
+    ReleaseAttestationV3,
     ReleaseCandidateV1,
     parse_publisher_request_v2_json,
+    parse_publisher_request_v3_json,
     parse_release_attestation_v2_json,
+    parse_release_attestation_v3_json,
 )
 
 _IDENTITY = re.compile(r"^releases/([a-z0-9][a-z0-9-]{0,62})/([1-9][0-9]*)$")
@@ -247,20 +251,24 @@ def _parse_candidate(path: Path) -> _CandidateDocument | _LegacyCandidateDocumen
             ) from error
 
 
-def _parse_publisher_request_v2(path: Path) -> PublisherRequestV2:
+def _parse_publisher_request(path: Path) -> PublisherRequestV2 | PublisherRequestV3:
     try:
-        return parse_publisher_request_v2_json(path.read_text(encoding="utf-8"))
+        raw = path.read_text(encoding="utf-8")
+        document = json.loads(raw)
+        if isinstance(document, dict) and document.get("schema_version") == "infralink.publisher-request.v3":
+            return parse_publisher_request_v3_json(raw)
+        return parse_publisher_request_v2_json(raw)
     except (OSError, ValueError, ValidationError) as error:
         raise _invalid(
             "publisher-request",
-            "does not match infralink.publisher-request.v2",
+            "does not match an accepted immutable publisher-request schema",
             {"path": str(path)},
         ) from error
 
 
 def _parse_attestation(
     path: Path,
-) -> _AttestationDocument | _LegacyAttestationDocument | ReleaseAttestationV2:
+) -> _AttestationDocument | _LegacyAttestationDocument | ReleaseAttestationV2 | ReleaseAttestationV3:
     try:
         raw = path.read_text(encoding="utf-8")
         discriminator = json.loads(raw)
@@ -277,6 +285,18 @@ def _parse_attestation(
             raise _invalid(
                 "attestation",
                 "does not match infralink.release-attestation.v2",
+                {"path": str(path)},
+            ) from error
+    if isinstance(discriminator, dict) and discriminator.get("schema_version") == (
+        "infralink.release-attestation.v3"
+    ):
+        try:
+            assert raw is not None
+            return parse_release_attestation_v3_json(raw)
+        except (ValueError, ValidationError) as error:
+            raise _invalid(
+                "attestation",
+                "does not match infralink.release-attestation.v3",
                 {"path": str(path)},
             ) from error
     try:
@@ -453,7 +473,7 @@ def validate_candidate(candidate: Path) -> None:
 def render_publisher_request(
     candidate: Path | None, admission: Path | None, publisher_request: Path | None
 ) -> None:
-    """Inspect a registry-rendered v2 request, or render legacy v1 evidence only."""
+    """Inspect a registry-rendered versioned request, or render legacy v1 evidence only."""
     if publisher_request is not None:
         if candidate is not None or admission is not None:
             raise _invalid(
@@ -465,7 +485,7 @@ def render_publisher_request(
             ok_envelope(
                 _context_for(path=["release", "render-publisher-request"]),
                 PublisherRequestResult(
-                    publisher_request=_parse_publisher_request_v2(publisher_request)
+                    publisher_request=_parse_publisher_request(publisher_request)
                 ),
                 [
                     action(
@@ -576,8 +596,8 @@ def render_publisher_request(
 def inspect_attestation(attestation: Path) -> None:
     """Inspect a publisher completion record without contacting a provider."""
     value = _parse_attestation(attestation)
-    if isinstance(value, ReleaseAttestationV2):
-        output: ReleaseAttestation | ReleaseAttestationV2 = value
+    if isinstance(value, (ReleaseAttestationV2, ReleaseAttestationV3)):
+        output: ReleaseAttestation | ReleaseAttestationV2 | ReleaseAttestationV3 = value
     elif isinstance(value, _LegacyAttestationDocument):
         output = ReleaseAttestation(
             release_identity=value.release_identity,

--- a/src/infralink/release/contracts.py
+++ b/src/infralink/release/contracts.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from pathlib import PurePath
 from typing import Annotated, Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -15,7 +16,8 @@ _COMMIT = r"^[0-9a-f]{40}$"
 _SHA256 = r"^[0-9a-f]{64}$"
 _SOURCE_IDENTITY = r"^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$"
 _OCI_IMAGE_DIGEST = r"^[a-z0-9][a-z0-9._/-]{0,383}@sha256:[0-9a-f]{64}$"
-_SSH_FINGERPRINT = r"^SHA256:[A-Za-z0-9+/]{43}$"
+_CANONICAL_GIT_REMOTE = r"^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)+$"
+_IMMUTABLE_GIT_BLOB = r"^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*/blobs/[0-9a-f]{40}$"
 
 
 class DuplicateJsonKeyError(ValueError):
@@ -152,25 +154,38 @@ class PublisherIdentityV2(_Contract):
     image: str = Field(pattern=_OCI_IMAGE_DIGEST, max_length=512)
 
 
-class ReleaseManifestSignerV1(_Contract):
-    """Public SSH signer identity named by a release manifest."""
+class ReleaseManifestAuthorityV1(_Contract):
+    """The request facts which a canonical release manifest must carry."""
 
-    principal: ConsumerId
-    fingerprint: str = Field(pattern=_SSH_FINGERPRINT)
-
-
-class ImmutablePolicySelectorV1(ArtifactBindingV1):
-    """Exact registry blob containing a public tag-signer policy."""
-
-    repository: str = Field(pattern=_SOURCE_IDENTITY, max_length=512)
-    commit: str = Field(pattern=_COMMIT)
+    release: ReleaseIdentityV1
+    registry_commit: str = Field(pattern=_COMMIT)
+    controller_commit: str = Field(pattern=_COMMIT)
+    ci_receipt: ImmutableSourceReceiptV2
+    artifacts: list[ArtifactSourceBindingV2] = Field(min_length=1, max_length=64)
+    publisher: PublisherIdentityV2
 
 
-class PublisherTagSignerPolicyV1(_Contract):
-    """Immutable policy location and the one public signer it authorizes."""
+class ReleaseManifestBindingV1(_Contract):
+    """Exact canonical registry blob and its declared request authority."""
 
-    selector: ImmutablePolicySelectorV1
-    signer: ReleaseManifestSignerV1
+    repository: str = Field(pattern=_CANONICAL_GIT_REMOTE, max_length=512)
+    blob_identity: str = Field(pattern=_IMMUTABLE_GIT_BLOB, max_length=640)
+    sha256: str = Field(pattern=_SHA256)
+    authority: ReleaseManifestAuthorityV1
+
+    @field_validator("repository")
+    @classmethod
+    def canonical_registry_remote(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("repository must be a credential-free canonical Git remote")
+        return value
+
+    @model_validator(mode="after")
+    def blob_identity_is_exact_immutable_registry_blob(self) -> ReleaseManifestBindingV1:
+        if not self.blob_identity.startswith(f"{self.repository}/blobs/"):
+            raise ValueError("blob identity must name an exact immutable registry blob")
+        return self
 
 
 class PublisherRequestV2(_Contract):
@@ -215,7 +230,7 @@ class PublisherRequestV2(_Contract):
 
 
 class PublisherRequestV3(_Contract):
-    """V2 request facts plus immutable tag-signer policy provenance."""
+    """V2 request facts plus one immutable canonical release-manifest binding."""
 
     schema_version: Literal["infralink.publisher-request.v3"]
     release: ReleaseIdentityV1
@@ -226,8 +241,7 @@ class PublisherRequestV3(_Contract):
     publisher: PublisherIdentityV2
     mode: Literal["dry-run", "publish"]
     request_digest: str = Field(pattern=_SHA256)
-    tag_signer_policy: PublisherTagSignerPolicyV1
-    manifest_signer: ReleaseManifestSignerV1
+    release_manifest: ReleaseManifestBindingV1
 
     @field_validator("artifacts")
     @classmethod
@@ -257,9 +271,18 @@ class PublisherRequestV3(_Contract):
         return self
 
     @model_validator(mode="after")
-    def manifest_signer_matches_policy(self) -> PublisherRequestV3:
-        if self.manifest_signer != self.tag_signer_policy.signer:
-            raise ValueError("manifest signer must match tag signer policy")
+    def manifest_repository_matches_request_authority(self) -> PublisherRequestV3:
+        if self.release_manifest.repository != self.ci_receipt.repository:
+            raise ValueError("manifest repository must match request authority")
+        if self.release_manifest.authority != ReleaseManifestAuthorityV1(
+            release=self.release,
+            registry_commit=self.registry_commit,
+            controller_commit=self.controller_commit,
+            ci_receipt=self.ci_receipt,
+            artifacts=self.artifacts,
+            publisher=self.publisher,
+        ):
+            raise ValueError("manifest authority must match request authority")
         return self
 
 

--- a/src/infralink/schemas/cli/v1/release-inspect-attestation.json
+++ b/src/infralink/schemas/cli/v1/release-inspect-attestation.json
@@ -310,6 +310,75 @@
       "title": "PublisherRequestV2",
       "type": "object"
     },
+    "PublisherRequestV3": {
+      "additionalProperties": false,
+      "description": "V2 request facts plus one immutable canonical release-manifest binding.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "release_manifest": {
+          "$ref": "#/$defs/ReleaseManifestBindingV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v3",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest",
+        "release_manifest"
+      ],
+      "title": "PublisherRequestV3",
+      "type": "object"
+    },
     "ReleaseArtifactBinding": {
       "additionalProperties": false,
       "properties": {
@@ -423,6 +492,9 @@
             },
             {
               "$ref": "#/$defs/ReleaseAttestationV2"
+            },
+            {
+              "$ref": "#/$defs/ReleaseAttestationV3"
             }
           ],
           "title": "Attestation"
@@ -484,6 +556,56 @@
       "title": "ReleaseAttestationV2",
       "type": "object"
     },
+    "ReleaseAttestationV3": {
+      "additionalProperties": false,
+      "description": "Immutable publisher result bound to one canonical v3 request.",
+      "properties": {
+        "publisher_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "request": {
+          "$ref": "#/$defs/PublisherRequestV3"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "result": {
+          "enum": [
+            "dry-run",
+            "published"
+          ],
+          "title": "Result",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.release-attestation.v3",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "tag": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReleaseTagV1"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "request",
+        "request_digest",
+        "publisher_receipt",
+        "result"
+      ],
+      "title": "ReleaseAttestationV3",
+      "type": "object"
+    },
     "ReleaseCiReceipt": {
       "additionalProperties": false,
       "properties": {
@@ -540,6 +662,84 @@
         "sequence"
       ],
       "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseManifestAuthorityV1": {
+      "additionalProperties": false,
+      "description": "The request facts which a canonical release manifest must carry.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        }
+      },
+      "required": [
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher"
+      ],
+      "title": "ReleaseManifestAuthorityV1",
+      "type": "object"
+    },
+    "ReleaseManifestBindingV1": {
+      "additionalProperties": false,
+      "description": "Exact canonical registry blob and its declared request authority.",
+      "properties": {
+        "authority": {
+          "$ref": "#/$defs/ReleaseManifestAuthorityV1"
+        },
+        "blob_identity": {
+          "maxLength": 640,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*/blobs/[0-9a-f]{40}$",
+          "title": "Blob Identity",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)+$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "blob_identity",
+        "sha256",
+        "authority"
+      ],
+      "title": "ReleaseManifestBindingV1",
       "type": "object"
     },
     "ReleasePublisherReceipt": {

--- a/src/infralink/schemas/cli/v1/release-render-publisher-request.json
+++ b/src/infralink/schemas/cli/v1/release-render-publisher-request.json
@@ -326,6 +326,9 @@
             },
             {
               "$ref": "#/$defs/PublisherRequestV2"
+            },
+            {
+              "$ref": "#/$defs/PublisherRequestV3"
             }
           ],
           "title": "Publisher Request"
@@ -400,6 +403,75 @@
         "request_digest"
       ],
       "title": "PublisherRequestV2",
+      "type": "object"
+    },
+    "PublisherRequestV3": {
+      "additionalProperties": false,
+      "description": "V2 request facts plus one immutable canonical release-manifest binding.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "dry-run",
+            "publish"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        },
+        "release_manifest": {
+          "$ref": "#/$defs/ReleaseManifestBindingV1"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "infralink.publisher-request.v3",
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher",
+        "mode",
+        "request_digest",
+        "release_manifest"
+      ],
+      "title": "PublisherRequestV3",
       "type": "object"
     },
     "ReleaseArtifactBinding": {
@@ -480,6 +552,84 @@
         "sequence"
       ],
       "title": "ReleaseIdentityV1",
+      "type": "object"
+    },
+    "ReleaseManifestAuthorityV1": {
+      "additionalProperties": false,
+      "description": "The request facts which a canonical release manifest must carry.",
+      "properties": {
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
+          "type": "string"
+        },
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        }
+      },
+      "required": [
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher"
+      ],
+      "title": "ReleaseManifestAuthorityV1",
+      "type": "object"
+    },
+    "ReleaseManifestBindingV1": {
+      "additionalProperties": false,
+      "description": "Exact canonical registry blob and its declared request authority.",
+      "properties": {
+        "authority": {
+          "$ref": "#/$defs/ReleaseManifestAuthorityV1"
+        },
+        "blob_identity": {
+          "maxLength": 640,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*/blobs/[0-9a-f]{40}$",
+          "title": "Blob Identity",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)+$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "blob_identity",
+        "sha256",
+        "authority"
+      ],
+      "title": "ReleaseManifestBindingV1",
       "type": "object"
     }
   },

--- a/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
+++ b/src/infralink/schemas/release/v3/publisher-request.v3.schema.json
@@ -36,42 +36,6 @@
       "title": "ArtifactSourceBindingV2",
       "type": "object"
     },
-    "ImmutablePolicySelectorV1": {
-      "additionalProperties": false,
-      "description": "Exact registry blob containing a public tag-signer policy.",
-      "properties": {
-        "commit": {
-          "pattern": "^[0-9a-f]{40}$",
-          "title": "Commit",
-          "type": "string"
-        },
-        "path": {
-          "maxLength": 256,
-          "minLength": 1,
-          "title": "Path",
-          "type": "string"
-        },
-        "repository": {
-          "maxLength": 512,
-          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
-          "title": "Repository",
-          "type": "string"
-        },
-        "sha256": {
-          "pattern": "^[0-9a-f]{64}$",
-          "title": "Sha256",
-          "type": "string"
-        }
-      },
-      "required": [
-        "path",
-        "sha256",
-        "repository",
-        "commit"
-      ],
-      "title": "ImmutablePolicySelectorV1",
-      "type": "object"
-    },
     "ImmutableSourceReceiptV2": {
       "additionalProperties": false,
       "description": "A receipt whose source cannot be silently retargeted.",
@@ -141,24 +105,6 @@
       "title": "PublisherIdentityV2",
       "type": "object"
     },
-    "PublisherTagSignerPolicyV1": {
-      "additionalProperties": false,
-      "description": "Immutable policy location and the one public signer it authorizes.",
-      "properties": {
-        "selector": {
-          "$ref": "#/$defs/ImmutablePolicySelectorV1"
-        },
-        "signer": {
-          "$ref": "#/$defs/ReleaseManifestSignerV1"
-        }
-      },
-      "required": [
-        "selector",
-        "signer"
-      ],
-      "title": "PublisherTagSignerPolicyV1",
-      "type": "object"
-    },
     "ReleaseIdentityV1": {
       "additionalProperties": false,
       "description": "Immutable release identity, expressed redundantly for simple CI consumers.",
@@ -187,34 +133,88 @@
       "title": "ReleaseIdentityV1",
       "type": "object"
     },
-    "ReleaseManifestSignerV1": {
+    "ReleaseManifestAuthorityV1": {
       "additionalProperties": false,
-      "description": "Public SSH signer identity named by a release manifest.",
+      "description": "The request facts which a canonical release manifest must carry.",
       "properties": {
-        "fingerprint": {
-          "pattern": "^SHA256:[A-Za-z0-9+/]{43}$",
-          "title": "Fingerprint",
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
           "type": "string"
         },
-        "principal": {
-          "maxLength": 63,
-          "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
-          "title": "Principal",
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        }
+      },
+      "required": [
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher"
+      ],
+      "title": "ReleaseManifestAuthorityV1",
+      "type": "object"
+    },
+    "ReleaseManifestBindingV1": {
+      "additionalProperties": false,
+      "description": "Exact canonical registry blob and its declared request authority.",
+      "properties": {
+        "authority": {
+          "$ref": "#/$defs/ReleaseManifestAuthorityV1"
+        },
+        "blob_identity": {
+          "maxLength": 640,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*/blobs/[0-9a-f]{40}$",
+          "title": "Blob Identity",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)+$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
           "type": "string"
         }
       },
       "required": [
-        "principal",
-        "fingerprint"
+        "repository",
+        "blob_identity",
+        "sha256",
+        "authority"
       ],
-      "title": "ReleaseManifestSignerV1",
+      "title": "ReleaseManifestBindingV1",
       "type": "object"
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "V2 request facts plus immutable tag-signer policy provenance.",
+  "description": "V2 request facts plus one immutable canonical release-manifest binding.",
   "properties": {
     "artifacts": {
       "items": {
@@ -232,9 +232,6 @@
       "pattern": "^[0-9a-f]{40}$",
       "title": "Controller Commit",
       "type": "string"
-    },
-    "manifest_signer": {
-      "$ref": "#/$defs/ReleaseManifestSignerV1"
     },
     "mode": {
       "enum": [
@@ -255,6 +252,9 @@
     "release": {
       "$ref": "#/$defs/ReleaseIdentityV1"
     },
+    "release_manifest": {
+      "$ref": "#/$defs/ReleaseManifestBindingV1"
+    },
     "request_digest": {
       "pattern": "^[0-9a-f]{64}$",
       "title": "Request Digest",
@@ -264,9 +264,6 @@
       "const": "infralink.publisher-request.v3",
       "title": "Schema Version",
       "type": "string"
-    },
-    "tag_signer_policy": {
-      "$ref": "#/$defs/PublisherTagSignerPolicyV1"
     }
   },
   "required": [
@@ -279,8 +276,7 @@
     "publisher",
     "mode",
     "request_digest",
-    "tag_signer_policy",
-    "manifest_signer"
+    "release_manifest"
   ],
   "title": "PublisherRequestV3",
   "type": "object"

--- a/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
+++ b/src/infralink/schemas/release/v3/release-attestation.v3.schema.json
@@ -36,42 +36,6 @@
       "title": "ArtifactSourceBindingV2",
       "type": "object"
     },
-    "ImmutablePolicySelectorV1": {
-      "additionalProperties": false,
-      "description": "Exact registry blob containing a public tag-signer policy.",
-      "properties": {
-        "commit": {
-          "pattern": "^[0-9a-f]{40}$",
-          "title": "Commit",
-          "type": "string"
-        },
-        "path": {
-          "maxLength": 256,
-          "minLength": 1,
-          "title": "Path",
-          "type": "string"
-        },
-        "repository": {
-          "maxLength": 512,
-          "pattern": "^[a-z][a-z0-9+.-]{0,31}://[A-Za-z0-9._~:/@+-]{1,384}$",
-          "title": "Repository",
-          "type": "string"
-        },
-        "sha256": {
-          "pattern": "^[0-9a-f]{64}$",
-          "title": "Sha256",
-          "type": "string"
-        }
-      },
-      "required": [
-        "path",
-        "sha256",
-        "repository",
-        "commit"
-      ],
-      "title": "ImmutablePolicySelectorV1",
-      "type": "object"
-    },
     "ImmutableSourceReceiptV2": {
       "additionalProperties": false,
       "description": "A receipt whose source cannot be silently retargeted.",
@@ -143,7 +107,7 @@
     },
     "PublisherRequestV3": {
       "additionalProperties": false,
-      "description": "V2 request facts plus immutable tag-signer policy provenance.",
+      "description": "V2 request facts plus one immutable canonical release-manifest binding.",
       "properties": {
         "artifacts": {
           "items": {
@@ -161,9 +125,6 @@
           "pattern": "^[0-9a-f]{40}$",
           "title": "Controller Commit",
           "type": "string"
-        },
-        "manifest_signer": {
-          "$ref": "#/$defs/ReleaseManifestSignerV1"
         },
         "mode": {
           "enum": [
@@ -184,6 +145,9 @@
         "release": {
           "$ref": "#/$defs/ReleaseIdentityV1"
         },
+        "release_manifest": {
+          "$ref": "#/$defs/ReleaseManifestBindingV1"
+        },
         "request_digest": {
           "pattern": "^[0-9a-f]{64}$",
           "title": "Request Digest",
@@ -193,9 +157,6 @@
           "const": "infralink.publisher-request.v3",
           "title": "Schema Version",
           "type": "string"
-        },
-        "tag_signer_policy": {
-          "$ref": "#/$defs/PublisherTagSignerPolicyV1"
         }
       },
       "required": [
@@ -208,28 +169,9 @@
         "publisher",
         "mode",
         "request_digest",
-        "tag_signer_policy",
-        "manifest_signer"
+        "release_manifest"
       ],
       "title": "PublisherRequestV3",
-      "type": "object"
-    },
-    "PublisherTagSignerPolicyV1": {
-      "additionalProperties": false,
-      "description": "Immutable policy location and the one public signer it authorizes.",
-      "properties": {
-        "selector": {
-          "$ref": "#/$defs/ImmutablePolicySelectorV1"
-        },
-        "signer": {
-          "$ref": "#/$defs/ReleaseManifestSignerV1"
-        }
-      },
-      "required": [
-        "selector",
-        "signer"
-      ],
-      "title": "PublisherTagSignerPolicyV1",
       "type": "object"
     },
     "ReleaseIdentityV1": {
@@ -260,28 +202,82 @@
       "title": "ReleaseIdentityV1",
       "type": "object"
     },
-    "ReleaseManifestSignerV1": {
+    "ReleaseManifestAuthorityV1": {
       "additionalProperties": false,
-      "description": "Public SSH signer identity named by a release manifest.",
+      "description": "The request facts which a canonical release manifest must carry.",
       "properties": {
-        "fingerprint": {
-          "pattern": "^SHA256:[A-Za-z0-9+/]{43}$",
-          "title": "Fingerprint",
+        "artifacts": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSourceBindingV2"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Artifacts",
+          "type": "array"
+        },
+        "ci_receipt": {
+          "$ref": "#/$defs/ImmutableSourceReceiptV2"
+        },
+        "controller_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Controller Commit",
           "type": "string"
         },
-        "principal": {
-          "maxLength": 63,
-          "minLength": 1,
-          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
-          "title": "Principal",
+        "publisher": {
+          "$ref": "#/$defs/PublisherIdentityV2"
+        },
+        "registry_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Registry Commit",
+          "type": "string"
+        },
+        "release": {
+          "$ref": "#/$defs/ReleaseIdentityV1"
+        }
+      },
+      "required": [
+        "release",
+        "registry_commit",
+        "controller_commit",
+        "ci_receipt",
+        "artifacts",
+        "publisher"
+      ],
+      "title": "ReleaseManifestAuthorityV1",
+      "type": "object"
+    },
+    "ReleaseManifestBindingV1": {
+      "additionalProperties": false,
+      "description": "Exact canonical registry blob and its declared request authority.",
+      "properties": {
+        "authority": {
+          "$ref": "#/$defs/ReleaseManifestAuthorityV1"
+        },
+        "blob_identity": {
+          "maxLength": 640,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)*/blobs/[0-9a-f]{40}$",
+          "title": "Blob Identity",
+          "type": "string"
+        },
+        "repository": {
+          "maxLength": 512,
+          "pattern": "^(?:https|ssh)://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._-]+)+$",
+          "title": "Repository",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
           "type": "string"
         }
       },
       "required": [
-        "principal",
-        "fingerprint"
+        "repository",
+        "blob_identity",
+        "sha256",
+        "authority"
       ],
-      "title": "ReleaseManifestSignerV1",
+      "title": "ReleaseManifestBindingV1",
       "type": "object"
     },
     "ReleaseTagV1": {

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -110,6 +110,26 @@ def _publisher_request_v2(path: Path) -> Path:
     return path
 
 
+def _publisher_request_v3(path: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "examples/release/publisher-request.v3.json"
+    path.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def _attestation_v3(path: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "examples/release/release-attestation.v2.json"
+    request_source = (
+        Path(__file__).resolve().parents[1] / "examples/release/publisher-request.v3.json"
+    )
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    request = json.loads(request_source.read_text(encoding="utf-8"))
+    payload["schema_version"] = "infralink.release-attestation.v3"
+    payload["request"] = request
+    payload["request_digest"] = request["request_digest"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
 def _attestation_v2(path: Path) -> Path:
     source = Path(__file__).resolve().parents[1] / "examples/release/release-attestation.v2.json"
     path.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
@@ -246,6 +266,30 @@ def test_release_render_publisher_request_accepts_the_registry_rendered_v2_reque
     assert [item["rel"] for item in payload["next_actions"]] == ["inspect-attestation"]
 
 
+def test_release_render_publisher_request_inspects_a_manifest_bound_v3_request(
+    tmp_path: Path,
+) -> None:
+    request = _publisher_request_v3(tmp_path / "publisher-request.v3.json")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "release",
+            "render-publisher-request",
+            "--publisher-request",
+            str(request),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _payload(result)
+    assert_schema(payload, "release-render-publisher-request")
+    rendered = payload["result"]["publisher_request"]
+    assert rendered["schema_version"] == "infralink.publisher-request.v3"
+    assert rendered["release_manifest"]["blob_identity"].endswith("/blobs/" + "a" * 40)
+    assert [item["rel"] for item in payload["next_actions"]] == ["inspect-attestation"]
+
+
 def test_release_render_publisher_request_rejects_noncanonical_v2_request_digest(
     tmp_path: Path,
 ) -> None:
@@ -328,6 +372,23 @@ def test_release_inspect_attestation_reads_the_strict_v2_completion_record(tmp_p
     output = payload["result"]["attestation"]
     assert output["schema_version"] == "infralink.release-attestation.v2"
     assert output["request"]["schema_version"] == "infralink.publisher-request.v2"
+
+
+def test_release_inspect_attestation_reads_the_manifest_bound_v3_completion_record(
+    tmp_path: Path,
+) -> None:
+    attestation = _attestation_v3(tmp_path / "release-attestation.v3.json")
+
+    result = CliRunner().invoke(
+        cli, ["release", "inspect-attestation", "--attestation", str(attestation)]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _payload(result)
+    assert_schema(payload, "release-inspect-attestation")
+    output = payload["result"]["attestation"]
+    assert output["schema_version"] == "infralink.release-attestation.v3"
+    assert output["request"]["release_manifest"]["authority"]["publisher"] == output["request"]["publisher"]
     assert output["result"] == "dry-run"
     assert output["tag"] is None
 

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -388,7 +388,10 @@ def test_release_inspect_attestation_reads_the_manifest_bound_v3_completion_reco
     assert_schema(payload, "release-inspect-attestation")
     output = payload["result"]["attestation"]
     assert output["schema_version"] == "infralink.release-attestation.v3"
-    assert output["request"]["release_manifest"]["authority"]["publisher"] == output["request"]["publisher"]
+    assert (
+        output["request"]["release_manifest"]["authority"]["publisher"]
+        == output["request"]["publisher"]
+    )
     assert output["result"] == "dry-run"
     assert output["tag"] is None
 

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -50,20 +50,32 @@ def _bind_request_digest(request: dict[str, object]) -> None:
 def _v3_request() -> dict[str, object]:
     request = _fixture("publisher-request.v2.json")
     request["schema_version"] = "infralink.publisher-request.v3"
-    signer = {
-        "principal": "infralink-release-publisher",
-        "fingerprint": "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    remote = "https://example.com/relaxgg/infra-registry"
+    receipt = request["ci_receipt"]
+    assert isinstance(receipt, dict)
+    receipt["repository"] = remote
+    request["release_manifest"] = {
+        "repository": remote,
+        "blob_identity": f"{remote}/blobs/{'a' * 40}",
+        "sha256": "b" * 64,
+        "authority": json.loads(
+            json.dumps(
+                {
+                    key: value
+                    for key, value in request.items()
+                    if key
+                    in {
+                        "release",
+                        "registry_commit",
+                        "controller_commit",
+                        "ci_receipt",
+                        "artifacts",
+                        "publisher",
+                    }
+                }
+            )
+        ),
     }
-    request["tag_signer_policy"] = {
-        "selector": {
-            "repository": "gitea://gitea.i.cyberstorm.dev/cyberstorm/infralink-release-publisher",
-            "commit": "a" * 40,
-            "path": "release-publisher/allowed-signers.json",
-            "sha256": "b" * 64,
-        },
-        "signer": signer,
-    }
-    request["manifest_signer"] = dict(signer)
     _bind_request_digest(request)
     return request
 
@@ -185,44 +197,13 @@ def test_v2_attestation_fixture_binds_the_canonical_request_digest() -> None:
     assert attestation.tag is None
 
 
-def test_v3_request_binds_manifest_signer_to_an_immutable_tag_policy() -> None:
+def test_v3_request_binds_a_canonical_immutable_release_manifest() -> None:
     request = PublisherRequestV3.model_validate(_v3_request())
 
     assert request.request_digest == request.canonical_digest()
-    assert request.tag_signer_policy.selector.commit == "a" * 40
-    assert request.tag_signer_policy.selector.sha256 == "b" * 64
-    assert request.tag_signer_policy.signer == request.manifest_signer
-
-
-def test_v3_request_accepts_the_canonical_unpadded_ssh_fingerprint() -> None:
-    request = PublisherRequestV3.model_validate(_v3_request())
-
-    assert request.manifest_signer.fingerprint == (
-        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    )
-
-
-@pytest.mark.parametrize(
-    "fingerprint",
-    [
-        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-    ],
-)
-def test_v3_request_rejects_noncanonical_ssh_fingerprint(fingerprint: str) -> None:
-    request = _v3_request()
-    policy = request["tag_signer_policy"]
-    assert isinstance(policy, dict)
-    policy_signer = policy["signer"]
-    assert isinstance(policy_signer, dict)
-    policy_signer["fingerprint"] = fingerprint
-    manifest_signer = request["manifest_signer"]
-    assert isinstance(manifest_signer, dict)
-    manifest_signer["fingerprint"] = fingerprint
-    _bind_request_digest(request)
-
-    with pytest.raises(ValidationError, match="fingerprint"):
-        PublisherRequestV3.model_validate(request)
+    assert request.release_manifest.blob_identity.endswith("/blobs/" + "a" * 40)
+    assert request.release_manifest.sha256 == "b" * 64
+    assert request.release_manifest.authority.release == request.release
 
 
 def test_v3_published_schema_and_strict_parser_accept_the_public_fixture() -> None:
@@ -245,50 +226,87 @@ def test_v3_attestation_carries_the_bound_v3_request() -> None:
 
     parsed = ReleaseAttestationV3.model_validate(attestation)
 
-    assert parsed.request.manifest_signer == parsed.request.tag_signer_policy.signer
+    assert parsed.request.release_manifest.repository == parsed.request.ci_receipt.repository
     assert parse_release_attestation_v3_json(json.dumps(attestation, separators=(",", ":")))
 
 
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     [
-        ("commit", "main", "commit"),
-        ("path", "../allowed-signers.json", "safe and relative"),
+        ("blob_identity", "release-candidates/core-v2/1/release-manifest.json", "blob_identity"),
+        ("blob_identity", "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/main", "blob_identity"),
+        ("blob_identity", "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/" + "A" * 40, "blob_identity"),
         ("sha256", "0" * 63, "sha256"),
     ],
 )
-def test_v3_request_rejects_mutable_or_unsafe_signer_policy_selector(
+def test_v3_request_rejects_path_only_mutable_or_noncanonical_manifest_identity(
     field: str, value: str, match: str
 ) -> None:
     request = _v3_request()
-    policy = request["tag_signer_policy"]
-    assert isinstance(policy, dict)
-    selector = policy["selector"]
-    assert isinstance(selector, dict)
-    selector[field] = value
+    manifest = request["release_manifest"]
+    assert isinstance(manifest, dict)
+    manifest[field] = value
+    _bind_request_digest(request)
 
     with pytest.raises(ValidationError, match=match):
         PublisherRequestV3.model_validate(request)
 
 
-def test_v3_request_rejects_a_manifest_signer_that_differs_from_policy() -> None:
+def test_v3_request_rejects_a_manifest_from_another_registry_authority() -> None:
     request = _v3_request()
-    manifest_signer = request["manifest_signer"]
-    assert isinstance(manifest_signer, dict)
-    manifest_signer["principal"] = "another-publisher"
+    manifest = request["release_manifest"]
+    assert isinstance(manifest, dict)
+    other_remote = "https://example.com/relaxgg/another-registry"
+    manifest["repository"] = other_remote
+    manifest["blob_identity"] = f"{other_remote}/blobs/{'a' * 40}"
     _bind_request_digest(request)
 
-    with pytest.raises(ValidationError, match="manifest signer must match tag signer policy"):
+    with pytest.raises(ValidationError, match="manifest repository must match request authority"):
         PublisherRequestV3.model_validate(request)
 
 
-def test_v3_request_rejects_a_missing_tag_signer_policy_binding() -> None:
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda request: request["release"].update({"identity": "releases/core-v2/43", "sequence": 43}),
+        lambda request: request.update({"registry_commit": "c" * 40}),
+        lambda request: request.update({"controller_commit": "c" * 40}),
+        lambda request: request["ci_receipt"].update({"run": "577"}),
+        lambda request: request["artifacts"][0].update({"sha256": "d" * 64}),
+        lambda request: request["publisher"].update({"identity": "another-publisher"}),
+    ],
+)
+def test_v3_request_rejects_manifest_authority_that_disagrees_with_request(
+    mutate: Callable[[dict[str, object]], None],
+) -> None:
     request = _v3_request()
-    request.pop("tag_signer_policy")
+    mutate(request)
     _bind_request_digest(request)
 
-    with pytest.raises(ValidationError, match="tag_signer_policy"):
+    with pytest.raises(ValidationError, match="manifest authority must match request authority"):
         PublisherRequestV3.model_validate(request)
+
+
+def test_v3_request_rejects_a_missing_manifest_binding() -> None:
+    request = _v3_request()
+    request.pop("release_manifest")
+    _bind_request_digest(request)
+
+    with pytest.raises(ValidationError, match="release_manifest"):
+        PublisherRequestV3.model_validate(request)
+
+
+def test_v3_published_schema_rejects_noncanonical_manifest_locator() -> None:
+    request = _v3_request()
+    manifest = request["release_manifest"]
+    assert isinstance(manifest, dict)
+    manifest["blob_identity"] = "release-candidates/core-v2/1/release-manifest.json"
+    _bind_request_digest(request)
+    schema = json.loads(
+        (V2_SCHEMAS.parent / "v3" / "publisher-request.v3.schema.json").read_text(encoding="utf-8")
+    )
+
+    assert list(Draft202012Validator(schema).iter_errors(request))
 
 
 def test_v2_request_remains_compatible_without_signer_policy_binding() -> None:

--- a/tests/test_release_producer_contract.py
+++ b/tests/test_release_producer_contract.py
@@ -234,8 +234,16 @@ def test_v3_attestation_carries_the_bound_v3_request() -> None:
     ("field", "value", "match"),
     [
         ("blob_identity", "release-candidates/core-v2/1/release-manifest.json", "blob_identity"),
-        ("blob_identity", "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/main", "blob_identity"),
-        ("blob_identity", "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/" + "A" * 40, "blob_identity"),
+        (
+            "blob_identity",
+            "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/main",
+            "blob_identity",
+        ),
+        (
+            "blob_identity",
+            "https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git/blobs/" + "A" * 40,
+            "blob_identity",
+        ),
         ("sha256", "0" * 63, "sha256"),
     ],
 )
@@ -268,7 +276,9 @@ def test_v3_request_rejects_a_manifest_from_another_registry_authority() -> None
 @pytest.mark.parametrize(
     "mutate",
     [
-        lambda request: request["release"].update({"identity": "releases/core-v2/43", "sequence": 43}),
+        lambda request: request["release"].update(
+            {"identity": "releases/core-v2/43", "sequence": 43}
+        ),
         lambda request: request.update({"registry_commit": "c" * 40}),
         lambda request: request.update({"controller_commit": "c" * 40}),
         lambda request: request["ci_receipt"].update({"run": "577"}),


### PR DESCRIPTION
Closes #53.

Adds a strict `infralink.publisher-request.v3` manifest binding with canonical immutable locator and full request-authority equality. V2 parser, schema, fixtures, and behavior remain unchanged.

Includes v3 CLI/HATEOAS request and attestation inspection support, generated schemas, and rejection coverage for mutable/path-only/noncanonical/mismatched manifest inputs.

Verification: full pytest `1267 passed, 1 skipped`; Ruff and diff check clean; independent re-review approved. No BWS, signing, tags, CI configuration, or host behavior.