### PR TITLE
fix(bootstrap): enable V2 reconciliation timer

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -70,6 +70,7 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "install_jq",
         "install_bws_cli",
         "install_self_deploy_dependencies",
+        "enable_self_deploy_timer",
     }
 )
 

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -267,3 +267,74 @@ def test_host_bootstrap_apply_never_sends_manual_secret_or_runtime_actions(
 
 def test_baseline_executor_mirrors_the_v2_timer_capability() -> None:
     assert "enable_self_deploy_timer" in BASELINE_EXECUTOR_ACTIONS
+
+
+def test_host_bootstrap_apply_forwards_only_the_timer_action_when_it_alone_is_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    readiness = HostReadinessProbe(
+        reachable=True,
+        hostname="database.example.com",
+        machine_id="machine-id",
+        commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": True},
+        devops_account=True,
+        devops_authorized_access=True,
+        bws_config=True,
+        self_deploy_dependencies=True,
+        self_deploy_runtime=True,
+        self_deploy_timer_enabled=False,
+        self_deploy_timer_active=False,
+        error=None,
+    )
+    monkeypatch.setattr(
+        "infralink.cli.main.evaluate_host_readiness",
+        lambda *_args: evaluate_readiness(
+            type(
+                "Host",
+                (),
+                {
+                    "canonical_name": "database.example.com",
+                    "tailscale_ip": "192.0.2.10",
+                    "public_ip": None,
+                },
+            )(),
+            type("Transport", (), {"probe": lambda _self, _address: readiness})(),
+        ),
+    )
+    control_root = tmp_path / "control"
+    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.touch()
+    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    calls: list[object] = []
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or Completed(),
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(ROOT / "examples" / "registry.yml"),
+            "--edges",
+            str(ROOT / "examples" / "edges.yml"),
+            "host",
+            "bootstrap",
+            "database.example.com",
+            "--apply",
+        ],
+    )
+
+    # The executor succeeded, but this response still represents the pre-apply
+    # readiness probe and therefore remains negative until the next probe.
+    assert result.exit_code == 1
+    argv, _kwargs = calls[0]
+    assert json.loads(argv[0][-1])["bootstrap_actions"] == ["enable_self_deploy_timer"]

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -262,4 +262,8 @@ def test_host_bootstrap_apply_never_sends_manual_secret_or_runtime_actions(
     assert "install_bws_cli" in serialized
     assert "configure_bws" not in serialized
     assert "install_self_deploy_runtime" not in serialized
-    assert "enable_self_deploy_timer" not in serialized
+    assert "enable_self_deploy_timer" in serialized
+
+
+def test_baseline_executor_mirrors_the_v2_timer_capability() -> None:
+    assert "enable_self_deploy_timer" in BASELINE_EXECUTOR_ACTIONS


### PR DESCRIPTION
Complements relax-dot-gg/infra-management#234.

Mirrors the managed baseline executor capability for `enable_self_deploy_timer` and proves a timer-only readiness failure submits exactly that action. The corresponding Ansible executor change is in relax-dot-gg/infra-management#235.

No host action, legacy self-deploy, or service configuration changes are included.