### PR TITLE
Fix host apply to trigger declared local reconcile

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -290,7 +290,7 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         ],
     },
     ("host", "apply"): {
-        "description": "Apply one declared host through the control plane.",
+        "description": "Start one declared host-local reconcile operation.",
         "arguments": [{"name": "host", "type": "string", "required": True}],
         "options": [
             {"name": "dry_run", "type": "boolean", "required": False},
@@ -303,16 +303,20 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         ],
     },
     ("operation",): {
-        "description": "Inspect durable host apply operations.",
+        "description": "Inspect declared host-local reconcile operations.",
         "arguments": [],
         "options": [],
-        "examples": ["infralink operation status op_01J00000000000000000000000"],
+        "examples": [
+            "infralink operation status ssh/32a3324f-c3d0-4a4f-9587-52c099bcb3fb/8d6c4ad6-0e4a-4b58-9fe3-5ad9e1760d56"
+        ],
     },
     ("operation", "status"): {
-        "description": "Get the current state of one durable host apply operation.",
+        "description": "Get the current state of one declared host-local reconcile operation.",
         "arguments": [{"name": "operation_id", "type": "string", "required": True}],
         "options": [],
-        "examples": ["infralink operation status op_01J00000000000000000000000"],
+        "examples": [
+            "infralink operation status ssh/32a3324f-c3d0-4a4f-9587-52c099bcb3fb/8d6c4ad6-0e4a-4b58-9fe3-5ad9e1760d56"
+        ],
     },
     ("edge",): {
         "description": "Inspect edges.",
@@ -1802,9 +1806,9 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
 )
 @pass_context
 def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: int) -> int:
-    """Apply one declared host through the configured control plane."""
+    """Start the declared host-local reconcile unit through SSH."""
     from infralink.cli.operations import (
-        operation_provider_from_environment,
+        operation_provider,
         resolve_apply_request,
         wait_for_terminal,
     )
@@ -1833,10 +1837,10 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
         )
         return 0
 
-    provider = operation_provider_from_environment()
+    provider = operation_provider()
     record = provider.submit(request)
     if wait:
-        record = wait_for_terminal(provider, record.id, timeout_seconds=timeout)
+        record = wait_for_terminal(provider, record.id, request, timeout_seconds=timeout)
     result = HostApplyResult(
         operation=OperationSummary(
             id=record.id,
@@ -1874,10 +1878,27 @@ def operation() -> None:
 @click.argument("operation_id")
 @pass_context
 def operation_status(ctx: Context, operation_id: str) -> int:
-    """Get the current state of one durable host apply operation."""
-    from infralink.cli.operations import operation_provider_from_environment
+    """Get the current state of one declared host-local reconcile operation."""
+    from infralink.cli.operations import operation_provider, resolve_apply_request
 
-    record = operation_provider_from_environment().status(operation_id)
+    if operation_id.startswith("op_"):
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Legacy control-plane operation status is unavailable",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Start a new declared host-local apply operation",
+            details={"operation_id": operation_id},
+        )
+    parts = operation_id.split("/", 2)
+    host_ref = parts[1] if len(parts) == 3 and parts[0] == "ssh" else operation_id
+    target_host = ctx.registry.get(host_ref)
+    if target_host is None:
+        raise entity_not_found("host", host_ref)
+    if ctx.registry_path is None:
+        raise configuration_required("registry")
+    record = operation_provider().status(
+        operation_id, resolve_apply_request(ctx.registry_path, target_host)
+    )
     target = DoctorTarget.model_validate(record.target) if record.target is not None else None
     result = OperationStatusResult(
         operation=OperationSummary(

--- a/src/infralink/cli/operation_contracts.py
+++ b/src/infralink/cli/operation_contracts.py
@@ -10,7 +10,13 @@ from infralink.cli.contracts import ContractModel, DoctorTarget
 
 
 class OperationSummary(ContractModel):
-    id: str = Field(pattern=r"^op_[A-Za-z0-9_-]{8,128}$")
+    id: str = Field(
+        pattern=(
+            r"^(?:op_[A-Za-z0-9_-]{8,128}|ssh/"
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            r"[0-9a-f]{32})$"
+        )
+    )
     state: Literal["queued", "applying", "converged", "failed"]
 
 

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -1,42 +1,53 @@
-"""Provider-neutral control-plane operation client for host apply."""
+"""Declared SSH transport for host-local reconcile operations."""
 
 from __future__ import annotations
 
-import json
-import os
 import re
 import subprocess
+import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 import yaml
 
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
 
-_OPERATION_ID = re.compile(r"^op_[A-Za-z0-9_-]{8,128}$")
-_REVISION = re.compile(r"^[0-9a-f]{40}$")
-_CHANNEL = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
-_CONTROL_PLANE_URL = "INFRALINK_CONTROL_PLANE_URL"
+_OPERATION_ID = re.compile(
+    r"^ssh/(?P<host>[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/"
+    r"(?P<invocation>[0-9a-f]{32})$"
+)
+_LEGACY_OPERATION_ID = re.compile(r"^op_[A-Za-z0-9_-]{8,128}$")
+_FINGERPRINT = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
+_UNIT = "self-deploy-v2-reconcile.service"
+
+_START_REMOTE = """set -eu
+unit=$1
+systemctl start --no-block "$unit"
+systemctl show "$unit" -p InvocationID -p ActiveState -p Result -p ExecMainStatus
+"""
+_STATUS_REMOTE = """set -eu
+unit=$1
+invocation=$2
+systemctl show "$unit" -p InvocationID -p ActiveState -p Result -p ExecMainStatus
+journalctl --quiet --no-pager --output=cat _SYSTEMD_INVOCATION_ID="$invocation" || true
+"""
 
 
 @dataclass(frozen=True)
 class ApplyRequest:
-    """The only provider input exposed by host apply."""
+    """One host declaration resolved to its sole permitted remote action."""
 
     host_uuid: str
-    registry_revision: str
-    selector: str
-
-    def as_payload(self) -> dict[str, str]:
-        return {
-            "host_uuid": self.host_uuid,
-            "registry_revision": self.registry_revision,
-            "selector": self.selector,
-        }
+    canonical_name: str
+    address: str
+    port: int
+    user: str
+    host_key_fingerprint: str
+    unit: str
 
 
 @dataclass(frozen=True)
@@ -45,144 +56,246 @@ class OperationRecord:
     state: str
     target: dict[str, str] | None = None
 
-    @classmethod
-    def from_payload(cls, value: object) -> OperationRecord:
-        if not isinstance(value, dict):
-            raise _provider_failure("Control plane returned an invalid operation record")
-        operation_id = value.get("id")
-        state = value.get("state")
-        if not isinstance(operation_id, str) or not _OPERATION_ID.fullmatch(operation_id):
-            raise _provider_failure("Control plane returned an invalid operation ID")
-        if state not in {"queued", "applying", "converged", "failed"}:
-            raise _provider_failure("Control plane returned an invalid operation state")
-        target = value.get("target")
-        if target is not None and (
-            not isinstance(target, dict)
-            or target.get("type") != "host"
-            or not isinstance(target.get("id"), str)
-            or not isinstance(target.get("canonical_name"), str)
-        ):
-            raise _provider_failure("Control plane returned an invalid operation target")
-        return cls(id=operation_id, state=state, target=target)
-
 
 class OperationProvider(Protocol):
     def submit(self, request: ApplyRequest) -> OperationRecord: ...
 
-    def status(self, operation_id: str) -> OperationRecord: ...
+    def status(self, operation_id: str, request: ApplyRequest) -> OperationRecord: ...
 
 
-class HttpOperationProvider:
-    """Minimal HTTP adapter; provider implementation owns operation durability."""
-
-    def __init__(self, base_url: str) -> None:
-        self._base_url = base_url.rstrip("/")
+class SshOperationProvider:
+    """Start and inspect one declared systemd reconcile unit over SSH."""
 
     def submit(self, request: ApplyRequest) -> OperationRecord:
-        return OperationRecord.from_payload(
-            self._request("POST", "/operations", request.as_payload())
+        values = self._run(request, _START_REMOTE)
+        return self._record(request, values)
+
+    def status(self, operation_id: str, request: ApplyRequest) -> OperationRecord:
+        match = _OPERATION_ID.fullmatch(operation_id)
+        if match is None or match.group("host") != request.host_uuid:
+            raise _usage_failure("Operation ID does not belong to the declared host", operation_id)
+        values = self._run(request, _STATUS_REMOTE, match.group("invocation"))
+        invocation = values.get("InvocationID", "").lower()
+        if invocation == match.group("invocation"):
+            return self._record(request, values)
+        state = _journal_state(values.get("journal", []))
+        if state is None:
+            raise _provider_failure("Declared host has not recorded the requested reconcile run")
+        return OperationRecord(
+            id=operation_id,
+            state=state,
+            target={
+                "type": "host",
+                "id": request.host_uuid,
+                "canonical_name": request.canonical_name,
+            },
         )
 
-    def status(self, operation_id: str) -> OperationRecord:
-        if not _OPERATION_ID.fullmatch(operation_id):
-            raise CliFailure(
-                code=ErrorCode.USAGE_ERROR,
-                message="Operation ID is invalid",
-                exit_code=ExitCode.USAGE_ERROR,
-                fix="Use the opaque operation ID returned by host apply",
-                details={"operation_id": operation_id},
-            )
-        return OperationRecord.from_payload(self._request("GET", f"/operations/{operation_id}"))
-
-    def _request(self, method: str, path: str, body: dict[str, str] | None = None) -> object:
-        data = json.dumps(body).encode("utf-8") if body is not None else None
-        request = Request(
-            f"{self._base_url}{path}",
-            data=data,
-            method=method,
-            headers={"Accept": "application/json", "Content-Type": "application/json"},
-        )
+    def _run(
+        self, request: ApplyRequest, script: str, invocation: str | None = None
+    ) -> dict[str, Any]:
+        remote_args = [request.unit] if invocation is None else [request.unit, invocation]
         try:
-            with urlopen(request, timeout=15) as response:  # noqa: S310 - configured control plane
-                return json.loads(response.read().decode("utf-8"))
-        except (HTTPError, URLError, TimeoutError, ValueError):
-            raise _provider_failure("Control plane operation is unavailable") from None
+            with _pinned_known_hosts(request) as known_hosts:
+                completed = subprocess.run(
+                    [
+                        "ssh",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=10",
+                        "-o",
+                        "LogLevel=ERROR",
+                        "-o",
+                        "StrictHostKeyChecking=yes",
+                        "-o",
+                        f"UserKnownHostsFile={known_hosts}",
+                        "-p",
+                        str(request.port),
+                        f"{request.user}@{request.address}",
+                        "sh",
+                        "-s",
+                        "--",
+                        *remote_args,
+                    ],
+                    input=script,
+                    text=True,
+                    capture_output=True,
+                    timeout=20,
+                    check=False,
+                )
+        except (OSError, subprocess.TimeoutExpired):
+            raise _provider_failure(
+                "Declared host SSH reconcile operation is unavailable"
+            ) from None
+        if completed.returncode != 0:
+            raise _provider_failure("Declared host rejected the reconcile operation")
+        values = _parse_properties(completed.stdout)
+        if not values.get("InvocationID"):
+            raise _provider_failure("Declared host returned no reconcile run reference")
+        return values
 
-
-def operation_provider_from_environment() -> OperationProvider:
-    url = os.environ.get(_CONTROL_PLANE_URL)
-    if not url:
-        raise CliFailure(
-            code=ErrorCode.CONFIGURATION_REQUIRED,
-            message="Host apply control plane is not configured",
-            exit_code=ExitCode.PROVIDER_ERROR,
-            fix=f"Set {_CONTROL_PLANE_URL} for the configured control-plane adapter",
-            details={"environment": _CONTROL_PLANE_URL},
+    @staticmethod
+    def _record(request: ApplyRequest, values: dict[str, Any]) -> OperationRecord:
+        invocation = values["InvocationID"].lower()
+        if not _is_uuid(invocation):
+            raise _provider_failure("Declared host returned an invalid reconcile run reference")
+        state = _state(values)
+        return OperationRecord(
+            id=f"ssh/{request.host_uuid}/{invocation}",
+            state=state,
+            target={
+                "type": "host",
+                "id": request.host_uuid,
+                "canonical_name": request.canonical_name,
+            },
         )
-    return HttpOperationProvider(url)
+
+
+def operation_provider() -> OperationProvider:
+    """Return the sole supported host-apply transport."""
+    return SshOperationProvider()
 
 
 def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
-    """Resolve one declared host to a target-set pointer at immutable HEAD."""
+    """Resolve and validate the host's explicit SSH reconcile declaration."""
     if not registry_path.is_dir():
-        raise CliFailure(
-            code=ErrorCode.CONFIGURATION_REQUIRED,
-            message="Host apply requires a directory registry checkout",
-            exit_code=ExitCode.INPUT_ERROR,
-            fix="Provide --registry pointing to the checked-out hosts directory",
-            details={"registry": str(registry_path)},
+        raise _registry_failure("Host apply requires a directory registry checkout", registry_path)
+    contract_path = registry_path / host.uuid / "operations" / "contract.yml"
+    contract = _read_mapping(contract_path, "Host apply requires a declared SSH reconcile contract")
+    machine = contract.get("machine")
+    transport = contract.get("transport")
+    reconcile = contract.get("reconcile")
+    if not isinstance(machine, dict) or machine.get("uuid") != host.uuid:
+        raise _registry_failure("Host apply contract does not match the target host", contract_path)
+    if machine.get("canonical_name") != host.canonical_name:
+        raise _registry_failure(
+            "Host apply contract canonical name does not match the target host", contract_path
         )
-    root = _git_toplevel(registry_path)
-    revision = _git_revision(root)
-    policy_path = registry_path / host.uuid / "operations" / "release-policy.yml"
-    policy = _read_mapping(policy_path, "Host apply policy is missing or invalid")
-    channel = _channel_from_policy(policy, host.uuid, policy_path)
-    selector = f"release-channels/{channel}.yml"
-    target_set = _read_mapping(root / selector, "Host apply target set is missing or invalid")
-    _validate_target_set(target_set, host.uuid, policy_path.relative_to(root).as_posix(), selector)
-    return ApplyRequest(host_uuid=host.uuid, registry_revision=revision, selector=selector)
+    if not isinstance(transport, dict) or transport.get("kind") != "ssh":
+        raise _registry_failure("Host apply contract must declare SSH transport", contract_path)
+    if not isinstance(reconcile, dict) or reconcile.get("unit") != _UNIT:
+        raise _registry_failure(
+            "Host apply contract must declare the supported reconcile unit", contract_path
+        )
+    address = transport.get("host")
+    port = transport.get("port")
+    user = transport.get("user")
+    fingerprint = transport.get("host_key_fingerprint")
+    if (
+        not isinstance(address, str)
+        or not address
+        or any(character.isspace() for character in address)
+    ):
+        raise _registry_failure("Host apply contract SSH address is invalid", contract_path)
+    if not isinstance(port, int) or not 1 <= port <= 65535:
+        raise _registry_failure("Host apply contract SSH port is invalid", contract_path)
+    if user != "root":
+        raise _registry_failure("Host apply contract must declare root SSH user", contract_path)
+    if not isinstance(fingerprint, str) or _FINGERPRINT.fullmatch(fingerprint) is None:
+        raise _registry_failure(
+            "Host apply contract SSH host key fingerprint is invalid", contract_path
+        )
+    return ApplyRequest(host.uuid, host.canonical_name, address, port, user, fingerprint, _UNIT)
 
 
 def wait_for_terminal(
-    provider: OperationProvider, operation_id: str, *, timeout_seconds: int
+    provider: OperationProvider, operation_id: str, request: ApplyRequest, *, timeout_seconds: int
 ) -> OperationRecord:
-    """Poll a durable provider operation without storing client-side state."""
+    """Poll the remote unit's own machine-readable status."""
     deadline = time.monotonic() + timeout_seconds
-    record = provider.status(operation_id)
-    while record.state in {"queued", "applying"} and time.monotonic() < deadline:
+    record = provider.status(operation_id, request)
+    while record.state == "applying" and time.monotonic() < deadline:
         time.sleep(1)
-        record = provider.status(operation_id)
+        record = provider.status(operation_id, request)
     return record
 
 
-def _git_toplevel(path: Path) -> Path:
-    try:
-        output = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        raise _registry_failure("Host apply requires a Git registry checkout", path) from None
-    return Path(output)
+def _parse_properties(stdout: str) -> dict[str, Any]:
+    values: dict[str, Any] = {"journal": []}
+    for line in stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key in {"InvocationID", "ActiveState", "Result", "ExecMainStatus"}:
+            values[key] = value
+            continue
+        try:
+            document = yaml.safe_load(line)
+        except yaml.YAMLError:
+            continue
+        if isinstance(document, dict):
+            values["journal"].append(document)
+    return values
 
 
-def _git_revision(root: Path) -> str:
+def _state(values: dict[str, Any]) -> str:
+    if values.get("ActiveState") in {"active", "activating", "reloading", "deactivating"}:
+        return "applying"
+    if values.get("Result") == "success" and values.get("ExecMainStatus") == "0":
+        return "converged"
+    return "failed"
+
+
+def _is_uuid(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{32}", value))
+
+
+def _journal_state(records: object) -> str | None:
+    if not isinstance(records, list):
+        return None
+    for record in reversed(records):
+        if isinstance(record, dict) and type(record.get("ok")) is bool:
+            return "converged" if record["ok"] else "failed"
+    return None
+
+
+@contextmanager
+def _pinned_known_hosts(request: ApplyRequest) -> Iterator[Path]:
+    """Use only a scanned key whose declared SHA256 fingerprint matches."""
     try:
-        revision = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
+        scanned = subprocess.run(
+            ["ssh-keyscan", "-T", "10", "-p", str(request.port), request.address],
             text=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        raise _registry_failure(
-            "Host apply could not resolve the registry revision", root
-        ) from None
-    if not _REVISION.fullmatch(revision):
-        raise _registry_failure("Host apply resolved an invalid registry revision", root)
-    return revision
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise _provider_failure("Declared host SSH key is unavailable") from None
+    if scanned.returncode != 0 or not scanned.stdout:
+        raise _provider_failure("Declared host SSH key is unavailable")
+    matching = []
+    for line in scanned.stdout.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        try:
+            fingerprint = subprocess.run(
+                ["ssh-keygen", "-lf", "-", "-E", "sha256"],
+                input=f"{line}\n",
+                text=True,
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if fingerprint.returncode == 0 and request.host_key_fingerprint == _ssh_fingerprint(
+            fingerprint.stdout
+        ):
+            matching.append(line)
+    if not matching:
+        raise _provider_failure("Declared host SSH key does not match its fingerprint")
+    with tempfile.TemporaryDirectory(prefix="infralink-known-hosts-") as directory:
+        path = Path(directory) / "known_hosts"
+        path.write_text("\n".join(matching) + "\n", encoding="utf-8")
+        path.chmod(0o600)
+        yield path
+
+
+def _ssh_fingerprint(stdout: str) -> str | None:
+    for value in stdout.split():
+        if _FINGERPRINT.fullmatch(value):
+            return value
+    return None
 
 
 def _read_mapping(path: Path, message: str) -> dict[str, Any]:
@@ -195,38 +308,23 @@ def _read_mapping(path: Path, message: str) -> dict[str, Any]:
     return value
 
 
-def _channel_from_policy(policy: dict[str, Any], host_uuid: str, path: Path) -> str:
-    release = policy.get("release")
-    if policy.get("host_uuid") != host_uuid or not isinstance(release, dict):
-        raise _registry_failure("Host apply policy does not match the target host", path)
-    channel = release.get("channel")
-    if not isinstance(channel, str) or not _CHANNEL.fullmatch(channel):
-        raise _registry_failure("Host apply policy has an invalid target channel", path)
-    return channel
-
-
-def _validate_target_set(
-    target_set: dict[str, Any], host_uuid: str, policy_path: str, selector: str
-) -> None:
-    if target_set.get("schema_version") != "infralink.release-target-set.v1":
-        raise _registry_failure("Host apply target set has an unsupported schema", Path(selector))
-    targets = target_set.get("targets")
-    if not isinstance(targets, list) or not any(
-        isinstance(item, dict)
-        and item.get("host_uuid") == host_uuid
-        and item.get("policy") == policy_path
-        for item in targets
-    ):
-        raise _registry_failure("Host is not selected by its declared target set", Path(selector))
-
-
 def _registry_failure(message: str, path: Path) -> CliFailure:
     return CliFailure(
         code=ErrorCode.INPUT_LOAD_FAILED,
         message=message,
         exit_code=ExitCode.INPUT_ERROR,
-        fix="Correct the declared host apply configuration and retry",
+        fix="Declare a matching SSH reconcile contract and retry",
         details={"path": str(path)},
+    )
+
+
+def _usage_failure(message: str, operation_id: str) -> CliFailure:
+    return CliFailure(
+        code=ErrorCode.USAGE_ERROR,
+        message=message,
+        exit_code=ExitCode.USAGE_ERROR,
+        fix="Use the opaque run reference returned by host apply for this host",
+        details={"operation_id": operation_id},
     )
 
 
@@ -235,5 +333,5 @@ def _provider_failure(message: str) -> CliFailure:
         code=ErrorCode.PROVIDER_UNAVAILABLE,
         message=message,
         exit_code=ExitCode.PROVIDER_ERROR,
-        fix="Retry the operation or inspect the control plane",
+        fix="Retry the host apply or inspect the host-local reconcile unit",
     )

--- a/src/infralink/schemas/cli/v1/host-apply.json
+++ b/src/infralink/schemas/cli/v1/host-apply.json
@@ -211,7 +211,7 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "pattern": "^op_[A-Za-z0-9_-]{8,128}$",
+          "pattern": "^(?:op_[A-Za-z0-9_-]{8,128}|ssh/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/[0-9a-f]{32})$",
           "title": "Id",
           "type": "string"
         },

--- a/src/infralink/schemas/cli/v1/operation-status.json
+++ b/src/infralink/schemas/cli/v1/operation-status.json
@@ -206,7 +206,7 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "pattern": "^op_[A-Za-z0-9_-]{8,128}$",
+          "pattern": "^(?:op_[A-Za-z0-9_-]{8,128}|ssh/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/[0-9a-f]{32})$",
           "title": "Id",
           "type": "string"
         },

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -10,175 +11,264 @@ from click.testing import CliRunner
 from infralink.cli.main import cli
 from tests.cli_helpers import assert_schema
 
-HOSTS = (
-    ("32a3324f-c3d0-4a4f-9587-52c099bcb3fb", "relaxgg-db-es1"),
-    ("7ffe46b7-0eb4-40cb-8e14-ea679b9948f4", "cyberstorm-watchtower"),
-    ("9157ddeb-cb6d-4d55-8252-9db358f5d932", "cyberstorm-citadel"),
-)
-HOST_ID, HOST_NAME = HOSTS[0]
+HOST_ID = "32a3324f-c3d0-4a4f-9587-52c099bcb3fb"
+HOST_NAME = "relaxgg-db-es1"
+UNIT = "self-deploy-v2-reconcile.service"
+INVOCATION = "8d6c4ad60e4a4b589fe35ad9e1760d56"
+FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 
 def _git(root: Path, *args: str) -> str:
-    completed = subprocess.run(
-        ["git", "-C", str(root), *args],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return completed.stdout.strip()
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
 
 
-def _registry_checkout(tmp_path: Path) -> tuple[Path, str]:
+def _registry_checkout(tmp_path: Path, *, declared: bool = True) -> Path:
     root = tmp_path / "registry"
-    (root / "release-channels").mkdir(parents=True)
-    for host_id, canonical_name in HOSTS:
-        host = root / "hosts" / host_id
-        host.mkdir(parents=True)
-        (host / "manifest.yml").write_text(
-            "hosts:\n"
-            f"  {host_id}:\n"
-            f"    canonical_name: {canonical_name}\n"
-            "    status: provisioning\n"
-            "    tailscale_ip: 100.64.68.83\n",
-            encoding="utf-8",
-        )
-        (host / "operations").mkdir()
-        (host / "operations" / "release-policy.yml").write_text(
-            "schema_version: infralink.release-admission.v1\n"
-            f"host_uuid: {host_id}\n"
-            "mode: release-channel\n"
-            "registry:\n  remote: https://gitea.i.cyberstorm.dev/relaxgg/infra-registry.git\n"
-            "release:\n  channel: v2\n"
-            "  allowed_signers_file: /etc/infralink/release-admission/allowed_signers\n"
-            "  recent_window: 20\n  maximum_candidates: 5\n",
-            encoding="utf-8",
-        )
-    (root / "release-channels" / "v2.yml").write_text(
-        "schema_version: infralink.release-target-set.v1\n"
-        "channel: v2\n"
-        "targets:\n"
-        + "".join(
-            f"  - host_uuid: {host_id}\n    policy: hosts/{host_id}/operations/release-policy.yml\n"
-            for host_id, _ in HOSTS
-        ),
+    host = root / "hosts" / HOST_ID
+    host.mkdir(parents=True)
+    (host / "manifest.yml").write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    status: active\n"
+        "    tailscale_ip: 100.64.68.83\n",
         encoding="utf-8",
     )
+    if declared:
+        operations = host / "operations"
+        operations.mkdir()
+        (operations / "contract.yml").write_text(
+            "schema_version: host-operations-contract.v1\n"
+            "machine:\n"
+            f"  uuid: {HOST_ID}\n"
+            f"  canonical_name: {HOST_NAME}\n"
+            "transport:\n"
+            "  kind: ssh\n"
+            "  host: 100.64.68.83\n"
+            "  port: 22\n"
+            "  user: root\n"
+            f"  host_key_fingerprint: {FINGERPRINT}\n"
+            "reconcile:\n"
+            f"  unit: {UNIT}\n",
+            encoding="utf-8",
+        )
     _git(root, "init", "--quiet")
     _git(root, "config", "user.email", "test@example.invalid")
     _git(root, "config", "user.name", "Test")
     _git(root, "add", ".")
     _git(root, "commit", "--quiet", "-m", "registry")
-    return root / "hosts", _git(root, "rev-parse", "HEAD")
+    return root / "hosts"
 
 
-@pytest.mark.parametrize(("host_id", "canonical_name"), HOSTS)
-def test_host_apply_submits_each_target_through_one_opaque_operation_for_an_immutable_registry_revision(
-    tmp_path: Path, monkeypatch, host_id: str, canonical_name: str
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_host_apply_starts_only_declared_reconcile_unit_and_returns_opaque_run_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from infralink.cli import operations
+    registry = _registry_checkout(tmp_path)
+    calls: list[list[str]] = []
+    fingerprints: list[str] = []
 
-    registry, revision = _registry_checkout(tmp_path)
-    submitted: dict[str, object] = {}
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(
+            f"InvocationID={INVOCATION}\nActiveState=activating\nResult=success\nExecMainStatus=0\n"
+        )
 
-    class Provider:
-        def submit(self, request: operations.ApplyRequest) -> operations.OperationRecord:
-            submitted.update(request.as_payload())
-            return operations.OperationRecord(id="op_01J00000000000000000000000", state="queued")
-
-        def status(self, operation_id: str) -> operations.OperationRecord:
-            raise AssertionError("default apply must not poll")
-
-    monkeypatch.setattr(operations, "operation_provider_from_environment", lambda: Provider())
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "apply", host_id])
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: (
+            fingerprints.append(request.host_key_fingerprint),
+            nullcontext(Path("/tmp/known-hosts")),
+        )[1],
+    )
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "apply", HOST_ID])
 
     payload = yaml.safe_load(response.output)
     assert response.exit_code == 0
     assert_schema(payload, "host-apply")
-    assert submitted == {
-        "host_uuid": host_id,
-        "registry_revision": revision,
-        "selector": "release-channels/v2.yml",
-    }
-    assert payload["result"] == {
-        "operation": {"id": "op_01J00000000000000000000000", "state": "queued"},
-        "target": {"type": "host", "id": host_id, "canonical_name": canonical_name},
-    }
-    assert payload["next_actions"] == [
-        {
-            "rel": "status",
-            "command": "infralink operation status op_01J00000000000000000000000",
-            "description": "Check host apply progress",
-            "safe": True,
-        }
+    assert calls == [
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "LogLevel=ERROR",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "UserKnownHostsFile=/tmp/known-hosts",
+            "-p",
+            "22",
+            "root@100.64.68.83",
+            "sh",
+            "-s",
+            "--",
+            UNIT,
+        ]
     ]
-    assert "release" not in response.output
-    assert "publisher" not in response.output
+    assert fingerprints == [FINGERPRINT]
+    assert payload["result"] == {
+        "operation": {
+            "id": f"ssh/{HOST_ID}/{INVOCATION}",
+            "state": "applying",
+        },
+        "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
+    }
+    assert payload["next_actions"][0]["rel"] == "status"
 
 
-def test_host_apply_wait_polls_the_submitted_operation_until_terminal(
-    tmp_path: Path, monkeypatch
+def test_host_apply_wait_polls_exact_run_until_converged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from infralink.cli import operations
-
-    registry, _ = _registry_checkout(tmp_path)
-
-    class Provider:
-        def submit(self, request: operations.ApplyRequest) -> operations.OperationRecord:
-            return operations.OperationRecord(id="op_01J00000000000000000000000", state="queued")
-
-        def status(self, operation_id: str) -> operations.OperationRecord:
-            return operations.OperationRecord(
-                id=operation_id,
-                state="converged",
-                target={"type": "host", "id": HOST_ID, "canonical_name": "relaxgg-db-es1"},
-            )
-
-    monkeypatch.setattr(operations, "operation_provider_from_environment", lambda: Provider())
+    registry = _registry_checkout(tmp_path)
+    responses = iter(
+        [
+            _completed(
+                f"InvocationID={INVOCATION}\n"
+                "ActiveState=activating\nResult=success\nExecMainStatus=0\n"
+            ),
+            _completed(
+                f"InvocationID={INVOCATION}\n"
+                "ActiveState=inactive\nResult=success\nExecMainStatus=0\n"
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: next(responses)
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
     monkeypatch.setattr("infralink.cli.operations.time.sleep", lambda _: None)
 
     response = CliRunner().invoke(
-        cli,
-        ["--registry", str(registry), "host", "apply", HOST_ID, "--wait", "--timeout", "1"],
+        cli, ["--registry", str(registry), "host", "apply", HOST_ID, "--wait", "--timeout", "1"]
     )
 
     payload = yaml.safe_load(response.output)
     assert response.exit_code == 0
     assert_schema(payload, "host-apply")
     assert payload["result"]["operation"]["state"] == "converged"
-    assert payload["result"]["operation"]["id"] == "op_01J00000000000000000000000"
+    assert payload["next_actions"][0]["rel"] == "doctor"
 
 
-@pytest.mark.parametrize(("host_id", "canonical_name"), HOSTS)
-def test_operation_status_is_a_resumable_provider_poll(
-    monkeypatch, host_id: str, canonical_name: str
+def test_host_apply_refuses_a_host_without_declared_ssh_reconcile_contract(tmp_path: Path) -> None:
+    registry = _registry_checkout(tmp_path, declared=False)
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "apply", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
+    assert "declared" in payload["error"]["message"].lower()
+
+
+def test_host_apply_refuses_a_noncanonical_ssh_fingerprint(tmp_path: Path) -> None:
+    registry = _registry_checkout(tmp_path)
+    contract = registry / HOST_ID / "operations" / "contract.yml"
+    contract.write_text(
+        contract.read_text(encoding="utf-8").replace(FINGERPRINT, "SHA256:short"), encoding="utf-8"
+    )
+    _git(registry.parent, "add", ".")
+    _git(registry.parent, "commit", "--quiet", "-m", "invalid fingerprint")
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "apply", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert "fingerprint" in payload["error"]["message"].lower()
+
+
+def test_operation_status_queries_the_declared_host_local_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from infralink.cli import operations
+    registry = _registry_checkout(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(
+            f"InvocationID={INVOCATION}\nActiveState=inactive\nResult=success\nExecMainStatus=0\n"
+        ),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+    operation_id = f"ssh/{HOST_ID}/{INVOCATION}"
 
-    class Provider:
-        def submit(self, request: operations.ApplyRequest) -> operations.OperationRecord:
-            raise AssertionError("status must not submit")
-
-        def status(self, operation_id: str) -> operations.OperationRecord:
-            assert operation_id == "op_01J00000000000000000000000"
-            return operations.OperationRecord(
-                id=operation_id,
-                state="applying",
-                target={"type": "host", "id": host_id, "canonical_name": canonical_name},
-            )
-
-    monkeypatch.setattr(operations, "operation_provider_from_environment", lambda: Provider())
-    response = CliRunner().invoke(cli, ["operation", "status", "op_01J00000000000000000000000"])
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "operation", "status", operation_id]
+    )
 
     payload = yaml.safe_load(response.output)
     assert response.exit_code == 0
     assert_schema(payload, "operation-status")
-    assert payload["result"]["operation"] == {
-        "id": "op_01J00000000000000000000000",
-        "state": "applying",
-    }
+    assert payload["result"]["operation"] == {"id": operation_id, "state": "converged"}
     assert payload["result"]["target"] == {
         "type": "host",
-        "id": host_id,
-        "canonical_name": canonical_name,
+        "id": HOST_ID,
+        "canonical_name": HOST_NAME,
     }
+
+
+def test_operation_status_reads_a_terminal_result_from_the_host_journal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(
+            "InvocationID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            "ActiveState=inactive\nResult=success\nExecMainStatus=0\n"
+            '{"ok":true,"run_id":"durable-host-local-result"}\n'
+        ),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+    operation_id = f"ssh/{HOST_ID}/{INVOCATION}"
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "operation", "status", operation_id]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert payload["result"]["operation"] == {"id": operation_id, "state": "converged"}
+
+
+def test_operation_status_refuses_a_run_reference_for_an_undeclared_host(tmp_path: Path) -> None:
+    registry = _registry_checkout(tmp_path, declared=False)
+
+    response = CliRunner().invoke(
+        cli,
+        [
+            "--registry",
+            str(registry),
+            "operation",
+            "status",
+            f"ssh/{HOST_ID}/{INVOCATION}",
+        ],
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
+
+
+def test_operation_status_explicitly_rejects_a_legacy_control_plane_reference() -> None:
+    response = CliRunner().invoke(cli, ["operation", "status", "op_01J00000000000000000000000"])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert "legacy" in payload["error"]["message"].lower()

--- a/tests/test_cli_secret_leaks.py
+++ b/tests/test_cli_secret_leaks.py
@@ -295,8 +295,13 @@ selection:
         ("host", "apply"): ([*source, "host", "apply", TARGET_ID, "--dry-run"], 3, False),
         ("info",): ([*source, "info"], 0, True),
         ("operation", "status"): (
-            ["operation", "status", "op_01J00000000000000000000000"],
-            4,
+            [
+                *source,
+                "operation",
+                "status",
+                "ssh/32a3324f-c3d0-4a4f-9587-52c099bcb3fb/8d6c4ad6-0e4a-4b58-9fe3-5ad9e1760d56",
+            ],
+            3,
             False,
         ),
         ("resolve",): ([*source, "resolve", EDGE_ID], 0, True),


### PR DESCRIPTION
Closes #77

Replaces the unmerged control-plane/Woodpecker host apply path with declared SSH transport. `host apply` accepts only a matching `operations/contract.yml` with exact `self-deploy-v2-reconcile.service`, starts that unit over SSH, returns an opaque systemd invocation reference, and polls the host-local result with `--wait`.

No release selector, generation, controller pipeline, or compose action remains in this path.

Verification:
- `python3 -m pytest -q`
- `python3 -m pytest -q --no-cov tests/test_cli_host_apply.py tests/test_cli_discovery.py tests/test_cli_contracts.py tests/test_cli_secret_leaks.py`
- `python3 -m ruff check ...`
- `PYTHONPATH=src python3 -m mypy ...`