### PR TITLE
Fix host apply manifest transport resolution

### DIFF
--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
 import subprocess
 import tempfile
@@ -22,6 +23,7 @@ _OPERATION_ID = re.compile(
 )
 _LEGACY_OPERATION_ID = re.compile(r"^op_[A-Za-z0-9_-]{8,128}$")
 _FINGERPRINT = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
+_CHANNEL = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 _UNIT = "self-deploy-v2-reconcile.service"
 
 _START_REMOTE = """set -eu
@@ -158,9 +160,66 @@ def operation_provider() -> OperationProvider:
 
 
 def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
-    """Resolve and validate the host's explicit SSH reconcile declaration."""
+    """Resolve a manifest-declared V2 SSH reconcile operation."""
     if not registry_path.is_dir():
         raise _registry_failure("Host apply requires a directory registry checkout", registry_path)
+    manifest_path = registry_path / host.uuid / "manifest.yml"
+    manifest = _read_mapping(manifest_path, "Host apply manifest is missing or invalid")
+    host_data = (
+        manifest.get("hosts", {}).get(host.uuid)
+        if isinstance(manifest.get("hosts"), dict)
+        else None
+    )
+    if not isinstance(host_data, dict) or host_data.get("canonical_name") != host.canonical_name:
+        raise _registry_failure("Host apply manifest does not match the target host", manifest_path)
+    manifest_request = _manifest_request(host.uuid, host.canonical_name, host_data, manifest_path)
+    if manifest_request is not None:
+        return manifest_request
+    return _contract_request(registry_path, host)
+
+
+def _manifest_request(
+    host_uuid: str, canonical_name: str, data: dict[str, Any], path: Path
+) -> ApplyRequest | None:
+    if not any(isinstance(field, str) and field.startswith("self_deploy_v2_") for field in data):
+        return None
+    if data.get("self_deploy_v2_reconcile_enabled") is not True:
+        raise _registry_failure("Host apply manifest does not enable V2 reconcile", path)
+    if data.get("self_deploy_v2_reconcile_packaged") is not True:
+        raise _registry_failure("Host apply manifest does not package V2 reconcile", path)
+    if data.get("self_deploy_v2_promotion_policy_enabled") is not True:
+        raise _registry_failure("Host apply manifest does not enable V2 promotion policy", path)
+    channel = data.get("self_deploy_v2_promotion_channel")
+    if not isinstance(channel, str) or _CHANNEL.fullmatch(channel) is None:
+        raise _registry_failure("Host apply manifest V2 promotion channel is invalid", path)
+    address = data.get("tailscale_ip")
+    if not isinstance(address, str):
+        raise _registry_failure("Host apply manifest Tailscale address is invalid", path)
+    try:
+        parsed_address = ipaddress.ip_address(address)
+    except ValueError:
+        raise _registry_failure("Host apply manifest Tailscale address is invalid", path) from None
+    if not isinstance(
+        parsed_address, ipaddress.IPv4Address
+    ) or parsed_address not in ipaddress.ip_network("100.64.0.0/10"):
+        raise _registry_failure(
+            "Host apply manifest Tailscale address is outside the tailnet range", path
+        )
+    fingerprint = _normalize_manifest_fingerprint(
+        data.get("self_deploy_v2_promotion_host_fingerprint")
+    )
+    if fingerprint is None:
+        raise _registry_failure("Host apply manifest SSH fingerprint is invalid", path)
+    reconcile = data.get("reconcile")
+    if reconcile is not None and (
+        not isinstance(reconcile, dict) or reconcile.get("unit") != _UNIT
+    ):
+        raise _registry_failure("Host apply manifest reconcile unit is invalid", path)
+    return ApplyRequest(host_uuid, canonical_name, address, 22, "root", fingerprint, _UNIT)
+
+
+def _contract_request(registry_path: Path, host: Any) -> ApplyRequest:
+    """Accept the pre-manifest operations contract for existing consumers."""
     contract_path = registry_path / host.uuid / "operations" / "contract.yml"
     contract = _read_mapping(contract_path, "Host apply requires a declared SSH reconcile contract")
     machine = contract.get("machine")
@@ -197,6 +256,15 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
             "Host apply contract SSH host key fingerprint is invalid", contract_path
         )
     return ApplyRequest(host.uuid, host.canonical_name, address, port, user, fingerprint, _UNIT)
+
+
+def _normalize_manifest_fingerprint(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    parts = value.split()
+    if len(parts) != 2 or parts[0] != "ssh-rsa" or _FINGERPRINT.fullmatch(parts[1]) is None:
+        return None
+    return parts[1]
 
 
 def wait_for_terminal(

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -16,6 +16,12 @@ HOST_NAME = "relaxgg-db-es1"
 UNIT = "self-deploy-v2-reconcile.service"
 INVOCATION = "8d6c4ad60e4a4b589fe35ad9e1760d56"
 FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+MANIFEST_FINGERPRINT = "SHA256:Pnpjf51QfL7khY8GiWuWNp/5G9Twt321Dd5Dk8dB50w"
+CORE_HOSTS = (
+    ("9157ddeb-cb6d-4d55-8252-9db358f5d932", "cyberstorm-citadel", "100.73.228.90"),
+    ("7ffe46b7-0eb4-40cb-8e14-ea679b9948f4", "cyberstorm-watchtower", "100.123.0.63"),
+    (HOST_ID, HOST_NAME, "100.64.68.83"),
+)
 
 
 def _git(root: Path, *args: str) -> str:
@@ -64,6 +70,115 @@ def _registry_checkout(tmp_path: Path, *, declared: bool = True) -> Path:
 
 def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _manifest_registry_checkout(tmp_path: Path) -> Path:
+    root = tmp_path / "registry"
+    for host_id, canonical_name, address in CORE_HOSTS:
+        host = root / "hosts" / host_id
+        host.mkdir(parents=True)
+        (host / "manifest.yml").write_text(
+            "hosts:\n"
+            f"  {host_id}:\n"
+            f"    canonical_name: {canonical_name}\n"
+            "    status: active\n"
+            f"    tailscale_ip: {address}\n"
+            f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {MANIFEST_FINGERPRINT}\n"
+            "    self_deploy_v2_promotion_channel: core-v2\n"
+            "    self_deploy_v2_promotion_policy_enabled: true\n"
+            "    self_deploy_v2_reconcile_enabled: true\n"
+            "    self_deploy_v2_reconcile_packaged: true\n",
+            encoding="utf-8",
+        )
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.email", "test@example.invalid")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "add", ".")
+    _git(root, "commit", "--quiet", "-m", "manifest registry")
+    return root / "hosts"
+
+
+@pytest.mark.parametrize(("host_id", "canonical_name", "address"), CORE_HOSTS)
+def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
+    tmp_path: Path, host_id: str, canonical_name: str, address: str
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "host", "apply", host_id, "--dry-run"]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert_schema(payload, "host-apply")
+    assert payload["result"] == {
+        "dry_run": True,
+        "target": {"type": "host", "id": host_id, "canonical_name": canonical_name},
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("tailscale_ip", "not an address"),
+        ("tailscale_ip", "192.0.2.1"),
+        ("self_deploy_v2_promotion_host_fingerprint", "ssh-rsa SHA256:short"),
+        ("self_deploy_v2_promotion_channel", "not valid"),
+        ("self_deploy_v2_reconcile_enabled", "false"),
+        ("self_deploy_v2_reconcile_packaged", "false"),
+    ),
+)
+def test_host_apply_refuses_malformed_or_disabled_manifest_declarations(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace(
+            {
+                "tailscale_ip": "tailscale_ip: 100.64.68.83",
+                "self_deploy_v2_promotion_host_fingerprint": (
+                    f"self_deploy_v2_promotion_host_fingerprint: ssh-rsa {MANIFEST_FINGERPRINT}"
+                ),
+                "self_deploy_v2_promotion_channel": "self_deploy_v2_promotion_channel: core-v2",
+                "self_deploy_v2_reconcile_enabled": "self_deploy_v2_reconcile_enabled: true",
+                "self_deploy_v2_reconcile_packaged": "self_deploy_v2_reconcile_packaged: true",
+            }[field],
+            f"{field}: {value}",
+        ),
+        encoding="utf-8",
+    )
+    _git(registry.parent, "add", ".")
+    _git(registry.parent, "commit", "--quiet", "-m", "malformed manifest")
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "host", "apply", HOST_ID, "--dry-run"]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
+
+
+def test_host_apply_refuses_a_partial_v2_manifest_instead_of_using_legacy_contract(
+    tmp_path: Path,
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "    self_deploy_v2_reconcile_packaged: true\n",
+        encoding="utf-8",
+    )
+    _git(registry.parent, "add", ".")
+    _git(registry.parent, "commit", "--quiet", "-m", "partial v2 manifest")
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "host", "apply", HOST_ID, "--dry-run"]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
 
 
 def test_host_apply_starts_only_declared_reconcile_unit_and_returns_opaque_run_reference(


### PR DESCRIPTION
Closes #79

Make the host manifest the primary declaration for host-local reconcile transport: Tailscale address, normalized existing SSH fingerprint, V2 reconcile/policy/channel indicators, and the standard reconcile unit. Keep the existing operations contract as a fallback only for manifests that do not declare V2 apply state.

No registry changes, Woodpecker/control-plane path, selector/SHA/generation, or Compose behavior.

Verification:
- `python3 -m pytest -q --no-cov tests/test_cli_host_apply.py tests/test_cli_contracts.py tests/test_cli_secret_leaks.py tests/test_cli_discovery.py`
- `python3 -m ruff format --check src tests scripts`
- `python3 -m ruff check src/infralink/cli/operations.py tests/test_cli_host_apply.py`
- `PYTHONPATH=src python3 -m mypy src/infralink/cli/operations.py`