### PR TITLE
fix(cli): expose terminal host reconcile diagnostics

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1847,6 +1847,7 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
             state=cast(Literal["queued", "applying", "converged", "failed"], record.state),
         ),
         target=doctor_target,
+        failure=record.failure,
     )
     actions = []
     if record.state in {"queued", "applying"}:
@@ -1906,6 +1907,7 @@ def operation_status(ctx: Context, operation_id: str) -> int:
             state=cast(Literal["queued", "applying", "converged", "failed"], record.state),
         ),
         target=target,
+        failure=record.failure,
     )
     actions = []
     if record.state in {"queued", "applying"}:

--- a/src/infralink/cli/operation_contracts.py
+++ b/src/infralink/cli/operation_contracts.py
@@ -20,12 +20,25 @@ class OperationSummary(ContractModel):
     state: Literal["queued", "applying", "converged", "failed"]
 
 
+class OperationUnitFailure(ContractModel):
+    active_state: str
+    result: str
+    exec_main_status: int
+
+
+class OperationFailure(ContractModel):
+    unit: OperationUnitFailure | None = None
+    journal: list[str] = Field(default_factory=list, max_length=8)
+
+
 class HostApplyResult(ContractModel):
     operation: OperationSummary | None = Field(default=None, exclude_if=lambda value: value is None)
     target: DoctorTarget
     dry_run: bool = Field(default=False, exclude_if=lambda value: not value)
+    failure: OperationFailure | None = Field(default=None, exclude_if=lambda value: value is None)
 
 
 class OperationStatusResult(ContractModel):
     operation: OperationSummary
     target: DoctorTarget | None = None
+    failure: OperationFailure | None = Field(default=None, exclude_if=lambda value: value is None)

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -16,6 +16,7 @@ from typing import Any, Protocol
 import yaml
 
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
+from infralink.cli.operation_contracts import OperationFailure, OperationUnitFailure
 
 _OPERATION_ID = re.compile(
     r"^ssh/(?P<host>[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/"
@@ -25,6 +26,9 @@ _LEGACY_OPERATION_ID = re.compile(r"^op_[A-Za-z0-9_-]{8,128}$")
 _FINGERPRINT = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
 _CHANNEL = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 _UNIT = "self-deploy-v2-reconcile.service"
+_JOURNAL_SEPARATOR = "__INFRALINK_JOURNAL__"
+_DIAGNOSTIC_CODE = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
+_MAX_FAILURE_JOURNAL_LINES = 8
 
 _START_REMOTE = """set -eu
 unit=$1
@@ -35,6 +39,7 @@ _STATUS_REMOTE = """set -eu
 unit=$1
 invocation=$2
 systemctl show "$unit" -p InvocationID -p ActiveState -p Result -p ExecMainStatus
+printf '%s\n' '__INFRALINK_JOURNAL__'
 journalctl --quiet --no-pager --output=cat _SYSTEMD_INVOCATION_ID="$invocation" || true
 """
 
@@ -57,6 +62,7 @@ class OperationRecord:
     id: str
     state: str
     target: dict[str, str] | None = None
+    failure: OperationFailure | None = None
 
 
 class OperationProvider(Protocol):
@@ -91,6 +97,7 @@ class SshOperationProvider:
                 "id": request.host_uuid,
                 "canonical_name": request.canonical_name,
             },
+            failure=_failure_diagnostics(values, include_unit=False) if state == "failed" else None,
         )
 
     def _run(
@@ -151,6 +158,7 @@ class SshOperationProvider:
                 "id": request.host_uuid,
                 "canonical_name": request.canonical_name,
             },
+            failure=_failure_diagnostics(values) if state == "failed" else None,
         )
 
 
@@ -280,12 +288,21 @@ def wait_for_terminal(
 
 
 def _parse_properties(stdout: str) -> dict[str, Any]:
-    values: dict[str, Any] = {"journal": []}
+    values: dict[str, Any] = {"journal": [], "journal_text": []}
+    journal_started = False
     for line in stdout.splitlines():
+        if line == _JOURNAL_SEPARATOR:
+            journal_started = True
+            continue
         key, separator, value = line.partition("=")
-        if separator and key in {"InvocationID", "ActiveState", "Result", "ExecMainStatus"}:
+        if (
+            not journal_started
+            and separator
+            and key in {"InvocationID", "ActiveState", "Result", "ExecMainStatus"}
+        ):
             values[key] = value
             continue
+        values["journal_text"].append(line)
         try:
             document = yaml.safe_load(line)
         except yaml.YAMLError:
@@ -314,6 +331,54 @@ def _journal_state(records: object) -> str | None:
         if isinstance(record, dict) and type(record.get("ok")) is bool:
             return "converged" if record["ok"] else "failed"
     return None
+
+
+def _failure_diagnostics(values: dict[str, Any], *, include_unit: bool = True) -> OperationFailure:
+    unit: OperationUnitFailure | None = None
+    if include_unit:
+        unit = OperationUnitFailure(
+            active_state=_diagnostic_text(values.get("ActiveState")),
+            result=_diagnostic_text(values.get("Result")),
+            exec_main_status=_diagnostic_status(values.get("ExecMainStatus")),
+        )
+    return OperationFailure(unit=unit, journal=_journal_diagnostics(values))
+
+
+def _journal_diagnostics(values: dict[str, Any]) -> list[str]:
+    records = values.get("journal")
+    diagnostics = _sanitize_journal(records)
+    journal_text = values.get("journal_text")
+    if diagnostics or not isinstance(journal_text, list) or not journal_text:
+        return diagnostics
+    return ["unstructured journal output omitted"]
+
+
+def _sanitize_journal(records: object) -> list[str]:
+    """Return only explicitly structured, non-secret diagnostic codes."""
+    if not isinstance(records, list):
+        return []
+    sanitized: list[str] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        code = record.get("code")
+        if not isinstance(code, str) or _DIAGNOSTIC_CODE.fullmatch(code) is None:
+            continue
+        sanitized.append(f"code: {code}")
+        if len(sanitized) == _MAX_FAILURE_JOURNAL_LINES:
+            break
+    return sanitized
+
+
+def _diagnostic_text(value: object) -> str:
+    return value if isinstance(value, str) and value else "unknown"
+
+
+def _diagnostic_status(value: object) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return -1
 
 
 @contextmanager

--- a/src/infralink/schemas/cli/v1/host-apply.json
+++ b/src/infralink/schemas/cli/v1/host-apply.json
@@ -174,6 +174,17 @@
           "title": "Dry Run",
           "type": "boolean"
         },
+        "failure": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationFailure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "operation": {
           "anyOf": [
             {
@@ -207,6 +218,32 @@
       "title": "Meta",
       "type": "object"
     },
+    "OperationFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "journal": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 8,
+          "title": "Journal",
+          "type": "array"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationUnitFailure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "OperationFailure",
+      "type": "object"
+    },
     "OperationSummary": {
       "additionalProperties": false,
       "properties": {
@@ -231,6 +268,30 @@
         "state"
       ],
       "title": "OperationSummary",
+      "type": "object"
+    },
+    "OperationUnitFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "active_state": {
+          "title": "Active State",
+          "type": "string"
+        },
+        "exec_main_status": {
+          "title": "Exec Main Status",
+          "type": "integer"
+        },
+        "result": {
+          "title": "Result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "active_state",
+        "result",
+        "exec_main_status"
+      ],
+      "title": "OperationUnitFailure",
       "type": "object"
     }
   },

--- a/src/infralink/schemas/cli/v1/operation-status.json
+++ b/src/infralink/schemas/cli/v1/operation-status.json
@@ -178,9 +178,46 @@
       "title": "Meta",
       "type": "object"
     },
+    "OperationFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "journal": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 8,
+          "title": "Journal",
+          "type": "array"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationUnitFailure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "OperationFailure",
+      "type": "object"
+    },
     "OperationStatusResult": {
       "additionalProperties": false,
       "properties": {
+        "failure": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperationFailure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "operation": {
           "$ref": "#/$defs/OperationSummary"
         },
@@ -226,6 +263,30 @@
         "state"
       ],
       "title": "OperationSummary",
+      "type": "object"
+    },
+    "OperationUnitFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "active_state": {
+          "title": "Active State",
+          "type": "string"
+        },
+        "exec_main_status": {
+          "title": "Exec Main Status",
+          "type": "integer"
+        },
+        "result": {
+          "title": "Result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "active_state",
+        "result",
+        "exec_main_status"
+      ],
+      "title": "OperationUnitFailure",
       "type": "object"
     }
   },

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -432,6 +432,104 @@ def test_operation_status_reads_a_terminal_result_from_the_host_journal(
     assert payload["result"]["operation"] == {"id": operation_id, "state": "converged"}
 
 
+def test_operation_status_reports_bounded_sanitized_terminal_failure_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(
+            f"InvocationID={INVOCATION}\n"
+            "ActiveState=inactive\n"
+            "Result=exit-code\n"
+            "ExecMainStatus=1\n"
+            "__INFRALINK_JOURNAL__\n"
+            '{"ok":false,"code":"registry_revision_mismatch","token":"super-secret-value"}\n'
+        ),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+    operation_id = f"ssh/{HOST_ID}/{INVOCATION}"
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "operation", "status", operation_id]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 1
+    assert_schema(payload, "operation-status")
+    assert payload["result"]["operation"] == {"id": operation_id, "state": "failed"}
+    assert payload["result"]["failure"] == {
+        "unit": {"active_state": "inactive", "result": "exit-code", "exec_main_status": 1},
+        "journal": ["code: registry_revision_mismatch"],
+    }
+    assert "super-secret-value" not in response.output
+
+
+def test_operation_status_uses_current_invocation_before_old_success_journal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(
+            f"InvocationID={INVOCATION}\n"
+            "ActiveState=activating\n"
+            "Result=success\n"
+            "ExecMainStatus=0\n"
+            '{"ok":true,"run_id":"prior-success-is-not-terminal"}\n'
+        ),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+    operation_id = f"ssh/{HOST_ID}/{INVOCATION}"
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "operation", "status", operation_id]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert payload["result"]["operation"] == {"id": operation_id, "state": "applying"}
+    assert "failure" not in payload["result"]
+
+
+def test_operation_status_does_not_read_journal_properties_as_current_unit_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(
+            f"InvocationID={INVOCATION}\n"
+            "ActiveState=activating\n"
+            "Result=success\n"
+            "ExecMainStatus=0\n"
+            "__INFRALINK_JOURNAL__\n"
+            "ActiveState=inactive\n"
+            "Result=success\n"
+            "ExecMainStatus=0\n"
+        ),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+    operation_id = f"ssh/{HOST_ID}/{INVOCATION}"
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "operation", "status", operation_id]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert payload["result"]["operation"] == {"id": operation_id, "state": "applying"}
+
+
 def test_operation_status_refuses_a_run_reference_for_an_undeclared_host(tmp_path: Path) -> None:
     registry = _registry_checkout(tmp_path, declared=False)
 


### PR DESCRIPTION
Closes #83

## Scope
- keep the current systemd invocation authoritative, so active work remains `applying` despite stale prior result fields
- expose bounded, sanitized unit and journal evidence only for terminal failed operations
- preserve declared SSH transport and fail-closed host key trust

## Verification
- `.venv/bin/python -m pytest -q -o addopts="" tests/test_cli_host_apply.py`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/ruff format --check src tests scripts`
- `.venv/bin/ruff check src tests scripts`
- `.venv/bin/mypy src scripts`