### PR TITLE
feat(cli): inspect V2 verifier facts

### DIFF
--- a/scripts/generate_cli_schemas.py
+++ b/scripts/generate_cli_schemas.py
@@ -42,7 +42,11 @@ from infralink.cli.observation_contracts import (
     ProjectSecretsResult,
     ProjectViewResult,
 )
-from infralink.cli.operation_contracts import HostApplyResult, OperationStatusResult
+from infralink.cli.operation_contracts import (
+    HostApplyResult,
+    HostVerifierResult,
+    OperationStatusResult,
+)
 
 ROOT = Path(__file__).parents[1]
 OUTPUT = ROOT / "src/infralink/schemas/cli/v1"
@@ -54,6 +58,7 @@ MODELS: dict[str, Any] = {
     "hosts": Envelope[HostListResult],
     "host-show": Envelope[HostShowResult],
     "host-bootstrap": Envelope[HostBootstrapPlanResult],
+    "host-verifier": Envelope[HostVerifierResult],
     "host-apply": Envelope[HostApplyResult],
     "operation-status": Envelope[OperationStatusResult],
     "services": Envelope[ServiceListResult],

--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -566,6 +566,14 @@ def _bootstrap_plan_action(ctx: Context, host_id: str) -> Any:
     )
 
 
+def _verifier_action(ctx: Context, host_id: str) -> Any:
+    return action(
+        "verifier",
+        [*_root_source_argv(ctx), "host", "verifier", host_id],
+        "Inspect the read-only self-deploy verifier facts",
+    )
+
+
 @click.command(name="doctor")
 @click.option(
     "--observation-plan",
@@ -722,6 +730,8 @@ def doctor(
     result = _apply_host_readiness(result, readiness)
     if readiness is not None and not readiness.ready:
         actions.append(_bootstrap_plan_action(ctx, target_id))
+        if any(item.id == "inspect_self_deploy_reconcile" for item in readiness.actions):
+            actions.append(_verifier_action(ctx, target_id))
     manifest_state = _host_manifest_git_state(ctx, target_id) if target_type == "host" else None
     result = _apply_host_manifest_git_state(result, manifest_state)
     if manifest_state is not None and manifest_state.state == "local_uncommitted":

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -42,6 +42,7 @@ from infralink.cli.errors import CliFailure, ErrorCode, ExitCode, internal_failu
 from infralink.cli.host_readiness import evaluate_host_readiness
 from infralink.cli.operation_contracts import (
     HostApplyResult,
+    HostVerifierResult,
     OperationStatusResult,
     OperationSummary,
 )
@@ -1773,6 +1774,21 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
                 details={"host": target.uuid},
             )
         readiness = evaluate_host_readiness(target, SshReadinessTransport())
+    actions = [
+        action(
+            "reinspect-readiness",
+            [*_root_source_argv(ctx), "host", "bootstrap", target.uuid, "--plan"],
+            "Reinspect live host readiness",
+        )
+    ]
+    if any(item.id == "inspect_self_deploy_reconcile" for item in readiness.actions):
+        actions.append(
+            action(
+                "verifier",
+                [*_root_source_argv(ctx), "host", "verifier", target.uuid],
+                "Inspect the read-only self-deploy verifier facts",
+            )
+        )
     result = HostBootstrapPlanResult(
         host=DoctorTarget(type="host", id=target.uuid, canonical_name=target.canonical_name),
         readiness=readiness,
@@ -1781,16 +1797,40 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         ok_envelope(
             _context_for(path=["host", "bootstrap"]),
             result,
+            actions,
+        )
+    )
+    return 0 if readiness.ready or plan_only else 1
+
+
+@host.command(name="verifier")
+@click.argument("host_ref")
+@pass_context
+def host_verifier(ctx: Context, host_ref: str) -> int:
+    """Inspect the declared host's public V2 Git signature verifier facts."""
+    from infralink.cli.operations import inspect_verifier, resolve_apply_request
+
+    target = ctx.registry.get(host_ref)
+    if target is None:
+        raise entity_not_found("host", host_ref)
+    if ctx.registry_path is None:
+        raise configuration_required("registry")
+    verifier = inspect_verifier(resolve_apply_request(ctx.registry_path, target))
+    doctor_target = DoctorTarget(type="host", id=target.uuid, canonical_name=target.canonical_name)
+    _emit(
+        ok_envelope(
+            _context_for(path=["host", "verifier"]),
+            HostVerifierResult(target=doctor_target, verifier=verifier),
             [
                 action(
-                    "reinspect-readiness",
-                    [*_root_source_argv(ctx), "host", "bootstrap", target.uuid, "--plan"],
-                    "Reinspect live host readiness",
+                    "doctor",
+                    [*_root_source_argv(ctx), "doctor", "host", target.uuid],
+                    "Reinspect the host convergence result",
                 )
             ],
         )
     )
-    return 0 if readiness.ready or plan_only else 1
+    return 0 if verifier.signature_verification == "passed" else 1
 
 
 @host.command(name="apply")

--- a/src/infralink/cli/operation_contracts.py
+++ b/src/infralink/cli/operation_contracts.py
@@ -42,3 +42,28 @@ class OperationStatusResult(ContractModel):
     operation: OperationSummary
     target: DoctorTarget | None = None
     failure: OperationFailure | None = Field(default=None, exclude_if=lambda value: value is None)
+
+
+class AllowedSignerDiagnostic(ContractModel):
+    """Public identity of the active Git SSH verification trust anchor."""
+
+    principal: str = Field(pattern=r"^[A-Za-z0-9._-]{1,128}$")
+    fingerprint: str = Field(pattern=r"^SHA256:[A-Za-z0-9+/]{43}$")
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class HostVerifierDiagnostic(ContractModel):
+    """Bounded, public-only facts used by the host-local V2 verifier."""
+
+    registry_remote: str = Field(min_length=1, max_length=1024)
+    registry_ref: Literal["refs/heads/main"]
+    runtime_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    allowed_signer: AllowedSignerDiagnostic
+    git_ssh_signature_capable: bool
+    fetched_tip: str = Field(pattern=r"^[0-9a-f]{40}$")
+    signature_verification: Literal["passed", "failed", "unavailable"]
+
+
+class HostVerifierResult(ContractModel):
+    target: DoctorTarget
+    verifier: HostVerifierDiagnostic

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -11,12 +11,18 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, cast
+from urllib.parse import urlsplit
 
 import yaml
 
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
-from infralink.cli.operation_contracts import OperationFailure, OperationUnitFailure
+from infralink.cli.operation_contracts import (
+    AllowedSignerDiagnostic,
+    HostVerifierDiagnostic,
+    OperationFailure,
+    OperationUnitFailure,
+)
 
 _OPERATION_ID = re.compile(
     r"^ssh/(?P<host>[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/"
@@ -30,6 +36,9 @@ _JOURNAL_SEPARATOR = "__INFRALINK_JOURNAL__"
 _DIAGNOSTIC_CODE = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
 _DIAGNOSTIC_STAGES = frozenset({"inspect", "validate", "plan", "apply", "verify", "record"})
 _MAX_FAILURE_JOURNAL_LINES = 6
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_SIGNER_PRINCIPAL = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 
 _START_REMOTE = """set -eu
 unit=$1
@@ -42,6 +51,48 @@ invocation=$2
 systemctl show "$unit" -p InvocationID -p ActiveState -p Result -p ExecMainStatus
 printf '%s\n' '__INFRALINK_JOURNAL__'
 journalctl --quiet --no-pager --output=cat _SYSTEMD_INVOCATION_ID="$invocation" || true
+"""
+_VERIFIER_REMOTE = """set -eu
+bootstrap=/etc/infra-management/self-deploy-bootstrap.yml
+signers=/etc/infra-management/registry-allowed-signers
+registry=/var/lib/infralink/registry
+
+value() {
+    sed -n "s/^    $1: //p" "$bootstrap" | head -n 1 | sed 's/^"//; s/"$//'
+}
+remote=$(value remote)
+ref=$(value ref)
+runtime=$(systemctl show self-deploy-v2-reconcile.service -p Environment --value | tr ' ' '\\n' | sed -n 's#^SELF_DEPLOY_V2_RUNTIME_ROOT=/var/lib/self-deploy-v2/runtime/##p' | head -n 1)
+principal=$(awk 'NF >= 3 { print $1; exit }' "$signers")
+fingerprint=$(awk 'NF >= 3 { print $2 " " $3; exit }' "$signers" | ssh-keygen -lf - -E sha256 2>/dev/null | awk '{ print $2; exit }')
+digest=$(sha256sum "$signers" | awk '{ print $1 }')
+tip=$(GIT_CONFIG_NOSYSTEM=1 git -C "$registry" rev-parse --verify refs/remotes/origin/main^{commit} 2>/dev/null || true)
+version=$(git --version | awk '{ print $3 }')
+major=${version%%.*}
+rest=${version#*.}
+minor=${rest%%.*}
+capable=false
+case "$major:$minor" in
+    '' | *[!0-9:]* ) ;;
+    * ) if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 34 ]; }; then capable=true; fi ;;
+esac
+verification=unavailable
+if [ "$capable" = true ] && [ -n "$tip" ]; then
+    if GIT_CONFIG_NOSYSTEM=1 git -C "$registry" -c gpg.format=ssh -c gpg.ssh.allowedSignersFile="$signers" verify-commit "$tip" >/dev/null 2>&1; then
+        verification=passed
+    else
+        verification=failed
+    fi
+fi
+printf 'registry_remote=%s\\n' "$remote"
+printf 'registry_ref=%s\\n' "$ref"
+printf 'runtime_revision=%s\\n' "$runtime"
+printf 'allowed_signer_principal=%s\\n' "$principal"
+printf 'allowed_signer_fingerprint=%s\\n' "$fingerprint"
+printf 'allowed_signers_sha256=%s\\n' "$digest"
+printf 'git_ssh_signature_capable=%s\\n' "$capable"
+printf 'fetched_tip=%s\\n' "$tip"
+printf 'signature_verification=%s\\n' "$verification"
 """
 
 
@@ -101,10 +152,25 @@ class SshOperationProvider:
             failure=_failure_diagnostics(values, include_unit=False) if state == "failed" else None,
         )
 
+    def inspect_verifier(self, request: ApplyRequest) -> HostVerifierDiagnostic:
+        """Read only the fixed, public facts behind V2 Git signature verification."""
+        return _parse_verifier_diagnostics(self._run(request, _VERIFIER_REMOTE, verifier=True))
+
     def _run(
-        self, request: ApplyRequest, script: str, invocation: str | None = None
+        self,
+        request: ApplyRequest,
+        script: str,
+        invocation: str | None = None,
+        *,
+        verifier: bool = False,
     ) -> dict[str, Any]:
-        remote_args = [request.unit] if invocation is None else [request.unit, invocation]
+        remote_args = (
+            ["verifier"]
+            if verifier
+            else [request.unit]
+            if invocation is None
+            else [request.unit, invocation]
+        )
         try:
             with _pinned_known_hosts(request) as known_hosts:
                 completed = subprocess.run(
@@ -140,6 +206,8 @@ class SshOperationProvider:
             ) from None
         if completed.returncode != 0:
             raise _provider_failure("Declared host rejected the reconcile operation")
+        if verifier:
+            return _parse_verifier_output(completed.stdout)
         values = _parse_properties(completed.stdout)
         if not values.get("InvocationID"):
             raise _provider_failure("Declared host returned no reconcile run reference")
@@ -166,6 +234,11 @@ class SshOperationProvider:
 def operation_provider() -> OperationProvider:
     """Return the sole supported host-apply transport."""
     return SshOperationProvider()
+
+
+def inspect_verifier(request: ApplyRequest) -> HostVerifierDiagnostic:
+    """Return fixed, read-only V2 verifier facts over the declared SSH transport."""
+    return SshOperationProvider().inspect_verifier(request)
 
 
 def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
@@ -311,6 +384,105 @@ def _parse_properties(stdout: str) -> dict[str, Any]:
         if isinstance(document, dict):
             values["journal"].append(document)
     return values
+
+
+def _parse_verifier_output(stdout: str) -> dict[str, Any]:
+    """Accept only the fixed public facts emitted by the verifier probe."""
+    accepted = {
+        "registry_remote",
+        "registry_ref",
+        "runtime_revision",
+        "allowed_signer_principal",
+        "allowed_signer_fingerprint",
+        "allowed_signers_sha256",
+        "git_ssh_signature_capable",
+        "fetched_tip",
+        "signature_verification",
+    }
+    values: dict[str, Any] = {}
+    for line in stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key in accepted and key not in values:
+            values[key] = value
+    return values
+
+
+def _parse_verifier_diagnostics(values: dict[str, Any]) -> HostVerifierDiagnostic:
+    """Validate public facts before they cross the CLI boundary."""
+    try:
+        remote = _required_text(values, "registry_remote")
+        parsed = urlsplit(remote)
+        if (
+            not parsed.scheme
+            or not parsed.hostname
+            or (
+                parsed.username is not None and (parsed.scheme != "ssh" or parsed.username != "git")
+            )
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or any(character.isspace() or ord(character) < 32 for character in remote)
+        ):
+            raise ValueError
+        capable = _required_text(values, "git_ssh_signature_capable")
+        if capable not in {"true", "false"}:
+            raise ValueError
+        registry_ref = _required_text(values, "registry_ref")
+        if registry_ref != "refs/heads/main":
+            raise ValueError
+        verification = _required_text(values, "signature_verification")
+        if verification not in {"passed", "failed", "unavailable"}:
+            raise ValueError
+        return HostVerifierDiagnostic(
+            registry_remote=remote,
+            registry_ref="refs/heads/main",
+            runtime_revision=_required_sha(values, "runtime_revision"),
+            allowed_signer=AllowedSignerDiagnostic(
+                principal=_required_signer_principal(values, "allowed_signer_principal"),
+                fingerprint=_required_fingerprint(values, "allowed_signer_fingerprint"),
+                sha256=_required_sha256(values, "allowed_signers_sha256"),
+            ),
+            git_ssh_signature_capable=capable == "true",
+            fetched_tip=_required_sha(values, "fetched_tip"),
+            signature_verification=cast(Literal["passed", "failed", "unavailable"], verification),
+        )
+    except (TypeError, ValueError):
+        raise _provider_failure("Declared host returned invalid verifier diagnostics") from None
+
+
+def _required_text(values: dict[str, Any], key: str) -> str:
+    value = values.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError
+    return value
+
+
+def _required_sha(values: dict[str, Any], key: str) -> str:
+    value = _required_text(values, key)
+    if _GIT_SHA.fullmatch(value) is None:
+        raise ValueError
+    return value
+
+
+def _required_sha256(values: dict[str, Any], key: str) -> str:
+    value = _required_text(values, key)
+    if _SHA256.fullmatch(value) is None:
+        raise ValueError
+    return value
+
+
+def _required_signer_principal(values: dict[str, Any], key: str) -> str:
+    value = _required_text(values, key)
+    if _SIGNER_PRINCIPAL.fullmatch(value) is None:
+        raise ValueError
+    return value
+
+
+def _required_fingerprint(values: dict[str, Any], key: str) -> str:
+    value = _required_text(values, key)
+    if _FINGERPRINT.fullmatch(value) is None:
+        raise ValueError
+    return value
 
 
 def _state(values: dict[str, Any]) -> str:

--- a/src/infralink/schemas/cli/v1/host-verifier.json
+++ b/src/infralink/schemas/cli/v1/host-verifier.json
@@ -1,0 +1,393 @@
+{
+  "$defs": {
+    "Action": {
+      "additionalProperties": false,
+      "description": "An internal action recipe with a compact public serialization.",
+      "properties": {
+        "bindings": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Binding"
+          },
+          "title": "Bindings",
+          "type": "object"
+        },
+        "command": {
+          "title": "Command",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "rel": {
+          "title": "Rel",
+          "type": "string"
+        },
+        "safe": {
+          "title": "Safe",
+          "type": "boolean"
+        },
+        "templated": {
+          "default": false,
+          "title": "Templated",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rel",
+        "command",
+        "description",
+        "safe"
+      ],
+      "title": "Action",
+      "type": "object"
+    },
+    "AllowedSignerDiagnostic": {
+      "additionalProperties": false,
+      "description": "Public identity of the active Git SSH verification trust anchor.",
+      "properties": {
+        "fingerprint": {
+          "pattern": "^SHA256:[A-Za-z0-9+/]{43}$",
+          "title": "Fingerprint",
+          "type": "string"
+        },
+        "principal": {
+          "pattern": "^[A-Za-z0-9._-]{1,128}$",
+          "title": "Principal",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal",
+        "fingerprint",
+        "sha256"
+      ],
+      "title": "AllowedSignerDiagnostic",
+      "type": "object"
+    },
+    "Binding": {
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "title": "Required",
+          "type": "boolean"
+        },
+        "source": {
+          "title": "Source",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "integer",
+            "boolean"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "required",
+        "source"
+      ],
+      "title": "Binding",
+      "type": "object"
+    },
+    "CommandContext": {
+      "additionalProperties": false,
+      "properties": {
+        "parsed": {
+          "additionalProperties": true,
+          "title": "Parsed",
+          "type": "object"
+        },
+        "raw": {
+          "title": "Raw",
+          "type": "string"
+        },
+        "resolved": {
+          "additionalProperties": true,
+          "title": "Resolved",
+          "type": "object"
+        }
+      },
+      "required": [
+        "raw",
+        "parsed",
+        "resolved"
+      ],
+      "title": "CommandContext",
+      "type": "object"
+    },
+    "DoctorTarget": {
+      "additionalProperties": false,
+      "properties": {
+        "canonical_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Canonical Name"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "type": {
+          "enum": [
+            "global",
+            "host",
+            "service",
+            "edge",
+            "profile"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "DoctorTarget",
+      "type": "object"
+    },
+    "ErrorDetail": {
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "details": {
+          "additionalProperties": true,
+          "title": "Details",
+          "type": "object"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "title": "ErrorDetail",
+      "type": "object"
+    },
+    "HostVerifierDiagnostic": {
+      "additionalProperties": false,
+      "description": "Bounded, public-only facts used by the host-local V2 verifier.",
+      "properties": {
+        "allowed_signer": {
+          "$ref": "#/$defs/AllowedSignerDiagnostic"
+        },
+        "fetched_tip": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Fetched Tip",
+          "type": "string"
+        },
+        "git_ssh_signature_capable": {
+          "title": "Git Ssh Signature Capable",
+          "type": "boolean"
+        },
+        "registry_ref": {
+          "const": "refs/heads/main",
+          "title": "Registry Ref",
+          "type": "string"
+        },
+        "registry_remote": {
+          "maxLength": 1024,
+          "minLength": 1,
+          "title": "Registry Remote",
+          "type": "string"
+        },
+        "runtime_revision": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Runtime Revision",
+          "type": "string"
+        },
+        "signature_verification": {
+          "enum": [
+            "passed",
+            "failed",
+            "unavailable"
+          ],
+          "title": "Signature Verification",
+          "type": "string"
+        }
+      },
+      "required": [
+        "registry_remote",
+        "registry_ref",
+        "runtime_revision",
+        "allowed_signer",
+        "git_ssh_signature_capable",
+        "fetched_tip",
+        "signature_verification"
+      ],
+      "title": "HostVerifierDiagnostic",
+      "type": "object"
+    },
+    "HostVerifierResult": {
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/DoctorTarget"
+        },
+        "verifier": {
+          "$ref": "#/$defs/HostVerifierDiagnostic"
+        }
+      },
+      "required": [
+        "target",
+        "verifier"
+      ],
+      "title": "HostVerifierResult",
+      "type": "object"
+    },
+    "Meta": {
+      "additionalProperties": false,
+      "properties": {
+        "truncated": {
+          "default": false,
+          "title": "Truncated",
+          "type": "boolean"
+        }
+      },
+      "title": "Meta",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "not": {
+        "required": [
+          "error"
+        ]
+      },
+      "properties": {
+        "ok": {
+          "const": true
+        },
+        "result": {
+          "not": {
+            "type": "null"
+          }
+        }
+      },
+      "required": [
+        "ok",
+        "result"
+      ]
+    },
+    {
+      "not": {
+        "required": [
+          "result"
+        ]
+      },
+      "properties": {
+        "error": {
+          "not": {
+            "type": "null"
+          }
+        },
+        "ok": {
+          "const": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ]
+    }
+  ],
+  "properties": {
+    "command": {
+      "$ref": "#/$defs/CommandContext"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ErrorDetail"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "fix": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Fix"
+    },
+    "meta": {
+      "$ref": "#/$defs/Meta"
+    },
+    "next_actions": {
+      "items": {
+        "$ref": "#/$defs/Action"
+      },
+      "title": "Next Actions",
+      "type": "array"
+    },
+    "ok": {
+      "title": "Ok",
+      "type": "boolean"
+    },
+    "result": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/HostVerifierResult"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "schema_version": {
+      "const": "infralink.cli/v1",
+      "default": "infralink.cli/v1",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "next_actions"
+  ],
+  "title": "Envelope[HostVerifierResult]",
+  "type": "object"
+}

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -69,6 +69,7 @@ SCHEMA_NAMES = (
     "hosts",
     "host-show",
     "host-bootstrap",
+    "host-verifier",
     "host-apply",
     "operation-status",
     "services",

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -469,7 +469,7 @@ def test_live_command_discovery_is_locked_to_checked_in_schema_coverage() -> Non
         },
         "app": {"app-list", "app-show"},
         "info": {"info"},
-        "host": {"hosts", "host-show", "host-bootstrap", "host-apply"},
+        "host": {"hosts", "host-show", "host-bootstrap", "host-verifier", "host-apply"},
         "operation": {"operation-status"},
         "edge": {"edges-list", "edge-show"},
         "service": {"services", "service-show"},

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -525,6 +525,8 @@ def test_doctor_host_fails_closed_when_latest_v2_reconcile_failed(
     )
     assert check["passed"] is False
     assert check["detail"] == "exit-code:1"
+    verifier_action = next(item for item in payload["next_actions"] if item["rel"] == "verifier")
+    assert shlex.split(verifier_action["command"])[-3:] == ["host", "verifier", HOST_ID]
 
 
 def test_doctor_keeps_zero_service_provisioning_host_out_of_unhealthy_state() -> None:

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -9,6 +9,7 @@ import yaml
 from click.testing import CliRunner
 
 from infralink.cli.main import cli
+from infralink.cli.operation_contracts import HostVerifierDiagnostic
 from tests.cli_helpers import assert_schema
 
 HOST_ID = "32a3324f-c3d0-4a4f-9587-52c099bcb3fb"
@@ -119,6 +120,152 @@ def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
         "dry_run": True,
         "target": {"type": "host", "id": host_id, "canonical_name": canonical_name},
     }
+
+
+def test_host_verifier_reports_only_public_v2_trust_facts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    public_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "runtime_revision=" + "a" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=passed",
+            "identity=PRIVATE-KEY-MUST-NOT-LEAK",
+            "token=SECRET-MUST-NOT-LEAK",
+        )
+    )
+    calls: list[list[str]] = []
+    scripts: list[str] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        scripts.append(str(kwargs["input"]))
+        return _completed(public_output)
+
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert_schema(payload, "host-verifier")
+    assert payload["result"] == {
+        "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
+        "verifier": {
+            "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref": "refs/heads/main",
+            "runtime_revision": "a" * 40,
+            "allowed_signer": {
+                "principal": "infra",
+                "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "sha256": "c" * 64,
+            },
+            "git_ssh_signature_capable": True,
+            "fetched_tip": "d" * 40,
+            "signature_verification": "passed",
+        },
+    }
+    assert "PRIVATE-KEY-MUST-NOT-LEAK" not in response.output
+    assert "SECRET-MUST-NOT-LEAK" not in response.output
+    assert calls[0][-4:] == ["sh", "-s", "--", "verifier"]
+    script = scripts[0]
+    assert "systemctl start" not in script
+
+
+def test_host_verifier_rejects_and_omits_a_remote_with_secret_material(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    secret = "PRIVATE-REGISTRY-TOKEN"
+    remote_output = "\n".join(
+        (
+            f"registry_remote=https://{secret}@gitea.example.invalid/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "runtime_revision=" + "a" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=failed",
+        )
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert secret not in response.output
+
+
+def test_host_verifier_rejects_a_non_main_registry_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    remote_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/release",
+            "runtime_revision=" + "a" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=passed",
+        )
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "provider_unavailable"
+
+
+def test_host_verifier_contract_allows_only_the_fixed_main_ref() -> None:
+    with pytest.raises(ValueError):
+        HostVerifierDiagnostic.model_validate(
+            {
+                "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+                "registry_ref": "refs/heads/release",
+                "runtime_revision": "a" * 40,
+                "allowed_signer": {
+                    "principal": "infra",
+                    "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                    "sha256": "c" * 64,
+                },
+                "git_ssh_signature_capable": True,
+                "fetched_tip": "d" * 40,
+                "signature_verification": "passed",
+            }
+        )
 
 
 def test_host_apply_reports_only_normalized_observed_fingerprints_on_key_mismatch(

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -116,6 +116,50 @@ def test_host_bootstrap_plan_uses_the_same_failed_readiness_checks(monkeypatch) 
     assert json.loads(follow_up.output)["result"]["readiness"] == payload["result"]["readiness"]
 
 
+def test_host_bootstrap_links_verifier_when_reconcile_failed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "infralink.cli.main.SshReadinessTransport.probe",
+        lambda self, address: HostReadinessProbe(
+            reachable=True,
+            hostname="database.example.com",
+            machine_id="machine-id",
+            commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": True},
+            devops_account=True,
+            devops_authorized_access=True,
+            bws_config=True,
+            self_deploy_dependencies=True,
+            self_deploy_runtime=True,
+            self_deploy_timer_enabled=True,
+            self_deploy_timer_active=True,
+            error=None,
+            self_deploy_mode="v2_reconcile",
+            registry_layout="v2_managed",
+            self_deploy_reconcile_result="exit-code",
+            self_deploy_reconcile_exit_status=1,
+        ),
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(ROOT / "examples" / "registry.yml"),
+            "--edges",
+            str(ROOT / "examples" / "edges.yml"),
+            "host",
+            "bootstrap",
+            "database.example.com",
+            "--plan",
+        ],
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    verifier_action = next(item for item in payload["next_actions"] if item["rel"] == "verifier")
+    assert verifier_action["command"].endswith("host verifier d1b9e5d5-36b0-459d-a556-96622811fbd5")
+
+
 def test_host_bootstrap_help_marks_plan_required_and_shows_an_example() -> None:
     result = CliRunner().invoke(cli, ["--output", "json", "help", "host", "bootstrap"])
     payload = json.loads(result.output)

--- a/tests/test_cli_root.py
+++ b/tests/test_cli_root.py
@@ -183,6 +183,7 @@ def test_host_group_lists_its_real_children_and_host_list_matches_compatibility_
         "create",
         "list",
         "show",
+        "verifier",
     }
     assert yaml.safe_load(listed.output)["result"] == yaml.safe_load(compatibility.output)["result"]
 
@@ -194,6 +195,7 @@ def test_host_group_lists_its_real_children_and_host_list_matches_compatibility_
         "create",
         "list",
         "show",
+        "verifier",
     }
     assert all(
         action["command"].startswith("infralink help host")

--- a/tests/test_cli_secret_leaks.py
+++ b/tests/test_cli_secret_leaks.py
@@ -293,6 +293,7 @@ selection:
         ),
         ("host", "bootstrap"): ([*source, "host", "bootstrap", TARGET_ID, "--plan"], 0, True),
         ("host", "apply"): ([*source, "host", "apply", TARGET_ID, "--dry-run"], 3, False),
+        ("host", "verifier"): ([*source, "host", "verifier", TARGET_ID], 3, False),
         ("info",): ([*source, "info"], 0, True),
         ("operation", "status"): (
             [


### PR DESCRIPTION
Closes #87

Adds `infralink host verifier <host>` as a bounded, read-only, SSH-pinned diagnostic for V2 Git signature verification. It emits only the declared/public verifier facts: registry remote/ref, runtime revision, signer principal/fingerprint/digest, Git SSH-signature capability, cached fetched tip, and verification outcome.

Doctor and bootstrap plan link to the command only after a failed V2 reconcile. The fixed remote script starts no unit and accepts no arbitrary command. It never serializes identity or token data; malformed or credential-bearing remote output is rejected without echoing it.

Validation: focused TDD tests, 165 contract/discovery/doctor tests, Ruff, mypy, schema generation, and diff check.