### PR TITLE
fix(cli): retain partial verifier diagnostics

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1830,7 +1830,7 @@ def host_verifier(ctx: Context, host_ref: str) -> int:
             ],
         )
     )
-    return 0 if verifier.signature_verification == "passed" else 1
+    return 0 if verifier.signature_verification == "passed" and not verifier.unavailable else 1
 
 
 @host.command(name="apply")

--- a/src/infralink/cli/operation_contracts.py
+++ b/src/infralink/cli/operation_contracts.py
@@ -52,16 +52,44 @@ class AllowedSignerDiagnostic(ContractModel):
     sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
 
 
+VerifierUnavailableFact = Literal[
+    "registry_remote",
+    "registry_ref",
+    "runtime_revision",
+    "allowed_signer",
+    "git_ssh_signature_capable",
+    "fetched_tip",
+    "signature_verification",
+]
+
+
 class HostVerifierDiagnostic(ContractModel):
     """Bounded, public-only facts used by the host-local V2 verifier."""
 
-    registry_remote: str = Field(min_length=1, max_length=1024)
-    registry_ref: Literal["refs/heads/main"]
-    runtime_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
-    allowed_signer: AllowedSignerDiagnostic
-    git_ssh_signature_capable: bool
-    fetched_tip: str = Field(pattern=r"^[0-9a-f]{40}$")
-    signature_verification: Literal["passed", "failed", "unavailable"]
+    registry_remote: str | None = Field(
+        default=None, min_length=1, max_length=1024, exclude_if=lambda value: value is None
+    )
+    registry_ref: Literal["refs/heads/main"] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    runtime_revision: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{40}$", exclude_if=lambda value: value is None
+    )
+    allowed_signer: AllowedSignerDiagnostic | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    git_ssh_signature_capable: bool | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    fetched_tip: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{40}$", exclude_if=lambda value: value is None
+    )
+    signature_verification: Literal["passed", "failed", "unavailable"] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    unavailable: list[VerifierUnavailableFact] = Field(
+        default_factory=list, max_length=7, exclude_if=lambda value: not value
+    )
 
 
 class HostVerifierResult(ContractModel):

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -22,6 +22,7 @@ from infralink.cli.operation_contracts import (
     HostVerifierDiagnostic,
     OperationFailure,
     OperationUnitFailure,
+    VerifierUnavailableFact,
 )
 
 _OPERATION_ID = re.compile(
@@ -402,52 +403,104 @@ def _parse_verifier_output(stdout: str) -> dict[str, Any]:
     values: dict[str, Any] = {}
     for line in stdout.splitlines():
         key, separator, value = line.partition("=")
-        if separator and key in accepted and key not in values:
-            values[key] = value
+        if not separator or key not in accepted:
+            continue
+        if key in values:
+            raise _provider_failure("Declared host returned invalid verifier diagnostics")
+        values[key] = value
     return values
 
 
 def _parse_verifier_diagnostics(values: dict[str, Any]) -> HostVerifierDiagnostic:
     """Validate public facts before they cross the CLI boundary."""
     try:
-        remote = _required_text(values, "registry_remote")
-        parsed = urlsplit(remote)
-        if (
-            not parsed.scheme
-            or not parsed.hostname
-            or (
-                parsed.username is not None and (parsed.scheme != "ssh" or parsed.username != "git")
-            )
-            or parsed.password is not None
-            or parsed.query
-            or parsed.fragment
-            or any(character.isspace() or ord(character) < 32 for character in remote)
-        ):
+        unavailable: list[VerifierUnavailableFact] = []
+
+        remote = _optional_verifier_value(values, "registry_remote", unavailable)
+        if remote is not None:
+            parsed = urlsplit(remote)
+            if (
+                not parsed.scheme
+                or not parsed.hostname
+                or (
+                    parsed.username is not None
+                    and (parsed.scheme != "ssh" or parsed.username != "git")
+                )
+                or parsed.password is not None
+                or parsed.query
+                or parsed.fragment
+                or any(character.isspace() or ord(character) < 32 for character in remote)
+            ):
+                raise ValueError
+
+        registry_ref = _optional_verifier_value(values, "registry_ref", unavailable)
+        if registry_ref is not None and registry_ref != "refs/heads/main":
             raise ValueError
-        capable = _required_text(values, "git_ssh_signature_capable")
-        if capable not in {"true", "false"}:
+
+        runtime = _optional_verifier_value(values, "runtime_revision", unavailable)
+        if runtime is not None and _GIT_SHA.fullmatch(runtime) is None:
             raise ValueError
-        registry_ref = _required_text(values, "registry_ref")
-        if registry_ref != "refs/heads/main":
+
+        signer = _optional_allowed_signer(values, unavailable)
+
+        capable = _optional_verifier_value(values, "git_ssh_signature_capable", unavailable)
+        if capable is not None and capable not in {"true", "false"}:
             raise ValueError
-        verification = _required_text(values, "signature_verification")
-        if verification not in {"passed", "failed", "unavailable"}:
+
+        tip = _optional_verifier_value(values, "fetched_tip", unavailable)
+        if tip is not None and _GIT_SHA.fullmatch(tip) is None:
+            raise ValueError
+
+        verification = _optional_verifier_value(values, "signature_verification", unavailable)
+        if verification is not None and verification not in {"passed", "failed", "unavailable"}:
             raise ValueError
         return HostVerifierDiagnostic(
             registry_remote=remote,
-            registry_ref="refs/heads/main",
-            runtime_revision=_required_sha(values, "runtime_revision"),
-            allowed_signer=AllowedSignerDiagnostic(
-                principal=_required_signer_principal(values, "allowed_signer_principal"),
-                fingerprint=_required_fingerprint(values, "allowed_signer_fingerprint"),
-                sha256=_required_sha256(values, "allowed_signers_sha256"),
+            registry_ref=cast(Literal["refs/heads/main"] | None, registry_ref),
+            runtime_revision=runtime,
+            allowed_signer=signer,
+            git_ssh_signature_capable=None if capable is None else capable == "true",
+            fetched_tip=tip,
+            signature_verification=cast(
+                Literal["passed", "failed", "unavailable"] | None, verification
             ),
-            git_ssh_signature_capable=capable == "true",
-            fetched_tip=_required_sha(values, "fetched_tip"),
-            signature_verification=cast(Literal["passed", "failed", "unavailable"], verification),
+            unavailable=unavailable,
         )
     except (TypeError, ValueError):
         raise _provider_failure("Declared host returned invalid verifier diagnostics") from None
+
+
+def _optional_verifier_value(
+    values: dict[str, Any], key: VerifierUnavailableFact, unavailable: list[VerifierUnavailableFact]
+) -> str | None:
+    value = values.get(key)
+    if value is None:
+        unavailable.append(key)
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError
+    return value
+
+
+def _optional_allowed_signer(
+    values: dict[str, Any], unavailable: list[VerifierUnavailableFact]
+) -> AllowedSignerDiagnostic | None:
+    keys = (
+        "allowed_signer_principal",
+        "allowed_signer_fingerprint",
+        "allowed_signers_sha256",
+    )
+    present = [key in values for key in keys]
+    if not any(present):
+        unavailable.append("allowed_signer")
+        return None
+    if not all(present):
+        raise ValueError
+    return AllowedSignerDiagnostic(
+        principal=_required_signer_principal(values, "allowed_signer_principal"),
+        fingerprint=_required_fingerprint(values, "allowed_signer_fingerprint"),
+        sha256=_required_sha256(values, "allowed_signers_sha256"),
+    )
 
 
 def _required_text(values: dict[str, Any], key: str) -> str:

--- a/src/infralink/schemas/cli/v1/host-verifier.json
+++ b/src/infralink/schemas/cli/v1/host-verifier.json
@@ -199,52 +199,116 @@
       "description": "Bounded, public-only facts used by the host-local V2 verifier.",
       "properties": {
         "allowed_signer": {
-          "$ref": "#/$defs/AllowedSignerDiagnostic"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AllowedSignerDiagnostic"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "fetched_tip": {
-          "pattern": "^[0-9a-f]{40}$",
-          "title": "Fetched Tip",
-          "type": "string"
+          "anyOf": [
+            {
+              "pattern": "^[0-9a-f]{40}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fetched Tip"
         },
         "git_ssh_signature_capable": {
-          "title": "Git Ssh Signature Capable",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Git Ssh Signature Capable"
         },
         "registry_ref": {
-          "const": "refs/heads/main",
-          "title": "Registry Ref",
-          "type": "string"
+          "anyOf": [
+            {
+              "const": "refs/heads/main",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Registry Ref"
         },
         "registry_remote": {
-          "maxLength": 1024,
-          "minLength": 1,
-          "title": "Registry Remote",
-          "type": "string"
+          "anyOf": [
+            {
+              "maxLength": 1024,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Registry Remote"
         },
         "runtime_revision": {
-          "pattern": "^[0-9a-f]{40}$",
-          "title": "Runtime Revision",
-          "type": "string"
+          "anyOf": [
+            {
+              "pattern": "^[0-9a-f]{40}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Runtime Revision"
         },
         "signature_verification": {
-          "enum": [
-            "passed",
-            "failed",
-            "unavailable"
+          "anyOf": [
+            {
+              "enum": [
+                "passed",
+                "failed",
+                "unavailable"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "title": "Signature Verification",
-          "type": "string"
+          "default": null,
+          "title": "Signature Verification"
+        },
+        "unavailable": {
+          "items": {
+            "enum": [
+              "registry_remote",
+              "registry_ref",
+              "runtime_revision",
+              "allowed_signer",
+              "git_ssh_signature_capable",
+              "fetched_tip",
+              "signature_verification"
+            ],
+            "type": "string"
+          },
+          "maxItems": 7,
+          "title": "Unavailable",
+          "type": "array"
         }
       },
-      "required": [
-        "registry_remote",
-        "registry_ref",
-        "runtime_revision",
-        "allowed_signer",
-        "git_ssh_signature_capable",
-        "fetched_tip",
-        "signature_verification"
-      ],
       "title": "HostVerifierDiagnostic",
       "type": "object"
     },

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -183,6 +183,88 @@ def test_host_verifier_reports_only_public_v2_trust_facts(
     assert "systemctl start" not in script
 
 
+def test_host_verifier_retains_valid_partial_facts_and_names_unavailable_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    partial_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=failed",
+        )
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run",
+        lambda *args, **kwargs: _completed(partial_output),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 1
+    assert_schema(payload, "host-verifier")
+    assert payload["result"] == {
+        "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
+        "verifier": {
+            "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref": "refs/heads/main",
+            "allowed_signer": {
+                "principal": "infra",
+                "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "sha256": "c" * 64,
+            },
+            "git_ssh_signature_capable": True,
+            "fetched_tip": "d" * 40,
+            "signature_verification": "failed",
+            "unavailable": ["runtime_revision"],
+        },
+    }
+
+
+def test_host_verifier_rejects_a_malformed_public_fact_instead_of_marking_it_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    malformed = "NOT-A-GIT-REVISION"
+    remote_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            f"runtime_revision={malformed}",
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=failed",
+        )
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert malformed not in response.output
+
+
 def test_host_verifier_rejects_and_omits_a_remote_with_secret_material(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -199,6 +281,41 @@ def test_host_verifier_rejects_and_omits_a_remote_with_secret_material(
             "git_ssh_signature_capable=true",
             "fetched_tip=" + "d" * 40,
             "signature_verification=failed",
+        )
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
+    )
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert secret not in response.output
+
+
+def test_host_verifier_rejects_duplicate_public_fact_with_secret_material(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _manifest_registry_checkout(tmp_path)
+    secret = "DUPLICATE-REGISTRY-TOKEN"
+    remote_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            f"registry_remote=https://{secret}@gitea.example.invalid/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "runtime_revision=" + "a" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=passed",
         )
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #89

Preserves valid read-only verifier facts from legacy host runtimes and reports omitted supported facts under `unavailable`. Malformed or credential-bearing public fields remain hard failures; the SSH verifier remains pinned and read-only.

Tests: `PYTHONPATH=src /root/.venvs/infralink-dev/bin/pytest --no-cov -q tests/test_cli_host_apply.py`; Ruff; mypy.