### PR TITLE
fix(cli): resolve legacy host operation contracts

### DIFF
--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -40,6 +40,15 @@ _MAX_FAILURE_JOURNAL_LINES = 6
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 _SIGNER_PRINCIPAL = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_MANIFEST_V2_APPLY_FIELDS = frozenset(
+    {
+        "self_deploy_v2_reconcile_enabled",
+        "self_deploy_v2_reconcile_packaged",
+        "self_deploy_v2_promotion_policy_enabled",
+        "self_deploy_v2_promotion_channel",
+        "self_deploy_v2_promotion_host_fingerprint",
+    }
+)
 
 _START_REMOTE = """set -eu
 unit=$1
@@ -264,7 +273,7 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
 def _manifest_request(
     host_uuid: str, canonical_name: str, data: dict[str, Any], path: Path
 ) -> ApplyRequest | None:
-    if not any(isinstance(field, str) and field.startswith("self_deploy_v2_") for field in data):
+    if _MANIFEST_V2_APPLY_FIELDS.isdisjoint(data):
         return None
     if data.get("self_deploy_v2_reconcile_enabled") is not True:
         raise _registry_failure("Host apply manifest does not enable V2 reconcile", path)
@@ -316,10 +325,10 @@ def _contract_request(registry_path: Path, host: Any) -> ApplyRequest:
         )
     if not isinstance(transport, dict) or transport.get("kind") != "ssh":
         raise _registry_failure("Host apply contract must declare SSH transport", contract_path)
-    if not isinstance(reconcile, dict) or reconcile.get("unit") != _UNIT:
-        raise _registry_failure(
-            "Host apply contract must declare the supported reconcile unit", contract_path
-        )
+    if reconcile is not None and (
+        not isinstance(reconcile, dict) or reconcile.get("unit") != _UNIT
+    ):
+        raise _registry_failure("Host apply contract reconcile unit is invalid", contract_path)
     address = transport.get("host")
     port = transport.get("port")
     user = transport.get("user")

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -516,6 +516,75 @@ def test_host_apply_refuses_a_partial_v2_manifest_instead_of_using_legacy_contra
     assert payload["error"]["code"] == "input_load_failed"
 
 
+def test_host_verifier_uses_legacy_contract_for_a_shadow_only_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "    self_deploy_v2_shadow_enabled: true\n",
+        encoding="utf-8",
+    )
+    contract = registry / HOST_ID / "operations" / "contract.yml"
+    contract.write_text(
+        contract.read_text(encoding="utf-8").replace(f"reconcile:\n  unit: {UNIT}\n", ""),
+        encoding="utf-8",
+    )
+    _git(registry.parent, "add", ".")
+    _git(registry.parent, "commit", "--quiet", "-m", "legacy shadow contract")
+
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+            "registry_ref=refs/heads/main\n"
+            "runtime_revision=" + "a" * 40 + "\n"
+            "allowed_signer_principal=infra\n"
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
+            "allowed_signers_sha256=" + "c" * 64 + "\n"
+            "git_ssh_signature_capable=true\n"
+            "fetched_tip=" + "d" * 40 + "\n"
+            "signature_verification=passed\n"
+        )
+
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
+    )
+
+    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code == 0
+    assert_schema(payload, "host-verifier")
+    assert calls[0][-5:] == ["root@100.64.68.83", "sh", "-s", "--", "verifier"]
+
+
+def test_host_apply_rejects_a_legacy_contract_with_a_different_reconcile_unit(
+    tmp_path: Path,
+) -> None:
+    registry = _registry_checkout(tmp_path)
+    contract = registry / HOST_ID / "operations" / "contract.yml"
+    contract.write_text(
+        contract.read_text(encoding="utf-8").replace(UNIT, "not-the-supported-unit.service"),
+        encoding="utf-8",
+    )
+    _git(registry.parent, "add", ".")
+    _git(registry.parent, "commit", "--quiet", "-m", "invalid legacy unit")
+
+    response = CliRunner().invoke(
+        cli, ["--registry", str(registry), "host", "apply", HOST_ID, "--dry-run"]
+    )
+
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
+    assert "reconcile unit" in payload["error"]["message"].lower()
+
+
 def test_host_apply_starts_only_declared_reconcile_unit_and_returns_opaque_run_reference(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #91

- Treat only current manifest V2 apply fields as manifest-contract selectors.
- Keep legacy shadow-only manifests on the existing operations-contract compatibility path.
- Default a legacy contract with no `reconcile` stanza to the sole supported unit; reject any differing declared unit.

Verification:
- `/root/.venvs/infralink-dev/bin/pytest --no-cov -q` (1416 passed)
- Ruff check/format and mypy for the changed resolver.