### PR TITLE
fix(cli): derive verifier from active host contract

### DIFF
--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -475,7 +475,9 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
     manifest_request = _manifest_request(host.uuid, host.canonical_name, host_data, manifest_path)
     if manifest_request is not None:
         return replace(manifest_request, verifier_source="active")
-    return _with_legacy_verifier_layout(_contract_request(registry_path, host), registry_path, host.uuid)
+    return _with_legacy_verifier_layout(
+        _contract_request(registry_path, host), registry_path, host.uuid
+    )
 
 
 def _manifest_request(

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -141,6 +141,7 @@ printf 'signature_verification=%s\\n' "$verification"
 
 _ACTIVE_VERIFIER_REMOTE = """set -eu
 unit=$1
+host_uuid=$2
 
 # The unit drop-in is the active public bootstrap contract. Do not read its
 # EnvironmentFile: it may contain credentials needed only by reconciliation.
@@ -173,7 +174,7 @@ case "$runtime" in
 esac
 [ -x "$runtime/.venv/bin/python" ] || exit 0
 
-"$runtime/.venv/bin/python" -P - "$runtime" "$origin" <<'PY'
+"$runtime/.venv/bin/python" -P - "$runtime" "$origin" "$host_uuid" <<'PY'
 import hashlib
 import re
 import subprocess
@@ -183,6 +184,7 @@ from urllib.parse import urlsplit
 
 runtime = Path(sys.argv[1])
 origin = sys.argv[2]
+host_uuid = sys.argv[3]
 try:
     from lib.self_deploy.registry_layout import REGISTRY_ROOT
     from lib.self_deploy.release_admission_authority import (
@@ -206,9 +208,23 @@ try:
     ):
         raise ValueError
     trust = _trust()
-    if trust.remote != origin or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", trust.channel):
+except ReleaseAdmissionAuthorityError:
+    # The active public contract is malformed; fail closed without diagnostics.
+    raise SystemExit(2)
+except (AttributeError, TypeError):
+    # A partial or pre-authority runtime cannot provide this capability.
+    raise SystemExit(0)
+
+try:
+    if (
+        trust.host_uuid != host_uuid
+        or trust.remote != origin
+        or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", trust.channel)
+    ):
         raise ValueError
-except (ReleaseAdmissionAuthorityError, ValueError):
+except AttributeError:
+    raise SystemExit(0)
+except ValueError:
     # The active public contract is malformed; fail closed without diagnostics.
     raise SystemExit(2)
 
@@ -261,9 +277,15 @@ try:
         raise ValueError
     fetched_tip = tip.stdout.strip()
     _channel_pointer(REGISTRY_ROOT, fetched_tip, trust)
-except (OSError, subprocess.TimeoutExpired, ReleaseAdmissionAuthorityError, ValueError):
+except ReleaseAdmissionAuthorityError:
+    # A present authority rejected malformed public release data; fail closed.
+    raise SystemExit(2)
+except (OSError, subprocess.TimeoutExpired, ValueError):
     print("git_ssh_signature_capable=false")
     print("signature_verification=unavailable")
+    raise SystemExit(0)
+except (AttributeError, TypeError):
+    # The installed authority does not expose the required public verifier API.
     raise SystemExit(0)
 
 version = subprocess.run(["git", "--version"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, timeout=5)
@@ -383,7 +405,7 @@ class SshOperationProvider:
                 verifier.registry_ref or "",
             ]
             if verifier is not None
-            else ["active-verifier", request.unit]
+            else ["active-verifier", request.unit, request.host_uuid]
             if active_verifier
             else [request.unit]
             if invocation is None

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -251,24 +251,26 @@ except AttributeError:
 except (TypeError, UnicodeError, ValueError):
     # Present signer evidence is malformed; fail closed.
     raise SystemExit(2)
-if first is not None:
-    try:
-        rendered = subprocess.run(
-            ["ssh-keygen", "-lf", "-", "-E", "sha256"],
-            input=" ".join(first) + "\\n",
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=5,
-        )
-        fingerprint = next((part for part in rendered.stdout.split() if part.startswith("SHA256:")), "")
-        if rendered.returncode == 0 and fingerprint:
-            print(f"allowed_signer_principal={first[0]}")
-            print(f"allowed_signer_fingerprint={fingerprint}")
-            print(f"allowed_signers_sha256={digest}")
-    except (OSError, subprocess.TimeoutExpired):
-        pass
+if first is None:
+    raise SystemExit(2)
+try:
+    rendered = subprocess.run(
+        ["ssh-keygen", "-lf", "-", "-E", "sha256"],
+        input=" ".join(first) + "\\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=5,
+    )
+    fingerprint = next((part for part in rendered.stdout.split() if part.startswith("SHA256:")), "")
+except (OSError, subprocess.TimeoutExpired):
+    raise SystemExit(2)
+if rendered.returncode != 0 or not fingerprint:
+    raise SystemExit(2)
+print(f"allowed_signer_principal={first[0]}")
+print(f"allowed_signer_fingerprint={fingerprint}")
+print(f"allowed_signers_sha256={digest}")
 
 try:
     remote = subprocess.run(

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -139,6 +139,146 @@ fi
 printf 'signature_verification=%s\\n' "$verification"
 """
 
+_ACTIVE_VERIFIER_REMOTE = """set -eu
+unit=$1
+
+# The unit drop-in is the active public bootstrap contract. Do not read its
+# EnvironmentFile: it may contain credentials needed only by reconciliation.
+unit_body=$(systemctl cat "$unit" 2>/dev/null) || exit 0
+extract_public_unit_value() {
+    name=$1
+    value=$(printf '%s\\n' "$unit_body" | awk -v name="$name" '
+        $0 ~ "^Environment=\\\"" name "=" {
+            line=$0
+            sub("^Environment=\\\"" name "=", "", line)
+            if (line !~ /"$/ || seen++) exit 2
+            sub(/"$/, "", line)
+            print line
+        }
+        END { if (seen > 1) exit 2 }
+    ') || exit 2
+    printf '%s' "$value"
+}
+
+runtime=$(extract_public_unit_value SELF_DEPLOY_V2_RUNTIME_ROOT)
+origin=$(extract_public_unit_value SELF_DEPLOY_REGISTRY_ORIGIN)
+[ -n "$runtime" ] && [ -n "$origin" ] || exit 0
+case "$runtime" in
+    /var/lib/self-deploy-v2/runtime/*)
+        revision=${runtime#/var/lib/self-deploy-v2/runtime/}
+        case "$revision" in '' | *[!0-9a-f]*) exit 2 ;; esac
+        [ "${#revision}" -eq 40 ] || exit 2
+        ;;
+    *) exit 2 ;;
+esac
+[ -x "$runtime/.venv/bin/python" ] || exit 0
+
+"$runtime/.venv/bin/python" -P - "$runtime" "$origin" <<'PY'
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+runtime = Path(sys.argv[1])
+origin = sys.argv[2]
+try:
+    from lib.self_deploy.registry_layout import REGISTRY_ROOT
+    from lib.self_deploy.release_admission_authority import (
+        ReleaseAdmissionAuthorityError,
+        _channel_pointer,
+        _trust,
+    )
+except ImportError:
+    # A pre-authority runtime cannot provide this public capability.
+    raise SystemExit(0)
+
+try:
+    parsed = urlsplit(origin)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError
+    trust = _trust()
+    if trust.remote != origin or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", trust.channel):
+        raise ValueError
+except (ReleaseAdmissionAuthorityError, ValueError):
+    # The active public contract is malformed; fail closed without diagnostics.
+    raise SystemExit(2)
+
+print(f"runtime_revision={runtime.name}")
+print(f"registry_remote={trust.remote}")
+print("registry_ref=refs/heads/main")
+
+signers = trust.allowed_signers
+digest = hashlib.sha256(signers).hexdigest()
+first = next((line.split() for line in signers.decode("utf-8", "strict").splitlines() if len(line.split()) >= 3), None)
+if first is not None:
+    try:
+        rendered = subprocess.run(
+            ["ssh-keygen", "-lf", "-", "-E", "sha256"],
+            input=" ".join(first) + "\\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+        fingerprint = next((part for part in rendered.stdout.split() if part.startswith("SHA256:")), "")
+        if rendered.returncode == 0 and fingerprint:
+            print(f"allowed_signer_principal={first[0]}")
+            print(f"allowed_signer_fingerprint={fingerprint}")
+            print(f"allowed_signers_sha256={digest}")
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+try:
+    remote = subprocess.run(
+        ["git", "-C", str(REGISTRY_ROOT), "remote", "get-url", "origin"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=5,
+    )
+    if remote.returncode != 0 or remote.stdout.strip() != trust.remote:
+        raise ValueError
+    tip = subprocess.run(
+        ["git", "-C", str(REGISTRY_ROOT), "rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=5,
+    )
+    if tip.returncode != 0 or re.fullmatch(r"[0-9a-f]{40}", tip.stdout.strip()) is None:
+        raise ValueError
+    fetched_tip = tip.stdout.strip()
+    _channel_pointer(REGISTRY_ROOT, fetched_tip, trust)
+except (OSError, subprocess.TimeoutExpired, ReleaseAdmissionAuthorityError, ValueError):
+    print("git_ssh_signature_capable=false")
+    print("signature_verification=unavailable")
+    raise SystemExit(0)
+
+version = subprocess.run(["git", "--version"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, timeout=5)
+parts = version.stdout.strip().split()
+numbers = parts[-1].split(".") if version.returncode == 0 and parts else []
+try:
+    capable = int(numbers[0]) > 2 or (int(numbers[0]) == 2 and int(numbers[1]) >= 34)
+except (IndexError, ValueError):
+    capable = False
+print(f"git_ssh_signature_capable={'true' if capable else 'false'}")
+print(f"fetched_tip={fetched_tip}")
+print("signature_verification=passed")
+PY
+"""
+
 
 @dataclass(frozen=True)
 class ApplyRequest:
@@ -152,6 +292,7 @@ class ApplyRequest:
     host_key_fingerprint: str
     unit: str
     verifier_layout: VerifierLayout | None = None
+    verifier_source: Literal["active", "legacy", "unavailable"] = "unavailable"
 
 
 @dataclass(frozen=True)
@@ -210,8 +351,14 @@ class SshOperationProvider:
 
     def inspect_verifier(self, request: ApplyRequest) -> HostVerifierDiagnostic:
         """Read only the declared, public facts behind V2 Git signature verification."""
-        if request.verifier_layout is None:
+        if request.verifier_source == "unavailable":
             return HostVerifierDiagnostic(unavailable=list(_VERIFIER_UNAVAILABLE_FACTS))
+        if request.verifier_source == "active":
+            return _parse_verifier_diagnostics(
+                self._run(request, _ACTIVE_VERIFIER_REMOTE, active_verifier=True), None
+            )
+        if request.verifier_layout is None:
+            raise _provider_failure("Declared host verifier contract is invalid")
         return _parse_verifier_diagnostics(
             self._run(request, _VERIFIER_REMOTE, verifier=request.verifier_layout),
             request.verifier_layout,
@@ -224,6 +371,7 @@ class SshOperationProvider:
         invocation: str | None = None,
         *,
         verifier: VerifierLayout | None = None,
+        active_verifier: bool = False,
     ) -> dict[str, Any]:
         remote_args = (
             [
@@ -235,6 +383,8 @@ class SshOperationProvider:
                 verifier.registry_ref or "",
             ]
             if verifier is not None
+            else ["active-verifier", request.unit]
+            if active_verifier
             else [request.unit]
             if invocation is None
             else [request.unit, invocation]
@@ -274,7 +424,7 @@ class SshOperationProvider:
             ) from None
         if completed.returncode != 0:
             raise _provider_failure("Declared host rejected the reconcile operation")
-        if verifier is not None:
+        if verifier is not None or active_verifier:
             return _parse_verifier_output(completed.stdout)
         values = _parse_properties(completed.stdout)
         if not values.get("InvocationID"):
@@ -324,8 +474,8 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
         raise _registry_failure("Host apply manifest does not match the target host", manifest_path)
     manifest_request = _manifest_request(host.uuid, host.canonical_name, host_data, manifest_path)
     if manifest_request is not None:
-        return _with_verifier_layout(manifest_request, registry_path, host.uuid)
-    return _with_verifier_layout(_contract_request(registry_path, host), registry_path, host.uuid)
+        return replace(manifest_request, verifier_source="active")
+    return _with_legacy_verifier_layout(_contract_request(registry_path, host), registry_path, host.uuid)
 
 
 def _manifest_request(
@@ -417,19 +567,19 @@ def _normalize_manifest_fingerprint(value: object) -> str | None:
     return parts[1]
 
 
-def _with_verifier_layout(
+def _with_legacy_verifier_layout(
     request: ApplyRequest, registry_path: Path, host_uuid: str
 ) -> ApplyRequest:
-    return replace(request, verifier_layout=_resolve_verifier_layout(registry_path, host_uuid))
+    layout = _resolve_legacy_verifier_layout(registry_path, host_uuid)
+    return replace(
+        request,
+        verifier_layout=layout,
+        verifier_source="legacy" if layout is not None else "unavailable",
+    )
 
 
-def _resolve_verifier_layout(registry_path: Path, host_uuid: str) -> VerifierLayout | None:
-    """Read only an explicit runtime layout; never invent compatibility paths."""
-    source_path = registry_path / host_uuid / "operations" / "release-admission-shadow-source.yml"
-    if source_path.exists():
-        source = _read_mapping(source_path, "Host verifier release-admission layout is invalid")
-        return _layout_from_release_admission(source, source_path)
-
+def _resolve_legacy_verifier_layout(registry_path: Path, host_uuid: str) -> VerifierLayout | None:
+    """Read only a legacy explicit contract; shadow metadata is never active."""
     contract_path = registry_path / host_uuid / "operations" / "contract.yml"
     if not contract_path.exists():
         return None
@@ -438,28 +588,6 @@ def _resolve_verifier_layout(registry_path: Path, host_uuid: str) -> VerifierLay
     if declared is None:
         return None
     return _layout_from_legacy_contract(declared, contract_path)
-
-
-def _layout_from_release_admission(document: dict[str, Any], path: Path) -> VerifierLayout:
-    if document.get("schema_version") != "infralink.release-admission-shadow-delivery.v1":
-        raise _registry_failure("Host verifier release-admission layout is invalid", path)
-    registry = document.get("registry")
-    paths = document.get("paths")
-    release = document.get("release")
-    if (
-        not isinstance(registry, dict)
-        or not isinstance(paths, dict)
-        or not isinstance(release, dict)
-    ):
-        raise _registry_failure("Host verifier release-admission layout is invalid", path)
-    return _verifier_layout(
-        registry.get("repository"),
-        paths.get("runtime_root"),
-        release.get("allowed_signers_file"),
-        registry.get("remote"),
-        registry.get("ref"),
-        path,
-    )
 
 
 def _layout_from_legacy_contract(value: object, path: Path) -> VerifierLayout:
@@ -599,7 +727,7 @@ def _parse_verifier_output(stdout: str) -> dict[str, Any]:
 
 
 def _parse_verifier_diagnostics(
-    values: dict[str, Any], layout: VerifierLayout
+    values: dict[str, Any], layout: VerifierLayout | None
 ) -> HostVerifierDiagnostic:
     """Validate public facts before they cross the CLI boundary."""
     try:
@@ -621,19 +749,19 @@ def _parse_verifier_diagnostics(
                 or any(character.isspace() or ord(character) < 32 for character in remote)
             ):
                 raise ValueError
-            if remote != layout.registry_remote:
+            if layout is not None and remote != layout.registry_remote:
                 raise ValueError
 
         registry_ref = _optional_verifier_value(values, "registry_ref", unavailable)
         if registry_ref is not None and registry_ref != "refs/heads/main":
             raise ValueError
-        if registry_ref is not None and registry_ref != layout.registry_ref:
+        if layout is not None and registry_ref != layout.registry_ref:
             raise ValueError
 
         runtime = _optional_verifier_value(values, "runtime_revision", unavailable)
         if runtime is not None and _GIT_SHA.fullmatch(runtime) is None:
             raise ValueError
-        if runtime is not None and runtime != PurePosixPath(layout.runtime_root).name:
+        if layout is not None and runtime != PurePosixPath(layout.runtime_root).name:
             raise ValueError
 
         signer = _optional_allowed_signer(values, unavailable)

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -232,9 +232,25 @@ print(f"runtime_revision={runtime.name}")
 print(f"registry_remote={trust.remote}")
 print("registry_ref=refs/heads/main")
 
-signers = trust.allowed_signers
-digest = hashlib.sha256(signers).hexdigest()
-first = next((line.split() for line in signers.decode("utf-8", "strict").splitlines() if len(line.split()) >= 3), None)
+try:
+    signers = trust.allowed_signers
+    if not isinstance(signers, bytes):
+        raise ValueError
+    digest = hashlib.sha256(signers).hexdigest()
+    first = next(
+        (
+            line.split()
+            for line in signers.decode("utf-8", "strict").splitlines()
+            if len(line.split()) >= 3
+        ),
+        None,
+    )
+except AttributeError:
+    # A partial authority cannot expose signer evidence.
+    raise SystemExit(0)
+except (TypeError, UnicodeError, ValueError):
+    # Present signer evidence is malformed; fail closed.
+    raise SystemExit(2)
 if first is not None:
     try:
         rendered = subprocess.run(

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -95,16 +95,6 @@ def _manifest_registry_checkout(tmp_path: Path) -> Path:
             "    self_deploy_v2_reconcile_packaged: true\n",
             encoding="utf-8",
         )
-    _release_admission_layout(root / "hosts")
-    source = root / "hosts" / HOST_ID / "operations" / "release-admission-shadow-source.yml"
-    source.write_text(
-        source.read_text(encoding="utf-8").replace(
-            "  repository: /var/lib/release-admission/registry-objects/citadel\n",
-            "  repository: /var/lib/release-admission/registry-objects/citadel\n"
-            "  ref: refs/heads/main\n",
-        ),
-        encoding="utf-8",
-    )
     _git(root, "init", "--quiet")
     _git(root, "config", "user.email", "test@example.invalid")
     _git(root, "config", "user.name", "Test")
@@ -162,7 +152,7 @@ def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
     }
 
 
-def test_host_verifier_reports_only_public_v2_trust_facts(
+def test_host_verifier_derives_public_v2_trust_facts_from_active_unit_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
@@ -218,12 +208,16 @@ def test_host_verifier_reports_only_public_v2_trust_facts(
     }
     assert "PRIVATE-KEY-MUST-NOT-LEAK" not in response.output
     assert "SECRET-MUST-NOT-LEAK" not in response.output
-    assert calls[0][calls[0].index("--") + 1] == "verifier"
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
     script = scripts[0]
     assert "systemctl start" not in script
+    assert 'systemctl cat "$unit"' in script
+    assert "BWS_ACCESS_TOKEN" not in script
+    assert "/etc/environment" not in script
+    assert "release-admission-shadow-source" not in script
 
 
-def test_host_verifier_uses_citadel_declared_release_admission_layout(
+def test_host_verifier_ignores_stale_release_admission_shadow_metadata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
@@ -259,17 +253,9 @@ def test_host_verifier_uses_citadel_declared_release_admission_layout(
     assert response.exit_code == 1
     assert_schema(payload, "host-verifier")
     assert payload["result"]["verifier"]["unavailable"] == ["registry_ref"]
-    assert calls[0][-6:] == [
-        "verifier",
-        "/var/lib/release-admission/registry-objects/citadel",
-        "/var/lib/release-admission/runtime/" + "a" * 40,
-        "/etc/infralink/release-admission/allowed_signers",
-        "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-        "",
-    ]
-    assert "/etc/infra-management" not in scripts[0]
-    assert "/var/lib/infralink" not in scripts[0]
-    assert "/var/lib/self-deploy-v2/runtime" not in scripts[0]
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
+    assert "release-admission-shadow-source" not in scripts[0]
+    assert "/var/lib/release-admission/registry-objects/citadel" not in scripts[0]
 
 
 def test_host_verifier_rejects_false_green_without_observed_remote_and_ref(
@@ -304,8 +290,8 @@ def test_host_verifier_rejects_false_green_without_observed_remote_and_ref(
         "registry_ref",
         "fetched_tip",
     ]
-    assert "remote get-url" in scripts[0]
-    assert "refs/remotes/$remote_name/$branch^{commit}" in scripts[0]
+    assert '"remote", "get-url", "origin"' in scripts[0]
+    assert "refs/remotes/origin/main^{commit}" in scripts[0]
     assert "rev-parse --verify HEAD^{commit}" not in scripts[0]
 
 
@@ -339,8 +325,7 @@ def test_host_verifier_rejects_passed_signature_without_observed_remote_and_ref(
 def test_host_verifier_marks_all_facts_unavailable_without_a_declared_layout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    (registry / HOST_ID / "operations" / "release-admission-shadow-source.yml").unlink()
+    registry = _registry_checkout(tmp_path)
     monkeypatch.setattr(
         "infralink.cli.operations.subprocess.run",
         lambda *args, **kwargs: pytest.fail("verifier must not guess undeclared paths"),
@@ -364,10 +349,11 @@ def test_host_verifier_marks_all_facts_unavailable_without_a_declared_layout(
     }
 
 
-def test_host_verifier_rejects_secret_bearing_declared_layout_before_ssh(
+def test_host_verifier_ignores_secret_bearing_shadow_metadata_before_ssh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
+    _release_admission_layout(registry)
     source = registry / HOST_ID / "operations" / "release-admission-shadow-source.yml"
     source.write_text(
         source.read_text(encoding="utf-8").replace(
@@ -376,16 +362,24 @@ def test_host_verifier_rejects_secret_bearing_declared_layout_before_ssh(
         ),
         encoding="utf-8",
     )
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed("signature_verification=unavailable\n")
+
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
     monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run",
-        lambda *args, **kwargs: pytest.fail("secret-bearing declarations must fail before SSH"),
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/known-hosts")),
     )
 
     response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
 
     payload = yaml.safe_load(response.output)
     assert response.exit_code != 0
-    assert payload["error"]["code"] == "input_load_failed"
+    assert payload["result"]["verifier"]["signature_verification"] == "unavailable"
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
     assert "secret@gitea" not in response.output
 
 

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -217,6 +217,9 @@ def test_host_verifier_derives_public_v2_trust_facts_from_active_unit_contract(
     assert "release-admission-shadow-source" not in script
     assert "trust.host_uuid != host_uuid" in script
     assert "except (AttributeError, TypeError):" in script
+    assert "signers = trust.allowed_signers" in script
+    assert "if not isinstance(signers, bytes):" in script
+    assert "except AttributeError:" in script
 
 
 def test_host_verifier_ignores_stale_release_admission_shadow_metadata(

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -220,6 +220,8 @@ def test_host_verifier_derives_public_v2_trust_facts_from_active_unit_contract(
     assert "signers = trust.allowed_signers" in script
     assert "if not isinstance(signers, bytes):" in script
     assert "except AttributeError:" in script
+    assert "if first is None:" in script
+    assert "if rendered.returncode != 0 or not fingerprint:" in script
 
 
 def test_host_verifier_ignores_stale_release_admission_shadow_metadata(

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -208,13 +208,15 @@ def test_host_verifier_derives_public_v2_trust_facts_from_active_unit_contract(
     }
     assert "PRIVATE-KEY-MUST-NOT-LEAK" not in response.output
     assert "SECRET-MUST-NOT-LEAK" not in response.output
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
     script = scripts[0]
     assert "systemctl start" not in script
     assert 'systemctl cat "$unit"' in script
     assert "BWS_ACCESS_TOKEN" not in script
     assert "/etc/environment" not in script
     assert "release-admission-shadow-source" not in script
+    assert "trust.host_uuid != host_uuid" in script
+    assert "except (AttributeError, TypeError):" in script
 
 
 def test_host_verifier_ignores_stale_release_admission_shadow_metadata(
@@ -253,7 +255,7 @@ def test_host_verifier_ignores_stale_release_admission_shadow_metadata(
     assert response.exit_code == 1
     assert_schema(payload, "host-verifier")
     assert payload["result"]["verifier"]["unavailable"] == ["registry_ref"]
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
     assert "release-admission-shadow-source" not in scripts[0]
     assert "/var/lib/release-admission/registry-objects/citadel" not in scripts[0]
 
@@ -379,7 +381,7 @@ def test_host_verifier_ignores_secret_bearing_shadow_metadata_before_ssh(
     payload = yaml.safe_load(response.output)
     assert response.exit_code != 0
     assert payload["result"]["verifier"]["signature_verification"] == "unavailable"
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT]
+    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
     assert "secret@gitea" not in response.output
 
 


### PR DESCRIPTION
Closes #95

- derive V2 verifier facts from the active reconcile unit and installed authority
- ignore retired shadow-layout metadata
- keep explicit legacy verifier contracts compatible
- never read EnvironmentFile or emit credentials