### PR TITLE
test: add hermetic core-v2 release-path fixture

### DIFF
--- a/tests/fixtures/core_v2_release_path/adapter-bindings.yml
+++ b/tests/fixtures/core_v2_release_path/adapter-bindings.yml
@@ -1,0 +1,7 @@
+schema_version: infra-observe.adapter-bindings.v1
+bindings:
+  - id: gatus-citadel-self-deploy
+    renderer_kind: gatus
+    observation_backend_id: core-health
+    output_identity: citadel-self-deploy
+    signal_ref: dependency/citadel-self-deploy/health/reachable

--- a/tests/fixtures/core_v2_release_path/admission.json
+++ b/tests/fixtures/core_v2_release_path/admission.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-admission.v2",
   "channel": "core-v2",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "signer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "signature": "ssh-ed25519 fixture-admission-signature"
 }

--- a/tests/fixtures/core_v2_release_path/admission.json
+++ b/tests/fixtures/core_v2_release_path/admission.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "infralink.release-admission.v2",
+  "channel": "core-v2",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "signer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
+  "signature": "ssh-ed25519 fixture-admission-signature"
+}

--- a/tests/fixtures/core_v2_release_path/admission.json
+++ b/tests/fixtures/core_v2_release_path/admission.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-admission.v2",
   "channel": "core-v2",
-  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
   "signer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "signature": "ssh-ed25519 fixture-admission-signature"
 }

--- a/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/manifest.yml
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/manifest.yml
@@ -1,0 +1,5 @@
+hosts:
+  9157ddeb-cb6d-4d55-8252-9db358f5d932:
+    canonical_name: cyberstorm-citadel
+    status: active
+    tailscale_ip: 100.73.228.90

--- a/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/contract.yml
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/contract.yml
@@ -1,0 +1,19 @@
+schema_version: host-operations-contract.v1
+machine:
+  uuid: 9157ddeb-cb6d-4d55-8252-9db358f5d932
+  canonical_name: cyberstorm-citadel
+transport:
+  kind: ssh
+  host: 100.73.228.90
+  port: 22
+  user: root
+  host_key_fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+reconcile:
+  unit: self-deploy-v2-reconcile.service
+verifier:
+  registry:
+    remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git
+    repository: /var/lib/legacy/registry
+    ref: refs/heads/main
+  runtime_root: /var/lib/legacy/runtime/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  allowed_signers_file: /etc/legacy/allowed_signers

--- a/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/release-admission-shadow-source.yml
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/release-admission-shadow-source.yml
@@ -1,0 +1,5 @@
+schema_version: infralink.release-admission-shadow-delivery.v1
+registry:
+  repository: /var/lib/release-admission/registry-objects/citadel
+paths:
+  runtime_root: /var/lib/release-admission/runtime/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
@@ -1,0 +1,3 @@
+{
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
@@ -1,3 +1,3 @@
 {
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7"
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 }

--- a/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
@@ -1,3 +1,3 @@
 {
-  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7"
 }

--- a/tests/fixtures/core_v2_release_path/candidate.json
+++ b/tests/fixtures/core_v2_release_path/candidate.json
@@ -2,7 +2,7 @@
   "schema_version": "infralink.release-candidate.v1",
   "channel": "core-v2",
   "main_registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
   "registry_tree": "candidate-registry/hosts",
   "consumer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "artifacts": [

--- a/tests/fixtures/core_v2_release_path/candidate.json
+++ b/tests/fixtures/core_v2_release_path/candidate.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "infralink.release-candidate.v1",
+  "channel": "core-v2",
+  "main_registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "registry_tree": "candidate-registry/hosts",
+  "consumer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
+  "artifacts": [
+    "hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/manifest.yml",
+    "hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/contract.yml"
+  ]
+}

--- a/tests/fixtures/core_v2_release_path/candidate.json
+++ b/tests/fixtures/core_v2_release_path/candidate.json
@@ -2,7 +2,8 @@
   "schema_version": "infralink.release-candidate.v1",
   "channel": "core-v2",
   "main_registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "runtime_revision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "registry_tree": "candidate-registry/hosts",
   "consumer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "artifacts": [

--- a/tests/fixtures/core_v2_release_path/candidate.json
+++ b/tests/fixtures/core_v2_release_path/candidate.json
@@ -2,7 +2,7 @@
   "schema_version": "infralink.release-candidate.v1",
   "channel": "core-v2",
   "main_registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "registry_tree": "candidate-registry/hosts",
   "consumer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "artifacts": [

--- a/tests/fixtures/core_v2_release_path/observation-plan.json
+++ b/tests/fixtures/core_v2_release_path/observation-plan.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "infralink.observation-plan/v1",
+  "dependencies": [
+    {
+      "id": "citadel-self-deploy",
+      "source_service_id": "9157ddeb-cb6d-4d55-8252-9db358f5d932/self-deploy",
+      "target_service_id": "7ffe46b7-0eb4-40cb-8e14-ea679b9948f4/gatus",
+      "target_endpoint_id": "7ffe46b7-0eb4-40cb-8e14-ea679b9948f4/gatus/http",
+      "required": true,
+      "execution_adapter": "gatus",
+      "health_signal_refs": ["dependency/citadel-self-deploy/health/reachable"]
+    }
+  ],
+  "service_profiles": [],
+  "services": []
+}

--- a/tests/fixtures/core_v2_release_path/pointer.json
+++ b/tests/fixtures/core_v2_release_path/pointer.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-pointer.v2",
   "channel": "core-v2",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "candidate": "candidate.json",
   "signature": "ssh-ed25519 fixture-pointer-signature"
 }

--- a/tests/fixtures/core_v2_release_path/pointer.json
+++ b/tests/fixtures/core_v2_release_path/pointer.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "infralink.release-pointer.v2",
+  "channel": "core-v2",
+  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "candidate": "candidate.json",
+  "signature": "ssh-ed25519 fixture-pointer-signature"
+}

--- a/tests/fixtures/core_v2_release_path/pointer.json
+++ b/tests/fixtures/core_v2_release_path/pointer.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-pointer.v2",
   "channel": "core-v2",
-  "registry_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
   "candidate": "candidate.json",
   "signature": "ssh-ed25519 fixture-pointer-signature"
 }

--- a/tests/fixtures/core_v2_release_path/registry-main/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/manifest.yml
+++ b/tests/fixtures/core_v2_release_path/registry-main/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/manifest.yml
@@ -1,0 +1,6 @@
+hosts:
+  9157ddeb-cb6d-4d55-8252-9db358f5d932:
+    canonical_name: cyberstorm-citadel
+    status: active
+    tailscale_ip: 100.73.228.90
+    self_deploy_v2_reconcile_enabled: true

--- a/tests/fixtures/core_v2_release_path/registry-main/release-selection.json
+++ b/tests/fixtures/core_v2_release_path/registry-main/release-selection.json
@@ -1,0 +1,3 @@
+{
+  "registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/tests/test_core_v2_release_path.py
+++ b/tests/test_core_v2_release_path.py
@@ -30,6 +30,7 @@ class CoreReleasePath:
     """The explicitly selected registry declaration used by every CLI call."""
 
     registry_commit: str
+    runtime_revision: str
     registry_path: Path
     host_id: str
 
@@ -63,6 +64,9 @@ def _select_release(
         if not isinstance(signature, str) or not signature.startswith("ssh-ed25519 "):
             raise ValueError(f"{name} signature is missing or invalid")
     expected = candidate["registry_commit"]
+    runtime_revision = candidate.get("runtime_revision")
+    if not isinstance(runtime_revision, str) or len(runtime_revision) != 40:
+        raise ValueError("candidate runtime revision is invalid")
     if pointer.get("channel") != "core-v2" or candidate.get("channel") != "core-v2":
         raise ValueError("core-v2 channel mismatch")
     if pointer.get("registry_commit") != expected or admission.get("registry_commit") != expected:
@@ -85,7 +89,9 @@ def _select_release(
         raise ValueError("selected candidate artifacts are missing")
     if not (registry_path / candidate["consumer_host_uuid"] / "manifest.yml").is_file():
         raise ValueError("selected candidate host declaration is missing")
-    return CoreReleasePath(expected, registry_path, candidate["consumer_host_uuid"])
+    return CoreReleasePath(
+        expected, runtime_revision, registry_path, candidate["consumer_host_uuid"]
+    )
 
 
 def _git(root: Path, *args: str) -> None:
@@ -127,6 +133,13 @@ def _selected_release(tmp_path: Path) -> CoreReleasePath:
         root / "release-selection.json",
     )
     pointer, admission, candidate = _release_artifacts()
+    head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head == candidate["registry_commit"]
     return _select_release(
         registry,
         pointer=pointer,
@@ -175,7 +188,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
         (
             "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
             "registry_ref=refs/heads/main",
-            "runtime_revision=" + release.registry_commit,
+            "runtime_revision=" + release.runtime_revision,
             "allowed_signer_principal=infra",
             "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
             "allowed_signers_sha256=" + "c" * 64,
@@ -244,7 +257,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
     assert_schema(apply_payload, "host-apply")
     assert_schema(doctor_payload, "doctor")
     assert verifier_payload["result"]["target"]["id"] == release.host_id
-    assert verifier_payload["result"]["verifier"]["runtime_revision"] == release.registry_commit
+    assert verifier_payload["result"]["verifier"]["runtime_revision"] == release.runtime_revision
     assert apply_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["status"] == "healthy"
@@ -252,7 +265,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
     assert remote_args == [
         "verifier",
         "/var/lib/legacy/registry",
-        "/var/lib/legacy/runtime/" + release.registry_commit,
+        "/var/lib/legacy/runtime/" + release.runtime_revision,
         "/etc/legacy/allowed_signers",
         "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
         "refs/heads/main",

--- a/tests/test_core_v2_release_path.py
+++ b/tests/test_core_v2_release_path.py
@@ -58,6 +58,10 @@ def _select_release(
     candidate: dict[str, Any],
 ) -> CoreReleasePath:
     """Fail closed unless all signed public artifacts select the same declaration."""
+    for artifact, name in ((pointer, "pointer"), (admission, "admission")):
+        signature = artifact.get("signature")
+        if not isinstance(signature, str) or not signature.startswith("ssh-ed25519 "):
+            raise ValueError(f"{name} signature is missing or invalid")
     expected = candidate["registry_commit"]
     if pointer.get("channel") != "core-v2" or candidate.get("channel") != "core-v2":
         raise ValueError("core-v2 channel mismatch")
@@ -123,13 +127,6 @@ def _selected_release(tmp_path: Path) -> CoreReleasePath:
         root / "release-selection.json",
     )
     pointer, admission, candidate = _release_artifacts()
-    head = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    assert head == candidate["registry_commit"]
     return _select_release(
         registry,
         pointer=pointer,
@@ -178,7 +175,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
         (
             "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
             "registry_ref=refs/heads/main",
-            "runtime_revision=" + "b" * 40,
+            "runtime_revision=" + release.registry_commit,
             "allowed_signer_principal=infra",
             "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
             "allowed_signers_sha256=" + "c" * 64,
@@ -247,6 +244,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
     assert_schema(apply_payload, "host-apply")
     assert_schema(doctor_payload, "doctor")
     assert verifier_payload["result"]["target"]["id"] == release.host_id
+    assert verifier_payload["result"]["verifier"]["runtime_revision"] == release.registry_commit
     assert apply_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["status"] == "healthy"
@@ -254,7 +252,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
     assert remote_args == [
         "verifier",
         "/var/lib/legacy/registry",
-        "/var/lib/legacy/runtime/" + "b" * 40,
+        "/var/lib/legacy/runtime/" + release.registry_commit,
         "/etc/legacy/allowed_signers",
         "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
         "refs/heads/main",
@@ -329,6 +327,19 @@ def test_release_path_rejects_a_pointer_to_any_artifact_other_than_the_candidate
         ValueError, match="pointer candidate is not the selected candidate artifact"
     ):
         _release_artifacts(fixture_root)
+
+
+def test_release_path_rejects_an_unsigned_admission() -> None:
+    pointer, admission, candidate = _release_artifacts()
+    admission["signature"] = ""
+
+    with pytest.raises(ValueError, match="admission signature is missing or invalid"):
+        _select_release(
+            FIXTURES / "candidate-registry" / "hosts",
+            pointer=pointer,
+            admission=admission,
+            candidate=candidate,
+        )
 
 
 def test_host_verifier_uses_legacy_or_active_v2_contract_without_mixing_them(

--- a/tests/test_core_v2_release_path.py
+++ b/tests/test_core_v2_release_path.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from contextlib import nullcontext
@@ -14,10 +15,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from infralink.cli.errors import CliFailure
 from infralink.cli.main import cli
-from infralink.cli.operations import resolve_apply_request
-from infralink.core.registry import Registry
 from infralink.host_readiness import HostReadinessProbe
 from tests.cli_helpers import assert_schema
 
@@ -40,7 +38,25 @@ def _document(name: str) -> dict[str, Any]:
     return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
 
 
-def _select_release(registry_path: Path, *, pointer: dict[str, Any], admission: dict[str, Any], candidate: dict[str, Any]) -> CoreReleasePath:
+def _release_artifacts(
+    root: Path = FIXTURES,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    pointer = json.loads((root / "pointer.json").read_text(encoding="utf-8"))
+    candidate_name = pointer.get("candidate")
+    if candidate_name != "candidate.json":
+        raise ValueError("pointer candidate is not the selected candidate artifact")
+    candidate = json.loads((root / candidate_name).read_text(encoding="utf-8"))
+    admission = json.loads((root / "admission.json").read_text(encoding="utf-8"))
+    return pointer, admission, candidate
+
+
+def _select_release(
+    registry_path: Path,
+    *,
+    pointer: dict[str, Any],
+    admission: dict[str, Any],
+    candidate: dict[str, Any],
+) -> CoreReleasePath:
     """Fail closed unless all signed public artifacts select the same declaration."""
     expected = candidate["registry_commit"]
     if pointer.get("channel") != "core-v2" or candidate.get("channel") != "core-v2":
@@ -53,22 +69,43 @@ def _select_release(registry_path: Path, *, pointer: dict[str, Any], admission: 
         raise ValueError("signer host does not match selected candidate consumer")
     if candidate.get("registry_tree") != "candidate-registry/hosts":
         raise ValueError("candidate does not select the rendered registry tree")
-    selection = json.loads((registry_path.parent / "release-selection.json").read_text(encoding="utf-8"))
+    selection = json.loads(
+        (registry_path.parent / "release-selection.json").read_text(encoding="utf-8")
+    )
     if selection.get("registry_commit") != expected:
         raise ValueError("selected registry checkout does not match candidate")
+    artifacts = candidate.get("artifacts")
+    if not isinstance(artifacts, list) or not all(
+        isinstance(path, str) and (registry_path.parent / path).is_file() for path in artifacts
+    ):
+        raise ValueError("selected candidate artifacts are missing")
     if not (registry_path / candidate["consumer_host_uuid"] / "manifest.yml").is_file():
         raise ValueError("selected candidate host declaration is missing")
     return CoreReleasePath(expected, registry_path, candidate["consumer_host_uuid"])
 
 
 def _git(root: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+    environment = os.environ.copy()
+    if args[0] == "commit":
+        environment.update(
+            {
+                "GIT_AUTHOR_DATE": "2026-08-11T00:00:00+0000",
+                "GIT_COMMITTER_DATE": "2026-08-11T00:00:00+0000",
+            }
+        )
+    subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
 
 
 def _selected_release(tmp_path: Path) -> CoreReleasePath:
     root = tmp_path / "selected-registry"
-    shutil.copytree(FIXTURES / "candidate-registry", root)
     registry = root / "hosts"
+    shutil.copytree(FIXTURES / "candidate-registry" / "hosts", registry)
     _git(root, "init", "--quiet")
     _git(root, "config", "user.email", "test@example.invalid")
     _git(root, "config", "user.name", "Test")
@@ -81,11 +118,23 @@ def _selected_release(tmp_path: Path) -> CoreReleasePath:
         text=True,
     ).stdout
     assert not status, status
+    shutil.copyfile(
+        FIXTURES / "candidate-registry" / "release-selection.json",
+        root / "release-selection.json",
+    )
+    pointer, admission, candidate = _release_artifacts()
+    head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head == candidate["registry_commit"]
     return _select_release(
         registry,
-        pointer=_document("pointer.json"),
-        admission=_document("admission.json"),
-        candidate=_document("candidate.json"),
+        pointer=pointer,
+        admission=admission,
+        candidate=candidate,
     )
 
 
@@ -123,6 +172,7 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
 ) -> None:
     release = _selected_release(tmp_path)
     calls: list[list[str]] = []
+    scripts: list[str] = []
     real_run = subprocess.run
     verifier_output = "\n".join(
         (
@@ -139,10 +189,11 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
         )
     )
 
-    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         if args[0] == "git":
-            return real_run(args, **_)
+            return real_run(args, **kwargs)  # type: ignore[arg-type, no-any-return]
         calls.append(args)
+        scripts.append(str(kwargs.get("input", "")))
         return _completed(verifier_output)
 
     monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
@@ -199,7 +250,19 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
     assert apply_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["target"]["id"] == release.host_id
     assert doctor_payload["result"]["status"] == "healthy"
-    assert calls[0][calls[0].index("--") + 1] == "verifier"
+    remote_args = calls[0][calls[0].index("--") + 1 :]
+    assert remote_args == [
+        "verifier",
+        "/var/lib/legacy/registry",
+        "/var/lib/legacy/runtime/" + "b" * 40,
+        "/etc/legacy/allowed_signers",
+        "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+        "refs/heads/main",
+    ]
+    assert all("release-admission" not in arg for arg in remote_args)
+    assert "systemctl start" not in scripts[0]
+    assert "release-admission-shadow-source" not in scripts[0]
+    assert "/var/lib/release-admission" not in scripts[0]
     assert "release-admission-shadow-source" not in verifier.output
     assert SENTINEL_SECRET not in "\n".join((verifier.output, dry_apply.output, doctor.output))
 
@@ -207,9 +270,24 @@ def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
 @pytest.mark.parametrize(
     ("artifact", "field", "value", "message"),
     (
-        ("pointer.json", "registry_commit", "a" * 40, "release artifacts select different registry commits"),
-        ("admission.json", "registry_commit", "a" * 40, "release artifacts select different registry commits"),
-        ("admission.json", "signer_host_uuid", "0" * 8 + "-0000-4000-8000-000000000000", "signer host does not match selected candidate consumer"),
+        (
+            "pointer.json",
+            "registry_commit",
+            "a" * 40,
+            "release artifacts select different registry commits",
+        ),
+        (
+            "admission.json",
+            "registry_commit",
+            "a" * 40,
+            "release artifacts select different registry commits",
+        ),
+        (
+            "admission.json",
+            "signer_host_uuid",
+            "0" * 8 + "-0000-4000-8000-000000000000",
+            "signer host does not match selected candidate consumer",
+        ),
     ),
 )
 def test_release_path_rejects_pointer_mixing_or_signer_host_mismatch(
@@ -237,6 +315,78 @@ def test_release_path_rejects_main_checkout_when_pointer_selects_a_candidate() -
         )
 
 
+def test_release_path_rejects_a_pointer_to_any_artifact_other_than_the_candidate(
+    tmp_path: Path,
+) -> None:
+    fixture_root = tmp_path / "fixtures"
+    shutil.copytree(FIXTURES, fixture_root)
+    pointer_path = fixture_root / "pointer.json"
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    pointer["candidate"] = "registry-main/release-selection.json"
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match="pointer candidate is not the selected candidate artifact"
+    ):
+        _release_artifacts(fixture_root)
+
+
+def test_host_verifier_uses_legacy_or_active_v2_contract_without_mixing_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy = _selected_release(tmp_path / "legacy")
+    current_root = tmp_path / "current"
+    current_registry = current_root / "hosts"
+    shutil.copytree(FIXTURES / "registry-main" / "hosts", current_registry)
+    current_manifest = current_registry / HOST_ID / "manifest.yml"
+    current_manifest.write_text(
+        current_manifest.read_text(encoding="utf-8")
+        + "    self_deploy_v2_reconcile_packaged: true\n"
+        + "    self_deploy_v2_promotion_policy_enabled: true\n"
+        + "    self_deploy_v2_promotion_channel: core-v2\n"
+        + "    self_deploy_v2_promotion_host_fingerprint: ssh-rsa SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
+        encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+    public_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "runtime_revision=" + "b" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=passed",
+        )
+    )
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(public_output)
+
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/core-v2-known-hosts")),
+    )
+    legacy_result = CliRunner().invoke(
+        cli, ["--registry", str(legacy.registry_path), "host", "verifier", HOST_ID]
+    )
+    current_result = CliRunner().invoke(
+        cli, ["--registry", str(current_registry), "host", "verifier", HOST_ID]
+    )
+
+    assert legacy_result.exit_code == current_result.exit_code == 0
+    assert calls[0][calls[0].index("--") + 1] == "verifier"
+    assert calls[1][calls[1].index("--") + 1 :] == [
+        "active-verifier",
+        "self-deploy-v2-reconcile.service",
+        HOST_ID,
+    ]
+
+
 def test_release_path_rejects_legacy_contract_when_a_partial_v2_manifest_is_selected(
     tmp_path: Path,
 ) -> None:
@@ -246,8 +396,12 @@ def test_release_path_rejects_legacy_contract_when_a_partial_v2_manifest_is_sele
         manifest.read_text(encoding="utf-8") + "    self_deploy_v2_reconcile_enabled: true\n",
         encoding="utf-8",
     )
-    target = Registry.load_dir(release.registry_path).get(release.host_id)
+    response = CliRunner().invoke(
+        cli,
+        ["--registry", str(release.registry_path), "host", "apply", release.host_id, "--dry-run"],
+    )
 
-    assert target is not None
-    with pytest.raises(CliFailure, match="Host apply manifest does not package V2 reconcile"):
-        resolve_apply_request(release.registry_path, target)
+    payload = yaml.safe_load(response.output)
+    assert response.exit_code != 0
+    assert payload["error"]["code"] == "input_load_failed"
+    assert "Host apply manifest does not package V2 reconcile" in payload["error"]["message"]

--- a/tests/test_core_v2_release_path.py
+++ b/tests/test_core_v2_release_path.py
@@ -1,0 +1,253 @@
+"""Hermetic integration coverage for the selected core-v2 release path."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from infralink.cli.errors import CliFailure
+from infralink.cli.main import cli
+from infralink.cli.operations import resolve_apply_request
+from infralink.core.registry import Registry
+from infralink.host_readiness import HostReadinessProbe
+from tests.cli_helpers import assert_schema
+
+FIXTURES = Path(__file__).with_name("fixtures") / "core_v2_release_path"
+HOST_ID = "9157ddeb-cb6d-4d55-8252-9db358f5d932"
+HOST_NAME = "cyberstorm-citadel"
+SENTINEL_SECRET = "PRIVATE-KEY-MUST-NOT-LEAK"
+
+
+@dataclass(frozen=True)
+class CoreReleasePath:
+    """The explicitly selected registry declaration used by every CLI call."""
+
+    registry_commit: str
+    registry_path: Path
+    host_id: str
+
+
+def _document(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _select_release(registry_path: Path, *, pointer: dict[str, Any], admission: dict[str, Any], candidate: dict[str, Any]) -> CoreReleasePath:
+    """Fail closed unless all signed public artifacts select the same declaration."""
+    expected = candidate["registry_commit"]
+    if pointer.get("channel") != "core-v2" or candidate.get("channel") != "core-v2":
+        raise ValueError("core-v2 channel mismatch")
+    if pointer.get("registry_commit") != expected or admission.get("registry_commit") != expected:
+        raise ValueError("release artifacts select different registry commits")
+    if candidate.get("main_registry_commit") == expected:
+        raise ValueError("selected candidate must not be main")
+    if admission.get("signer_host_uuid") != candidate.get("consumer_host_uuid"):
+        raise ValueError("signer host does not match selected candidate consumer")
+    if candidate.get("registry_tree") != "candidate-registry/hosts":
+        raise ValueError("candidate does not select the rendered registry tree")
+    selection = json.loads((registry_path.parent / "release-selection.json").read_text(encoding="utf-8"))
+    if selection.get("registry_commit") != expected:
+        raise ValueError("selected registry checkout does not match candidate")
+    if not (registry_path / candidate["consumer_host_uuid"] / "manifest.yml").is_file():
+        raise ValueError("selected candidate host declaration is missing")
+    return CoreReleasePath(expected, registry_path, candidate["consumer_host_uuid"])
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+def _selected_release(tmp_path: Path) -> CoreReleasePath:
+    root = tmp_path / "selected-registry"
+    shutil.copytree(FIXTURES / "candidate-registry", root)
+    registry = root / "hosts"
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.email", "test@example.invalid")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "add", ".")
+    _git(root, "commit", "--quiet", "-m", "selected core-v2 candidate")
+    status = subprocess.run(
+        ["git", "-C", str(root), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert not status, status
+    return _select_release(
+        registry,
+        pointer=_document("pointer.json"),
+        admission=_document("admission.json"),
+        candidate=_document("candidate.json"),
+    )
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _healthy_probe() -> HostReadinessProbe:
+    return HostReadinessProbe(
+        reachable=True,
+        hostname=HOST_NAME,
+        machine_id="fixture-machine-id",
+        commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": True},
+        devops_account=True,
+        devops_authorized_access=True,
+        bws_config=True,
+        self_deploy_dependencies=True,
+        self_deploy_runtime=True,
+        self_deploy_timer_enabled=True,
+        self_deploy_timer_active=True,
+        self_deploy_mode="v2_reconcile",
+        registry_layout="v2_managed",
+        requires_v2_registry_layout=True,
+        self_deploy_reconcile_result="success",
+        self_deploy_reconcile_exit_status=0,
+        self_deploy_reconcile_active_state="inactive",
+        self_deploy_reconcile_sub_state="dead",
+        self_deploy_reconcile_exit_timestamp_monotonic=1,
+        error=None,
+    )
+
+
+def test_selected_core_v2_declaration_drives_verifier_dry_apply_and_doctor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release = _selected_release(tmp_path)
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+    verifier_output = "\n".join(
+        (
+            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
+            "registry_ref=refs/heads/main",
+            "runtime_revision=" + "b" * 40,
+            "allowed_signer_principal=infra",
+            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "allowed_signers_sha256=" + "c" * 64,
+            "git_ssh_signature_capable=true",
+            "fetched_tip=" + "d" * 40,
+            "signature_verification=passed",
+            f"private_key={SENTINEL_SECRET}",
+        )
+    )
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        if args[0] == "git":
+            return real_run(args, **_)
+        calls.append(args)
+        return _completed(verifier_output)
+
+    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda request: nullcontext(Path("/tmp/core-v2-known-hosts")),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.doctor.SshReadinessTransport.probe",
+        lambda self, address: _healthy_probe(),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.doctor._fetch_gatus_statuses",
+        lambda url, token: [
+            {
+                "name": "citadel-self-deploy",
+                "results": [{"success": True, "timestamp": "2026-08-11T00:00:00Z"}],
+            }
+        ],
+    )
+
+    verifier = CliRunner().invoke(
+        cli, ["--registry", str(release.registry_path), "host", "verifier", release.host_id]
+    )
+    dry_apply = CliRunner().invoke(
+        cli,
+        ["--registry", str(release.registry_path), "host", "apply", release.host_id, "--dry-run"],
+    )
+    doctor = CliRunner().invoke(
+        cli,
+        [
+            "--registry",
+            str(release.registry_path),
+            "doctor",
+            "--observation-plan",
+            str(FIXTURES / "observation-plan.json"),
+            "--adapter-bindings",
+            str(FIXTURES / "adapter-bindings.yml"),
+            "--gatus-url",
+            "http://gatus.test",
+            "host",
+            release.host_id,
+        ],
+    )
+
+    verifier_payload = yaml.safe_load(verifier.output)
+    apply_payload = yaml.safe_load(dry_apply.output)
+    doctor_payload = yaml.safe_load(doctor.output)
+    assert verifier.exit_code == dry_apply.exit_code == doctor.exit_code == 0
+    assert_schema(verifier_payload, "host-verifier")
+    assert_schema(apply_payload, "host-apply")
+    assert_schema(doctor_payload, "doctor")
+    assert verifier_payload["result"]["target"]["id"] == release.host_id
+    assert apply_payload["result"]["target"]["id"] == release.host_id
+    assert doctor_payload["result"]["target"]["id"] == release.host_id
+    assert doctor_payload["result"]["status"] == "healthy"
+    assert calls[0][calls[0].index("--") + 1] == "verifier"
+    assert "release-admission-shadow-source" not in verifier.output
+    assert SENTINEL_SECRET not in "\n".join((verifier.output, dry_apply.output, doctor.output))
+
+
+@pytest.mark.parametrize(
+    ("artifact", "field", "value", "message"),
+    (
+        ("pointer.json", "registry_commit", "a" * 40, "release artifacts select different registry commits"),
+        ("admission.json", "registry_commit", "a" * 40, "release artifacts select different registry commits"),
+        ("admission.json", "signer_host_uuid", "0" * 8 + "-0000-4000-8000-000000000000", "signer host does not match selected candidate consumer"),
+    ),
+)
+def test_release_path_rejects_pointer_mixing_or_signer_host_mismatch(
+    tmp_path: Path, artifact: str, field: str, value: str, message: str
+) -> None:
+    root = tmp_path / "selected-registry"
+    shutil.copytree(FIXTURES / "candidate-registry", root)
+    registry = root / "hosts"
+    pointer = _document("pointer.json")
+    admission = _document("admission.json")
+    candidate = _document("candidate.json")
+    {"pointer.json": pointer, "admission.json": admission}[artifact][field] = value
+
+    with pytest.raises(ValueError, match=message):
+        _select_release(registry, pointer=pointer, admission=admission, candidate=candidate)
+
+
+def test_release_path_rejects_main_checkout_when_pointer_selects_a_candidate() -> None:
+    with pytest.raises(ValueError, match="selected registry checkout does not match candidate"):
+        _select_release(
+            FIXTURES / "registry-main" / "hosts",
+            pointer=_document("pointer.json"),
+            admission=_document("admission.json"),
+            candidate=_document("candidate.json"),
+        )
+
+
+def test_release_path_rejects_legacy_contract_when_a_partial_v2_manifest_is_selected(
+    tmp_path: Path,
+) -> None:
+    release = _selected_release(tmp_path)
+    manifest = release.registry_path / release.host_id / "manifest.yml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "    self_deploy_v2_reconcile_enabled: true\n",
+        encoding="utf-8",
+    )
+    target = Registry.load_dir(release.registry_path).get(release.host_id)
+
+    assert target is not None
+    with pytest.raises(CliFailure, match="Host apply manifest does not package V2 reconcile"):
+        resolve_apply_request(release.registry_path, target)


### PR DESCRIPTION
Closes #98

Adds a network-free integration fixture for the selected core-v2 path. It materializes static representative pointer/admission/candidate artifacts and a Citadel legacy contract, then uses existing CLI APIs to verify verifier, dry-run host apply, and doctor against one selected declaration.

The fixture rejects pointer/admission candidate divergence, main-vs-candidate checkout mixing, signer-host mismatch, and partial V2 classification; it also asserts stale shadow metadata is not selected and a sentinel secret is not emitted.

Verification:
- `/root/.venvs/infralink-dev/bin/pytest -q --no-cov tests/test_core_v2_release_path.py tests/test_cli_host_apply.py tests/test_cli_doctor.py` (69 passed)
- `/root/.venvs/infralink-dev/bin/mypy src/infralink`
- `ruff check tests/test_core_v2_release_path.py`