### PR TITLE
feat(cli): refresh legacy controller through host bootstrap

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -74,6 +74,8 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "enable_self_deploy_timer",
     }
 )
+_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "b10333f45d4a2d0687fd7ac2aa9b7e016fac072e"
+_CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 
 
 class Context:
@@ -279,7 +281,7 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         "examples": ["infralink host show host-1"],
     },
     ("host", "bootstrap"): {
-        "description": "Plan host bootstrap actions without applying them.",
+        "description": "Plan host bootstrap actions or refresh a failed V2 controller.",
         "arguments": [{"name": "host_id", "type": "string", "required": True}],
         "options": [
             {"name": "plan", "type": "boolean", "required": False},
@@ -1709,11 +1711,14 @@ def host_show(
     help="Emit a read-only bootstrap plan.",
 )
 @click.option(
-    "--apply", "apply_changes", is_flag=True, help="Apply only failed host baseline actions."
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Apply failed host baseline actions or the declared V2 controller refresh.",
 )
 @pass_context
 def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: bool) -> int:
-    """Plan required host bootstrap actions without applying them."""
+    """Plan required bootstrap actions or refresh a failed V2 controller."""
     target = ctx.registry.get(host_id)
     if target is None:
         raise entity_not_found("host", host_id)
@@ -1723,7 +1728,21 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
     automated_actions = [
         item.id for item in readiness.actions if item.id in BASELINE_EXECUTOR_ACTIONS
     ]
-    if apply_changes and automated_actions:
+    refresh_controller = any(
+        item.id == "inspect_self_deploy_reconcile" for item in readiness.actions
+    )
+    controller_runtime_revision: str | None = None
+    if refresh_controller and ctx.registry_path is not None and ctx.registry_path.is_dir():
+        controller_runtime_revision, _ = _controller_refresh_extra_vars(ctx.registry_path, target)
+    if (
+        apply_changes
+        and refresh_controller
+        and ctx.registry_path is not None
+        and ctx.registry_path.is_dir()
+    ):
+        _apply_controller_refresh(ctx, target, controller_runtime_revision)
+        readiness = evaluate_host_readiness(target, SshReadinessTransport())
+    elif apply_changes and automated_actions:
         control_root = Path("/opt/infra")
         playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
         if not playbook.is_file():
@@ -1782,6 +1801,15 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         )
     ]
     if any(item.id == "inspect_self_deploy_reconcile" for item in readiness.actions):
+        if controller_runtime_revision is not None:
+            actions.append(
+                action(
+                    "refresh-controller",
+                    [*_root_source_argv(ctx), "host", "bootstrap", target.uuid, "--apply"],
+                    f"Refresh controller runtime {controller_runtime_revision}",
+                    safe=False,
+                )
+            )
         actions.append(
             action(
                 "verifier",
@@ -1801,6 +1829,164 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         )
     )
     return 0 if readiness.ready or plan_only else 1
+
+
+def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str | None) -> None:
+    """Run only the pinned controller refresh playbook over declared SSH."""
+    from infralink.cli.operations import _pinned_known_hosts, resolve_apply_request
+
+    if ctx.registry_path is None or not ctx.registry_path.is_dir():
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Controller refresh requires a directory registry checkout",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Provide the selected registry hosts directory",
+            details={"host": target.uuid},
+        )
+    request = resolve_apply_request(ctx.registry_path, target)
+    resolved_runtime_revision, extra_vars = _controller_refresh_extra_vars(
+        ctx.registry_path, target
+    )
+    if runtime_revision is not None and runtime_revision != resolved_runtime_revision:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected controller runtime revision changed during bootstrap",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Re-run host bootstrap --plan and apply the newly selected controller revision",
+            details={"host": target.uuid},
+        )
+    runtime_revision = resolved_runtime_revision
+    control_root = Path("/opt/infra")
+    playbook = control_root / _CONTROLLER_REFRESH_PLAYBOOK
+    if not playbook.is_file() or not _controller_refresh_capability_installed(control_root):
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Bastion controller-refresh capability is not installed",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Install infra-management including the pinned controller-refresh playbook on Bastion",
+            details={
+                "capability": "controller_refresh",
+                "required_revision": _CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION,
+            },
+        )
+    ssh_args = "-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes "
+    try:
+        with _pinned_known_hosts(request) as known_hosts:
+            completed = subprocess.run(
+                [
+                    "ansible-playbook",
+                    "-i",
+                    f"{request.address},",
+                    "-u",
+                    "root",
+                    "--ssh-common-args",
+                    ssh_args + f"-o UserKnownHostsFile={known_hosts}",
+                    str(playbook),
+                    "-e",
+                    json.dumps(extra_vars, sort_keys=True),
+                ],
+                cwd=control_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+    except (OSError, subprocess.TimeoutExpired):
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Declared host controller refresh is unavailable",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Verify the declared SSH transport and rerun host bootstrap --apply",
+            details={"host": target.uuid, "runtime_revision": runtime_revision},
+        ) from None
+    if completed.returncode != 0:
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Host controller refresh failed",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Inspect Bastion Ansible logs and rerun host bootstrap --apply",
+            details={"host": target.uuid, "runtime_revision": runtime_revision},
+        )
+
+
+def _controller_refresh_capability_installed(control_root: Path) -> bool:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(control_root),
+            "merge-base",
+            "--is-ancestor",
+            _CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION,
+            "HEAD",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _controller_refresh_extra_vars(registry_path: Path, target: Any) -> tuple[str, dict[str, Any]]:
+    """Read only the selected candidate declaration and its locked runtime SHA."""
+    lock = registry_path.parent / "operations" / "infra-management.lock"
+    try:
+        runtime_revision = lock.read_text(encoding="utf-8").strip()
+    except OSError:
+        runtime_revision = ""
+    if re.fullmatch(r"[0-9a-f]{40}", runtime_revision) is None:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected candidate does not bind an exact controller runtime revision",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Publish a selected registry candidate with operations/infra-management.lock",
+            details={"path": str(lock)},
+        )
+    manifest_path = registry_path / target.uuid / "manifest.yml"
+    try:
+        document = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        declaration = document["hosts"][target.uuid]
+    except (OSError, KeyError, TypeError, yaml.YAMLError):
+        declaration = None
+    required_true = (
+        "self_deploy_v2_reconcile_enabled",
+        "self_deploy_v2_reconcile_packaged",
+        "self_deploy_v2_promotion_policy_enabled",
+    )
+    required_strings = (
+        "self_deploy_v2_promotion_registry_remote",
+        "self_deploy_v2_promotion_bws_project_id",
+        "self_deploy_v2_registry_read_identity_secret_uuid",
+        "self_deploy_v2_promotion_host_fingerprint",
+        "self_deploy_v2_promotion_allowed_signers",
+        "self_deploy_v2_promotion_channel",
+        "self_deploy_registry_origin",
+    )
+    if (
+        not isinstance(declaration, dict)
+        or any(declaration.get(name) is not True for name in required_true)
+        or declaration.get("self_deploy_legacy_cron_enabled") is not False
+        or any(
+            not isinstance(declaration.get(name), str) or not declaration[name]
+            for name in required_strings
+        )
+    ):
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected host declaration is incomplete for controller refresh",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare the complete V2 controller inputs in the selected host manifest",
+            details={"host": target.uuid},
+        )
+    return runtime_revision, {
+        "uuid": target.uuid,
+        "canonical_name": target.canonical_name,
+        "self_deploy_v2_runtime_revision": runtime_revision,
+        "self_deploy_v2_reconcile_enabled": True,
+        "self_deploy_v2_reconcile_packaged": True,
+        "self_deploy_v2_promotion_policy_enabled": True,
+        "self_deploy_legacy_cron_enabled": False,
+        **{name: declaration[name] for name in required_strings},
+    }
 
 
 @host.command(name="verifier")

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -9,7 +9,9 @@ import os
 import re
 import subprocess
 import sys
-from collections.abc import Sequence
+import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -63,6 +65,7 @@ _INVOCATION_ARGS: ContextVar[list[str] | None] = ContextVar(
 _ENVELOPE_EMITTED: ContextVar[bool] = ContextVar("infralink_envelope_emitted", default=False)
 _DEFER_ENVELOPE: ContextVar[bool] = ContextVar("infralink_defer_envelope", default=False)
 _PENDING_ENVELOPE: ContextVar[str | None] = ContextVar("infralink_pending_envelope", default=None)
+_CONTROL_ROOT = Path("/opt/infra")
 BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
     {
         "create_devops_account",
@@ -74,7 +77,6 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "enable_self_deploy_timer",
     }
 )
-_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "09c5c0fcfd9354b179a4bf2cb2aa11247c8ab5d4"
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 
 
@@ -1743,7 +1745,7 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         _apply_controller_refresh(ctx, target, controller_runtime_revision)
         readiness = evaluate_host_readiness(target, SshReadinessTransport())
     elif apply_changes and automated_actions:
-        control_root = Path("/opt/infra")
+        control_root = _CONTROL_ROOT
         playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
         if not playbook.is_file():
             raise CliFailure(
@@ -1856,40 +1858,29 @@ def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str |
             details={"host": target.uuid},
         )
     runtime_revision = resolved_runtime_revision
-    control_root = Path("/opt/infra")
-    playbook = control_root / _CONTROLLER_REFRESH_PLAYBOOK
-    if not playbook.is_file() or not _controller_refresh_capability_installed(control_root):
-        raise CliFailure(
-            code=ErrorCode.PROVIDER_UNAVAILABLE,
-            message="Bastion controller-refresh capability is not installed",
-            exit_code=ExitCode.PROVIDER_ERROR,
-            fix="Install infra-management including the pinned controller-refresh playbook on Bastion",
-            details={
-                "capability": "controller_refresh",
-                "required_revision": _CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION,
-            },
-        )
+    control_root = _CONTROL_ROOT
     ssh_args = "-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes "
     try:
-        with _pinned_known_hosts(request) as known_hosts:
-            completed = subprocess.run(
-                [
-                    "ansible-playbook",
-                    "-i",
-                    f"{request.address},",
-                    "-u",
-                    "root",
-                    "--ssh-common-args",
-                    ssh_args + f"-o UserKnownHostsFile={known_hosts}",
-                    str(playbook),
-                    "-e",
-                    json.dumps(extra_vars, sort_keys=True),
-                ],
-                cwd=control_root,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
+        with _controller_refresh_source(control_root, runtime_revision) as source:
+            with _pinned_known_hosts(request) as known_hosts:
+                completed = subprocess.run(
+                    [
+                        "ansible-playbook",
+                        "-i",
+                        f"{request.address},",
+                        "-u",
+                        "root",
+                        "--ssh-common-args",
+                        ssh_args + f"-o UserKnownHostsFile={known_hosts}",
+                        str(source / _CONTROLLER_REFRESH_PLAYBOOK),
+                        "-e",
+                        json.dumps(extra_vars, sort_keys=True),
+                    ],
+                    cwd=source,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
     except (OSError, subprocess.TimeoutExpired):
         raise CliFailure(
             code=ErrorCode.PROVIDER_UNAVAILABLE,
@@ -1908,22 +1899,75 @@ def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str |
         )
 
 
-def _controller_refresh_capability_installed(control_root: Path) -> bool:
-    result = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(control_root),
-            "merge-base",
-            "--is-ancestor",
-            _CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION,
-            "HEAD",
-        ],
+@contextmanager
+def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Path]:
+    """Materialize the selected immutable controller tree, never the live checkout."""
+    status = subprocess.run(
+        ["git", "-C", str(control_root), "status", "--porcelain"],
         text=True,
         capture_output=True,
         check=False,
     )
-    return result.returncode == 0
+    present = subprocess.run(
+        ["git", "-C", str(control_root), "cat-file", "-e", f"{revision}^{{commit}}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if status.returncode != 0 or status.stdout or present.returncode != 0:
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Bastion cannot materialize the selected immutable controller source",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Clean and refresh the Bastion infra-management checkout at the selected revision",
+            details={"capability": "controller_refresh", "required_revision": revision},
+        )
+    with tempfile.TemporaryDirectory(prefix="infralink-controller-refresh-") as temporary:
+        source = Path(temporary) / "source"
+        created = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(control_root),
+                "worktree",
+                "add",
+                "--detach",
+                str(source),
+                revision,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        head = subprocess.run(
+            ["git", "-C", str(source), "rev-parse", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        playbook = source / _CONTROLLER_REFRESH_PLAYBOOK
+        if (
+            created.returncode != 0
+            or head.returncode != 0
+            or head.stdout.strip() != revision
+            or not playbook.is_file()
+        ):
+            raise CliFailure(
+                code=ErrorCode.PROVIDER_UNAVAILABLE,
+                message="Bastion could not materialize the selected controller source",
+                exit_code=ExitCode.PROVIDER_ERROR,
+                fix="Refresh the Bastion infra-management clone with the selected controller revision",
+                details={"capability": "controller_refresh", "required_revision": revision},
+            )
+        try:
+            yield source
+        finally:
+            subprocess.run(
+                ["git", "-C", str(control_root), "worktree", "remove", "--force", str(source)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
 
 def _controller_refresh_extra_vars(registry_path: Path, target: Any) -> tuple[str, dict[str, Any]]:

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -74,7 +74,7 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "enable_self_deploy_timer",
     }
 )
-_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "b10333f45d4a2d0687fd7ac2aa9b7e016fac072e"
+_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "b10333f7b56b726d56f6938998998369c12e554b"
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 
 

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -74,7 +74,7 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "enable_self_deploy_timer",
     }
 )
-_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "b10333f7b56b726d56f6938998998369c12e554b"
+_CONTROLLER_REFRESH_INFRA_MANAGEMENT_REVISION = "09c5c0fcfd9354b179a4bf2cb2aa11247c8ab5d4"
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 
 

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -80,6 +80,21 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 
 
+def _isolated_git_environment() -> dict[str, str]:
+    """Run controller-source Git commands without user/global replacement state."""
+    return {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/nonexistent",
+        "LANG": "C",
+        "LC_ALL": "C",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "GIT_NO_LAZY_FETCH": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+    }
+
+
 class Context:
     """CLI context object passed to commands."""
 
@@ -1907,12 +1922,14 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
         text=True,
         capture_output=True,
         check=False,
+        env=_isolated_git_environment(),
     )
     present = subprocess.run(
         ["git", "-C", str(control_root), "cat-file", "-e", f"{revision}^{{commit}}"],
         text=True,
         capture_output=True,
         check=False,
+        env=_isolated_git_environment(),
     )
     if status.returncode != 0 or status.stdout or present.returncode != 0:
         raise CliFailure(
@@ -1938,12 +1955,14 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
             text=True,
             capture_output=True,
             check=False,
+            env=_isolated_git_environment(),
         )
         head = subprocess.run(
             ["git", "-C", str(source), "rev-parse", "HEAD"],
             text=True,
             capture_output=True,
             check=False,
+            env=_isolated_git_environment(),
         )
         playbook = source / _CONTROLLER_REFRESH_PLAYBOOK
         if (
@@ -1959,15 +1978,26 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
                 fix="Refresh the Bastion infra-management clone with the selected controller revision",
                 details={"capability": "controller_refresh", "required_revision": revision},
             )
+        completed = False
         try:
             yield source
+            completed = True
         finally:
-            subprocess.run(
+            removed = subprocess.run(
                 ["git", "-C", str(control_root), "worktree", "remove", "--force", str(source)],
                 text=True,
                 capture_output=True,
                 check=False,
+                env=_isolated_git_environment(),
             )
+            if completed and removed.returncode != 0:
+                raise CliFailure(
+                    code=ErrorCode.ARTIFACT_IO_FAILED,
+                    message="Bastion could not remove the temporary controller source",
+                    exit_code=ExitCode.ARTIFACT_IO_ERROR,
+                    fix="Remove the temporary controller worktree and rerun host bootstrap --apply",
+                    details={"capability": "controller_refresh", "required_revision": revision},
+                )
 
 
 def _controller_refresh_extra_vars(registry_path: Path, target: Any) -> tuple[str, dict[str, Any]]:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -71,6 +71,42 @@ def test_controller_refresh_rejects_a_dirty_or_missing_controller_source(tmp_pat
     assert missing.value.code == ErrorCode.PROVIDER_UNAVAILABLE
 
 
+def test_controller_refresh_ignores_a_git_replacement_ref(tmp_path: Path) -> None:
+    repository, revision = _controller_source_repository(tmp_path)
+    playbook = repository / "ansible/playbooks/infralink_controller_refresh.yml"
+    playbook.write_text("unsafe replacement\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "--quiet", "-m", "replacement")
+    replacement = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "replace", revision, replacement)
+
+    with _controller_refresh_source(repository, revision) as source:
+        assert (source / "ansible/playbooks/infralink_controller_refresh.yml").read_text(
+            encoding="utf-8"
+        ) == "---\n- hosts: all\n"
+
+
+def test_controller_refresh_reports_failed_temporary_worktree_cleanup(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repository, revision = _controller_source_repository(tmp_path)
+    real_run = subprocess.run
+
+    def failing_cleanup(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[-4:-1] == ["worktree", "remove", "--force"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr="cleanup failed"
+            )
+        return real_run(args, **kwargs)  # type: ignore[arg-type, no-any-return]
+
+    monkeypatch.setattr("infralink.cli.main.subprocess.run", failing_cleanup)
+
+    with pytest.raises(CliFailure) as cleanup:
+        with _controller_refresh_source(repository, revision):
+            pass
+    assert cleanup.value.code == ErrorCode.ARTIFACT_IO_FAILED
+
+
 def test_cli_readiness_enforces_declared_v2_registry_layout_migration() -> None:
     probe = HostReadinessProbe(
         reachable=True,

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import subprocess
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -12,14 +13,62 @@ import yaml
 from click.testing import CliRunner
 
 from infralink.cli.contracts import HostBootstrapAction, HostReadinessResult
+from infralink.cli.errors import CliFailure, ErrorCode
 from infralink.cli.host_readiness import evaluate_host_readiness as evaluate_readiness
-from infralink.cli.main import BASELINE_EXECUTOR_ACTIONS, cli
+from infralink.cli.main import BASELINE_EXECUTOR_ACTIONS, _controller_refresh_source, cli
 from infralink.host_readiness import HostReadinessProbe
 
 ROOT = Path(__file__).resolve().parents[1]
 HOST_ID = "d1b9e5d5-36b0-459d-a556-96622811fbd5"
 HOST_NAME = "database.example.com"
 HOST_FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _controller_source_repository(tmp_path: Path) -> tuple[Path, str]:
+    repository = tmp_path / "infra-management"
+    playbook = repository / "ansible/playbooks/infralink_controller_refresh.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.write_text("---\n- hosts: all\n", encoding="utf-8")
+    _git(repository.parent, "init", "--quiet", str(repository))
+    _git(repository, "config", "user.email", "test@example.invalid")
+    _git(repository, "config", "user.name", "Test")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "--quiet", "-m", "controller refresh")
+    return repository, _git(repository, "rev-parse", "HEAD")
+
+
+def test_controller_refresh_materializes_an_exact_detached_source(tmp_path: Path) -> None:
+    repository, revision = _controller_source_repository(tmp_path)
+
+    with _controller_refresh_source(repository, revision) as source:
+        assert source != repository
+        assert _git(source, "rev-parse", "HEAD") == revision
+        assert (source / "ansible/playbooks/infralink_controller_refresh.yml").is_file()
+
+
+def test_controller_refresh_rejects_a_dirty_or_missing_controller_source(tmp_path: Path) -> None:
+    repository, revision = _controller_source_repository(tmp_path)
+    (repository / "dirty").write_text("not accepted", encoding="utf-8")
+
+    with pytest.raises(CliFailure) as dirty:
+        with _controller_refresh_source(repository, revision):
+            pass
+    assert dirty.value.code == ErrorCode.PROVIDER_UNAVAILABLE
+
+    (repository / "dirty").unlink()
+    with pytest.raises(CliFailure) as missing:
+        with _controller_refresh_source(repository, "a" * 40):
+            pass
+    assert missing.value.code == ErrorCode.PROVIDER_UNAVAILABLE
 
 
 def test_cli_readiness_enforces_declared_v2_registry_layout_migration() -> None:
@@ -213,7 +262,7 @@ def test_real_module_apply_failure_emits_an_envelope_and_nonzero_exit() -> None:
 def test_host_bootstrap_apply_missing_bastion_executor_is_provider_unavailable(
     monkeypatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: tmp_path)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", tmp_path)
     result = CliRunner().invoke(
         cli,
         [
@@ -271,7 +320,7 @@ def test_host_bootstrap_apply_never_sends_manual_secret_or_runtime_actions(
     playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
     playbook.parent.mkdir(parents=True)
     playbook.touch()
-    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
     calls: list[object] = []
 
     class Completed:
@@ -354,7 +403,7 @@ def test_host_bootstrap_apply_forwards_only_the_timer_action_when_it_alone_is_mi
     playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
     playbook.parent.mkdir(parents=True)
     playbook.touch()
-    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
     calls: list[object] = []
 
     class Completed:
@@ -441,7 +490,11 @@ def test_host_bootstrap_apply_refreshes_only_the_pinned_controller_runtime(
         self_deploy_reconcile_exit_status=1,
     )
     monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
+    monkeypatch.setattr(
+        "infralink.cli.main._controller_refresh_source",
+        lambda _root, _revision: nullcontext(control_root),
+    )
     monkeypatch.setattr(
         "infralink.cli.operations._pinned_known_hosts",
         lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),
@@ -594,7 +647,11 @@ def test_host_bootstrap_controller_refresh_failure_does_not_reprobe_or_start_ser
         return readiness
 
     monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", fake_readiness)
-    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
+    monkeypatch.setattr(
+        "infralink.cli.main._controller_refresh_source",
+        lambda _root, _revision: nullcontext(control_root),
+    )
     monkeypatch.setattr(
         "infralink.cli.operations._pinned_known_hosts",
         lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -7,14 +7,19 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 from click.testing import CliRunner
 
+from infralink.cli.contracts import HostBootstrapAction, HostReadinessResult
 from infralink.cli.host_readiness import evaluate_host_readiness as evaluate_readiness
 from infralink.cli.main import BASELINE_EXECUTOR_ACTIONS, cli
 from infralink.host_readiness import HostReadinessProbe
 
 ROOT = Path(__file__).resolve().parents[1]
+HOST_ID = "d1b9e5d5-36b0-459d-a556-96622811fbd5"
+HOST_NAME = "database.example.com"
+HOST_FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 
 def test_cli_readiness_enforces_declared_v2_registry_layout_migration() -> None:
@@ -382,3 +387,235 @@ def test_host_bootstrap_apply_forwards_only_the_timer_action_when_it_alone_is_mi
     assert result.exit_code == 1
     argv, _kwargs = calls[0]
     assert json.loads(argv[0][-1])["bootstrap_actions"] == ["enable_self_deploy_timer"]
+
+
+def test_host_bootstrap_apply_refreshes_only_the_pinned_controller_runtime(
+    monkeypatch, tmp_path: Path
+) -> None:
+    registry_root = tmp_path / "registry"
+    registry = registry_root / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
+        "    self_deploy_v2_promotion_channel: core-v2\n"
+        "    self_deploy_v2_promotion_policy_enabled: true\n"
+        "    self_deploy_v2_reconcile_enabled: true\n"
+        "    self_deploy_v2_reconcile_packaged: true\n"
+        "    self_deploy_legacy_cron_enabled: false\n"
+        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
+        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
+        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
+        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
+        encoding="utf-8",
+    )
+    lock = registry_root / "operations" / "infra-management.lock"
+    lock.parent.mkdir()
+    runtime_revision = "b" * 40
+    lock.write_text(runtime_revision + "\n", encoding="utf-8")
+    control_root = tmp_path / "control"
+    playbook = control_root / "ansible/playbooks/infralink_controller_refresh.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.touch()
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="inspect_self_deploy_reconcile",
+                check_id="self_deploy_reconcile",
+                description="Refresh the legacy controller runtime.",
+            )
+        ],
+        runtime_mode="legacy_pull",
+        registry_layout="legacy_nested",
+        self_deploy_reconcile_result="exit-code",
+        self_deploy_reconcile_exit_status=1,
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda args, **kwargs: (
+            calls.append((args, kwargs))
+            or subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
+    )
+
+    assert result.exit_code == 1
+    ansible_calls = [call for call in calls if call[0][0] == "ansible-playbook"]
+    assert len(ansible_calls) == 1
+    argv, kwargs = ansible_calls[0]
+    assert argv[:7] == [
+        "ansible-playbook",
+        "-i",
+        "100.64.68.83,",
+        "-u",
+        "root",
+        "--ssh-common-args",
+        "-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes "
+        f"-o UserKnownHostsFile={tmp_path / 'known_hosts'}",
+    ]
+    assert argv[7] == str(playbook)
+    assert kwargs["cwd"] == control_root
+    extra_vars = json.loads(argv[-1])
+    assert extra_vars["self_deploy_v2_runtime_revision"] == runtime_revision
+    assert extra_vars["uuid"] == HOST_ID
+    assert "bws_access_token" not in extra_vars
+    assert "BWS_ACCESS_TOKEN" not in " ".join(argv)
+
+
+def test_host_bootstrap_plan_reports_the_selected_controller_refresh_without_running_it(
+    monkeypatch, tmp_path: Path
+) -> None:
+    registry_root = tmp_path / "registry"
+    registry = registry_root / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
+        "    self_deploy_v2_promotion_channel: core-v2\n"
+        "    self_deploy_v2_promotion_policy_enabled: true\n"
+        "    self_deploy_v2_reconcile_enabled: true\n"
+        "    self_deploy_v2_reconcile_packaged: true\n"
+        "    self_deploy_legacy_cron_enabled: false\n"
+        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
+        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
+        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
+        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
+        encoding="utf-8",
+    )
+    lock = registry_root / "operations" / "infra-management.lock"
+    lock.parent.mkdir()
+    runtime_revision = "b" * 40
+    lock.write_text(runtime_revision + "\n", encoding="utf-8")
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="inspect_self_deploy_reconcile",
+                check_id="self_deploy_reconcile",
+                description="Refresh the legacy controller runtime.",
+            )
+        ],
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda *_args, **_kwargs: pytest.fail("host bootstrap --plan must not execute a runner"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--plan"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    refresh = next(item for item in payload["next_actions"] if item["rel"] == "refresh-controller")
+    assert refresh["safe"] is False
+    assert runtime_revision in refresh["description"]
+    assert refresh["command"].endswith(f"host bootstrap {HOST_ID} --apply")
+
+
+def test_host_bootstrap_controller_refresh_failure_does_not_reprobe_or_start_services(
+    monkeypatch, tmp_path: Path
+) -> None:
+    registry_root = tmp_path / "registry"
+    registry = registry_root / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
+        "    self_deploy_v2_promotion_channel: core-v2\n"
+        "    self_deploy_v2_promotion_policy_enabled: true\n"
+        "    self_deploy_v2_reconcile_enabled: true\n"
+        "    self_deploy_v2_reconcile_packaged: true\n"
+        "    self_deploy_legacy_cron_enabled: false\n"
+        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
+        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
+        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
+        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
+        encoding="utf-8",
+    )
+    lock = registry_root / "operations" / "infra-management.lock"
+    lock.parent.mkdir()
+    lock.write_text("b" * 40 + "\n", encoding="utf-8")
+    control_root = tmp_path / "control"
+    playbook = control_root / "ansible/playbooks/infralink_controller_refresh.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.touch()
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="inspect_self_deploy_reconcile",
+                check_id="self_deploy_reconcile",
+                description="Refresh the legacy controller runtime.",
+            )
+        ],
+    )
+    probes = 0
+
+    def fake_readiness(*_args: object) -> HostReadinessResult:
+        nonlocal probes
+        probes += 1
+        return readiness
+
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", fake_readiness)
+    monkeypatch.setattr("infralink.cli.main.Path", lambda _value: control_root)
+    monkeypatch.setattr(
+        "infralink.cli.operations._pinned_known_hosts",
+        lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),
+    )
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda args, **_kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0 if args[0] == "git" else 1,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
+    )
+
+    assert result.exit_code == 4
+    payload = json.loads(result.output)
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert payload["error"]["details"]["host"] == HOST_ID
+    assert probes == 1


### PR DESCRIPTION
Implements the CLI half of #100.

- `host bootstrap --plan` resolves the selected candidate runtime from `operations/infra-management.lock` and links the explicit refresh action.
- `--apply` invokes only the pinned infra-management `infralink_controller_refresh.yml` through declared root SSH with a temporary pinned known_hosts file.
- No BWS token or secret is passed as an extra variable. The target reads its existing local BWS environment.
- The infra-management capability dependency is pinned at `b10333f45d4a2d0687fd7ac2aa9b7e016fac072e`; the CLI fails closed if Bastion lacks it.
- A successful refresh returns to verifier/explicit `host apply`; it does not reconcile services itself.

Validation:
- focused bootstrap runner tests
- CLI contract/discovery/secret-boundary suites (149 tests)
- Ruff + mypy