### PR TITLE
fix: bind V2 bootstrap actions to declared state

### DIFF
--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -61,6 +61,75 @@ class Action(ContractModel):
     bindings: dict[str, Binding] = Field(default_factory=dict, exclude_if=lambda value: not value)
 
 
+BootstrapActionId = Literal[
+    "create_devops_account",
+    "configure_devops_authorized_access",
+    "install_docker",
+    "install_jq",
+    "install_bws_cli",
+    "install_self_deploy_dependencies",
+    "migrate_v2_registry_layout",
+    "install_self_deploy_runtime",
+    "enable_self_deploy_timer",
+]
+
+
+class HostBootstrapV2State(ContractModel):
+    """The declared V2 state that a baseline executor may materialize."""
+
+    self_deploy_v2_runtime_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    self_deploy_legacy_cron_enabled: Literal[False]
+    self_deploy_registry_origin: str = Field(
+        pattern=r"^https?://[^/@:?#\s\[\]]+(?::[0-9]{1,5})?/[^?#\s]*$"
+    )
+    self_deploy_v2_promotion_allowed_signers: str = Field(min_length=1, max_length=4096)
+    self_deploy_v2_promotion_bws_project_id: str = Field(
+        pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    )
+    self_deploy_v2_promotion_channel: str = Field(pattern=r"^[a-z0-9][a-z0-9-]{0,62}$")
+    self_deploy_v2_promotion_host_fingerprint: str = Field(min_length=1, max_length=1024)
+    self_deploy_v2_promotion_policy_enabled: Literal[True]
+    self_deploy_v2_promotion_registry_remote: str = Field(min_length=1, max_length=1024)
+    self_deploy_v2_reconcile_enabled: Literal[True]
+    self_deploy_v2_reconcile_packaged: Literal[True]
+    self_deploy_v2_registry_read_identity_secret_uuid: str = Field(
+        pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    )
+
+
+class HostBootstrapRequest(ContractModel):
+    """Bounded control-plane input for one declared baseline executor invocation."""
+
+    host_address: str = Field(min_length=1, max_length=255)
+    host_uuid: str = Field(
+        pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    )
+    canonical_name: str = Field(min_length=1, max_length=255)
+    bootstrap_actions: list[BootstrapActionId] = Field(min_length=1, max_length=9)
+    v2: HostBootstrapV2State | None = None
+
+    @model_validator(mode="after")
+    def require_v2_state_for_v2_materialization(self) -> HostBootstrapRequest:
+        if (
+            {"migrate_v2_registry_layout", "install_self_deploy_runtime"}
+            & set(self.bootstrap_actions)
+        ) and self.v2 is None:
+            raise ValueError("V2 bootstrap actions require declared V2 state")
+        return self
+
+    def ansible_extra_vars(self) -> dict[str, Any]:
+        """Flatten the exact approved input shape expected by the executor."""
+        values: dict[str, Any] = {
+            "host_address": self.host_address,
+            "host_uuid": self.host_uuid,
+            "canonical_name": self.canonical_name,
+            "bootstrap_actions": self.bootstrap_actions,
+        }
+        if self.v2 is not None:
+            values.update(self.v2.model_dump())
+        return values
+
+
 class CommandContext(ContractModel):
     raw: str
     parsed: dict[str, Any]

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1784,6 +1784,7 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         _apply_controller_refresh(ctx, target, controller_runtime_revision)
         readiness = evaluate_host_readiness(target, SshReadinessTransport())
     elif apply_changes and automated_actions:
+        request = _bootstrap_apply_request(ctx, target, automated_actions)
         control_root = _CONTROL_ROOT
         playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
         if not playbook.is_file():
@@ -1794,7 +1795,6 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
                 fix="Install the current infra-management host-bootstrap capability on Bastion",
                 details={"capability": "host_bootstrap"},
             )
-        request = _bootstrap_apply_request(ctx, target, automated_actions)
         completed = subprocess.run(
             [
                 "ansible-playbook",

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1762,9 +1762,7 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
     readiness = evaluate_host_readiness(target, SshReadinessTransport())
     if plan_only == apply_changes:
         raise click.UsageError("pass exactly one of --plan or --apply")
-    v2_bootstrap_declared = bool(
-        getattr(target, "self_deploy_v2_registry_layout_enabled", False)
-    )
+    v2_bootstrap_declared = bool(getattr(target, "self_deploy_v2_registry_layout_enabled", False))
     automated_actions = [
         item.id
         for item in readiness.actions
@@ -1921,12 +1919,16 @@ def _bootstrap_apply_request(
         ) from None
 
 
-def _bootstrap_failure_details(host_uuid: str, completed: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+def _bootstrap_failure_details(
+    host_uuid: str, completed: subprocess.CompletedProcess[str]
+) -> dict[str, Any]:
     """Expose only bounded Ansible task labels, never raw controller output."""
     task_labels = [
         match.group(1)
         for match in re.finditer(r"^TASK \[([^\]]+)\]", completed.stdout, flags=re.MULTILINE)
-        if not re.search(r"(?:secret|token|password|credential|authorization)", match.group(1), re.I)
+        if not re.search(
+            r"(?:secret|token|password|credential|authorization)", match.group(1), re.I
+        )
     ]
     details: dict[str, Any] = {
         "host": host_uuid,

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1763,6 +1763,13 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
     if plan_only == apply_changes:
         raise click.UsageError("pass exactly one of --plan or --apply")
     v2_bootstrap_declared = bool(getattr(target, "self_deploy_v2_registry_layout_enabled", False))
+    required_v2_actions = (
+        [item.id for item in readiness.actions if item.id in _V2_BOOTSTRAP_ACTIONS]
+        if v2_bootstrap_declared
+        else []
+    )
+    if required_v2_actions:
+        _bootstrap_apply_request(ctx, target, required_v2_actions)
     automated_actions = [
         item.id
         for item in readiness.actions
@@ -1922,21 +1929,16 @@ def _bootstrap_apply_request(
 def _bootstrap_failure_details(
     host_uuid: str, completed: subprocess.CompletedProcess[str]
 ) -> dict[str, Any]:
-    """Expose only bounded Ansible task labels, never raw controller output."""
-    task_labels = [
-        match.group(1)
-        for match in re.finditer(r"^TASK \[([^\]]+)\]", completed.stdout, flags=re.MULTILINE)
-        if not re.search(
-            r"(?:secret|token|password|credential|authorization)", match.group(1), re.I
-        )
-    ]
+    """Expose bounded execution shape only, never controller-rendered task names."""
+    task_count = min(len(re.findall(r"^TASK \[[^\]]+\]", completed.stdout, re.MULTILINE)), 8)
     details: dict[str, Any] = {
         "host": host_uuid,
         "executor": "host_baseline",
         "return_code": completed.returncode,
     }
-    if task_labels:
-        details["failed_task_context"] = task_labels[-8:]
+    if task_count:
+        details["task_count"] = task_count
+        details["task_output_redacted"] = True
     return details
 
 

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -34,6 +34,8 @@ from infralink.cli.contracts import (
     HelpResult,
     HelpSubcommand,
     HostBootstrapPlanResult,
+    HostBootstrapRequest,
+    HostBootstrapV2State,
     InfoResult,
     InfoSources,
     InfoSummary,
@@ -76,7 +78,12 @@ BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
         "install_bws_cli",
         "install_self_deploy_dependencies",
         "enable_self_deploy_timer",
+        "migrate_v2_registry_layout",
+        "install_self_deploy_runtime",
     }
+)
+_V2_BOOTSTRAP_ACTIONS: frozenset[str] = frozenset(
+    {"migrate_v2_registry_layout", "install_self_deploy_runtime"}
 )
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 _CONTROLLER_REFRESH_SOURCE_REMOTE = "https://github.com/relax-dot-gg/infra-management.git"
@@ -1755,8 +1762,14 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
     readiness = evaluate_host_readiness(target, SshReadinessTransport())
     if plan_only == apply_changes:
         raise click.UsageError("pass exactly one of --plan or --apply")
+    v2_bootstrap_declared = bool(
+        getattr(target, "self_deploy_v2_registry_layout_enabled", False)
+    )
     automated_actions = [
-        item.id for item in readiness.actions if item.id in BASELINE_EXECUTOR_ACTIONS
+        item.id
+        for item in readiness.actions
+        if item.id in BASELINE_EXECUTOR_ACTIONS
+        and (item.id not in _V2_BOOTSTRAP_ACTIONS or v2_bootstrap_declared)
     ]
     refresh_controller = any(
         item.id == "inspect_self_deploy_reconcile" for item in readiness.actions
@@ -1783,31 +1796,17 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
                 fix="Install the current infra-management host-bootstrap capability on Bastion",
                 details={"capability": "host_bootstrap"},
             )
-        address = target.tailscale_ip or target.public_ip
-        if not address:
-            raise CliFailure(
-                code=ErrorCode.CONFIGURATION_REQUIRED,
-                message="Host address is required for bootstrap",
-                exit_code=ExitCode.INPUT_ERROR,
-                fix="Declare a Tailscale or public address for the host",
-                details={"host": target.uuid},
-            )
+        request = _bootstrap_apply_request(ctx, target, automated_actions)
         completed = subprocess.run(
             [
                 "ansible-playbook",
                 "-i",
-                f"{address},",
+                f"{request.host_address},",
                 "-u",
                 "root",
                 str(playbook),
                 "-e",
-                f"host_address={address}",
-                "-e",
-                f"host_uuid={target.uuid}",
-                "-e",
-                f"canonical_name={target.canonical_name}",
-                "-e",
-                json.dumps({"bootstrap_actions": automated_actions}),
+                json.dumps(request.ansible_extra_vars(), sort_keys=True),
             ],
             cwd=control_root,
             text=True,
@@ -1819,8 +1818,8 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
                 code=ErrorCode.PROVIDER_UNAVAILABLE,
                 message="Host baseline apply failed",
                 exit_code=ExitCode.PROVIDER_ERROR,
-                fix="Inspect Bastion Ansible logs and rerun host bootstrap --apply",
-                details={"host": target.uuid},
+                fix="Verify the declared bootstrap executor and rerun host bootstrap --apply",
+                details=_bootstrap_failure_details(target.uuid, completed),
             )
         readiness = evaluate_host_readiness(target, SshReadinessTransport())
     actions = [
@@ -1859,6 +1858,84 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
         )
     )
     return 0 if readiness.ready or plan_only else 1
+
+
+def _bootstrap_apply_request(
+    ctx: Context, target: Any, automated_actions: list[str]
+) -> HostBootstrapRequest:
+    """Resolve a bounded executor request before any remote mutation begins."""
+    address = target.tailscale_ip or target.public_ip
+    if not address:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Host address is required for bootstrap",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare a Tailscale or public address for the host",
+            details={"host": target.uuid},
+        )
+    try:
+        v2: HostBootstrapV2State | None = None
+        if _V2_BOOTSTRAP_ACTIONS & set(automated_actions):
+            if ctx.registry_path is None or not ctx.registry_path.is_dir():
+                raise CliFailure(
+                    code=ErrorCode.CONFIGURATION_REQUIRED,
+                    message="V2 bootstrap actions require a directory registry checkout",
+                    exit_code=ExitCode.INPUT_ERROR,
+                    fix="Provide the selected registry hosts directory with its operations lock",
+                    details={"host": target.uuid},
+                )
+            runtime_revision, desired = _controller_refresh_extra_vars(ctx.registry_path, target)
+            v2 = HostBootstrapV2State.model_validate(
+                {
+                    "self_deploy_v2_runtime_revision": runtime_revision,
+                    **{
+                        name: value
+                        for name, value in desired.items()
+                        if name
+                        not in {
+                            "uuid",
+                            "canonical_name",
+                            "self_deploy_v2_runtime_revision",
+                        }
+                    },
+                }
+            )
+        return HostBootstrapRequest.model_validate(
+            {
+                "host_address": str(address),
+                "host_uuid": target.uuid,
+                "canonical_name": target.canonical_name,
+                "bootstrap_actions": automated_actions,
+                "v2": v2,
+            }
+        )
+    except CliFailure:
+        raise
+    except ValueError:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected host declaration is incomplete for bootstrap",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare complete V2 bootstrap state and rerun host bootstrap --plan",
+            details={"host": target.uuid},
+        ) from None
+
+
+def _bootstrap_failure_details(host_uuid: str, completed: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    """Expose only bounded Ansible task labels, never raw controller output."""
+    task_labels = [
+        match.group(1)
+        for match in re.finditer(r"^TASK \[([^\]]+)\]", completed.stdout, flags=re.MULTILINE)
+        if not re.search(r"(?:secret|token|password|credential|authorization)", match.group(1), re.I)
+    ]
+    details: dict[str, Any] = {
+        "host": host_uuid,
+        "executor": "host_baseline",
+        "return_code": completed.returncode,
+    }
+    if task_labels:
+        details["failed_task_context"] = task_labels[-8:]
+    return details
 
 
 def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str | None) -> None:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -791,20 +791,34 @@ def test_host_bootstrap_apply_forwards_a_bounded_v2_request_for_es1_layout_runti
     assert len(ansible_calls) == 1
     extra_vars = json.loads(ansible_calls[0][0][-1])
     assert set(extra_vars) == {
-        "bootstrap_actions", "canonical_name", "host_address", "host_uuid",
-        "self_deploy_legacy_cron_enabled", "self_deploy_registry_origin",
-        "self_deploy_v2_promotion_allowed_signers", "self_deploy_v2_promotion_bws_project_id",
-        "self_deploy_v2_promotion_channel", "self_deploy_v2_promotion_host_fingerprint",
-        "self_deploy_v2_promotion_policy_enabled", "self_deploy_v2_promotion_registry_remote",
-        "self_deploy_v2_reconcile_enabled", "self_deploy_v2_reconcile_packaged",
-        "self_deploy_v2_registry_read_identity_secret_uuid", "self_deploy_v2_runtime_revision",
+        "bootstrap_actions",
+        "canonical_name",
+        "host_address",
+        "host_uuid",
+        "self_deploy_legacy_cron_enabled",
+        "self_deploy_registry_origin",
+        "self_deploy_v2_promotion_allowed_signers",
+        "self_deploy_v2_promotion_bws_project_id",
+        "self_deploy_v2_promotion_channel",
+        "self_deploy_v2_promotion_host_fingerprint",
+        "self_deploy_v2_promotion_policy_enabled",
+        "self_deploy_v2_promotion_registry_remote",
+        "self_deploy_v2_reconcile_enabled",
+        "self_deploy_v2_reconcile_packaged",
+        "self_deploy_v2_registry_read_identity_secret_uuid",
+        "self_deploy_v2_runtime_revision",
     }
     assert extra_vars["bootstrap_actions"] == [
-        "migrate_v2_registry_layout", "install_self_deploy_runtime", "enable_self_deploy_timer"
+        "migrate_v2_registry_layout",
+        "install_self_deploy_runtime",
+        "enable_self_deploy_timer",
     ]
     assert extra_vars["host_uuid"] == HOST_ID
     assert extra_vars["self_deploy_v2_runtime_revision"] == runtime_revision
-    assert extra_vars["self_deploy_registry_origin"] == "http://100.73.228.90:3000/relaxgg/infra-registry.git"
+    assert (
+        extra_vars["self_deploy_registry_origin"]
+        == "http://100.73.228.90:3000/relaxgg/infra-registry.git"
+    )
 
 
 def test_host_bootstrap_apply_rejects_incomplete_v2_state_before_starting_ansible(
@@ -879,7 +893,7 @@ def test_host_bootstrap_apply_failure_returns_only_bounded_safe_task_context(
             returncode=2,
             stdout=(
                 "TASK [Install jq] ********************************************************\n"
-                "fatal: [host]: FAILED! => {\"msg\": \"token=not-for-output\"}\n"
+                'fatal: [host]: FAILED! => {"msg": "token=not-for-output"}\n'
                 "TASK [Read BWS secret] ***************************************************\n"
             ),
             stderr="credential=not-for-output",

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -445,6 +445,54 @@ def test_host_bootstrap_plan_uses_the_same_failed_readiness_checks(monkeypatch) 
     assert json.loads(follow_up.output)["result"]["readiness"] == payload["result"]["readiness"]
 
 
+def test_host_bootstrap_plan_rejects_required_v2_action_with_incomplete_v2_declaration(
+    monkeypatch, tmp_path: Path
+) -> None:
+    registry = tmp_path / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        "    self_deploy_v2_registry_layout_enabled: true\n",
+        encoding="utf-8",
+    )
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="install_self_deploy_runtime",
+                check_id="self_deploy_runtime",
+                description="Install the self-deploy runtime.",
+            )
+        ],
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(registry),
+            "host",
+            "bootstrap",
+            "database.example.com",
+            "--plan",
+        ],
+    )
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["error"]["code"] == "configuration_required"
+    assert payload["error"]["details"]["path"].endswith("operations/infra-management.lock")
+
+
 def test_host_bootstrap_links_verifier_when_reconcile_failed(monkeypatch) -> None:
     monkeypatch.setattr(
         "infralink.cli.main.SshReadinessTransport.probe",
@@ -866,7 +914,7 @@ def test_host_bootstrap_apply_rejects_incomplete_v2_state_before_starting_ansibl
     assert payload["error"]["details"]["path"].endswith("operations/infra-management.lock")
 
 
-def test_host_bootstrap_apply_failure_returns_only_bounded_safe_task_context(
+def test_host_bootstrap_apply_failure_returns_only_bounded_redacted_task_count(
     monkeypatch, tmp_path: Path
 ) -> None:
     readiness = HostReadinessResult(
@@ -924,8 +972,10 @@ def test_host_bootstrap_apply_failure_returns_only_bounded_safe_task_context(
         "host": HOST_ID,
         "executor": "host_baseline",
         "return_code": 2,
-        "failed_task_context": ["Install jq"],
+        "task_count": 2,
+        "task_output_redacted": True,
     }
+    assert "Install jq" not in result.output
     assert "not-for-output" not in result.output
 
 

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -848,6 +848,7 @@ def test_host_bootstrap_apply_rejects_incomplete_v2_state_before_starting_ansibl
         ],
     )
     monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", tmp_path / "missing-controller")
     monkeypatch.setattr(
         "infralink.cli.main.subprocess.run",
         lambda *_args, **_kwargs: pytest.fail("incomplete V2 state must not start Ansible"),

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -713,6 +713,207 @@ def test_host_bootstrap_apply_forwards_only_the_timer_action_when_it_alone_is_mi
     assert json.loads(argv[0][-1])["bootstrap_actions"] == ["enable_self_deploy_timer"]
 
 
+def test_host_bootstrap_apply_forwards_a_bounded_v2_request_for_es1_layout_runtime_and_timer(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The ES1-shaped plan must reach the baseline with its required V2 state."""
+    registry_root = tmp_path / "registry"
+    registry = registry_root / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        "    self_deploy_legacy_cron_enabled: false\n"
+        "    self_deploy_v2_registry_layout_enabled: true\n"
+        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
+        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
+        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
+        "    self_deploy_v2_promotion_channel: core-v2\n"
+        "    self_deploy_v2_promotion_policy_enabled: true\n"
+        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+        "    self_deploy_v2_reconcile_enabled: true\n"
+        "    self_deploy_v2_reconcile_packaged: true\n"
+        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
+        "    self_deploy_registry_origin: http://100.73.228.90:3000/relaxgg/infra-registry.git\n",
+        encoding="utf-8",
+    )
+    runtime_revision = "b" * 40
+    operations = registry_root / "operations"
+    operations.mkdir()
+    (operations / "infra-management.lock").write_text(runtime_revision + "\n", encoding="utf-8")
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="migrate_v2_registry_layout",
+                check_id="registry_layout",
+                description="Migrate the host registry checkout to the V2-owned root.",
+            ),
+            HostBootstrapAction(
+                id="install_self_deploy_runtime",
+                check_id="self_deploy_runtime",
+                description="Install the self-deploy runtime.",
+            ),
+            HostBootstrapAction(
+                id="enable_self_deploy_timer",
+                check_id="self_deploy_timer",
+                description="Enable and start the self-deploy timer.",
+            ),
+        ],
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    control_root = tmp_path / "control"
+    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.touch()
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda args, **kwargs: (
+            calls.append((args, kwargs))
+            or subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
+    )
+
+    assert result.exit_code == 1
+    ansible_calls = [call for call in calls if call[0][0] == "ansible-playbook"]
+    assert len(ansible_calls) == 1
+    extra_vars = json.loads(ansible_calls[0][0][-1])
+    assert set(extra_vars) == {
+        "bootstrap_actions", "canonical_name", "host_address", "host_uuid",
+        "self_deploy_legacy_cron_enabled", "self_deploy_registry_origin",
+        "self_deploy_v2_promotion_allowed_signers", "self_deploy_v2_promotion_bws_project_id",
+        "self_deploy_v2_promotion_channel", "self_deploy_v2_promotion_host_fingerprint",
+        "self_deploy_v2_promotion_policy_enabled", "self_deploy_v2_promotion_registry_remote",
+        "self_deploy_v2_reconcile_enabled", "self_deploy_v2_reconcile_packaged",
+        "self_deploy_v2_registry_read_identity_secret_uuid", "self_deploy_v2_runtime_revision",
+    }
+    assert extra_vars["bootstrap_actions"] == [
+        "migrate_v2_registry_layout", "install_self_deploy_runtime", "enable_self_deploy_timer"
+    ]
+    assert extra_vars["host_uuid"] == HOST_ID
+    assert extra_vars["self_deploy_v2_runtime_revision"] == runtime_revision
+    assert extra_vars["self_deploy_registry_origin"] == "http://100.73.228.90:3000/relaxgg/infra-registry.git"
+
+
+def test_host_bootstrap_apply_rejects_incomplete_v2_state_before_starting_ansible(
+    monkeypatch, tmp_path: Path
+) -> None:
+    registry = tmp_path / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    tailscale_ip: 100.64.68.83\n"
+        "    self_deploy_v2_registry_layout_enabled: true\n",
+        encoding="utf-8",
+    )
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="install_self_deploy_runtime",
+                check_id="self_deploy_runtime",
+                description="Install the self-deploy runtime.",
+            )
+        ],
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda *_args, **_kwargs: pytest.fail("incomplete V2 state must not start Ansible"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
+    )
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["error"]["code"] == "configuration_required"
+    assert "host" not in payload["error"]["details"]
+    assert payload["error"]["details"]["path"].endswith("operations/infra-management.lock")
+
+
+def test_host_bootstrap_apply_failure_returns_only_bounded_safe_task_context(
+    monkeypatch, tmp_path: Path
+) -> None:
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(
+                id="install_jq",
+                check_id="jq",
+                description="Install jq.",
+            )
+        ],
+    )
+    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
+    control_root = tmp_path / "control"
+    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
+    playbook.parent.mkdir(parents=True)
+    playbook.touch()
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
+    monkeypatch.setattr(
+        "infralink.cli.main.subprocess.run",
+        lambda args, **_kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=2,
+            stdout=(
+                "TASK [Install jq] ********************************************************\n"
+                "fatal: [host]: FAILED! => {\"msg\": \"token=not-for-output\"}\n"
+                "TASK [Read BWS secret] ***************************************************\n"
+            ),
+            stderr="credential=not-for-output",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(ROOT / "examples" / "registry.yml"),
+            "--edges",
+            str(ROOT / "examples" / "edges.yml"),
+            "host",
+            "bootstrap",
+            "database.example.com",
+            "--apply",
+        ],
+    )
+
+    assert result.exit_code == 4
+    payload = json.loads(result.output)
+    assert payload["error"]["code"] == "provider_unavailable"
+    assert payload["error"]["details"] == {
+        "host": HOST_ID,
+        "executor": "host_baseline",
+        "return_code": 2,
+        "failed_task_context": ["Install jq"],
+    }
+    assert "not-for-output" not in result.output
+
+
 def test_host_bootstrap_apply_refreshes_only_the_pinned_controller_runtime(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #108.\n\n- sends a typed, bounded bootstrap request for declared V2 layout/runtime actions\n- resolves the locked controller revision and declared registry origin before Ansible runs\n- fails closed before remote mutation when required V2 state is absent\n- returns bounded, secret-safe Ansible task context on bootstrap failure\n\nTests: focused ES1 layout/runtime/timer boundary, missing-state preflight, and failure diagnostic coverage; ruff; mypy.