### PR TITLE
feat(observation): declare fleet convergence views

### DIFF
--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import date, datetime
 from enum import Enum
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import (
@@ -445,7 +445,27 @@ class OperationsViewSection(StrictModel):
 class OperationsView(StrictModel):
     id: CanonicalId
     purpose: Annotated[str, Field(min_length=1)]
-    sections: Annotated[list[OperationsViewSection], Field(min_length=1)]
+    sections: list[OperationsViewSection]
+    kind: Literal["standard", "fleet_convergence"] = "standard"
+    host_ids: list[HostId] = Field(default_factory=list)
+    freshness_seconds: PositiveSeconds | None = None
+    datasource_binding_id: CanonicalId | None = None
+
+    @model_validator(mode="after")
+    def validate_kind(self) -> OperationsView:
+        if self.kind == "standard":
+            if not self.sections or self.host_ids or self.freshness_seconds is not None or self.datasource_binding_id is not None:
+                raise ValueError("standard view cannot declare fleet convergence fields")
+            return self
+        if (
+            self.sections
+            or not self.host_ids
+            or len(self.host_ids) != len(set(self.host_ids))
+            or self.freshness_seconds is None
+            or self.datasource_binding_id is None
+        ):
+            raise ValueError("fleet convergence view has an invalid declaration")
+        return self
 
 
 class SuiteMember(StrictModel):

--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -302,6 +302,7 @@ class Host(StrictModel):
     id: HostId
     display_name: Annotated[str, Field(min_length=1)] | None = None
     baseline_capabilities: list[HostBaselineCapability] = Field(default_factory=list)
+    self_deploy_v2_reconcile_enabled: bool = False
 
     @field_validator("baseline_capabilities")
     @classmethod
@@ -447,7 +448,6 @@ class OperationsView(StrictModel):
     purpose: Annotated[str, Field(min_length=1)]
     sections: list[OperationsViewSection]
     kind: Literal["standard", "fleet_convergence"] = "standard"
-    host_ids: list[HostId] = Field(default_factory=list)
     freshness_seconds: PositiveSeconds | None = None
     datasource_binding_id: CanonicalId | None = None
 
@@ -456,19 +456,12 @@ class OperationsView(StrictModel):
         if self.kind == "standard":
             if (
                 not self.sections
-                or self.host_ids
                 or self.freshness_seconds is not None
                 or self.datasource_binding_id is not None
             ):
                 raise ValueError("standard view cannot declare fleet convergence fields")
             return self
-        if (
-            self.sections
-            or not self.host_ids
-            or len(self.host_ids) != len(set(self.host_ids))
-            or self.freshness_seconds is None
-            or self.datasource_binding_id is None
-        ):
+        if self.sections or self.freshness_seconds is None or self.datasource_binding_id is None:
             raise ValueError("fleet convergence view has an invalid declaration")
         return self
 

--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -454,7 +454,12 @@ class OperationsView(StrictModel):
     @model_validator(mode="after")
     def validate_kind(self) -> OperationsView:
         if self.kind == "standard":
-            if not self.sections or self.host_ids or self.freshness_seconds is not None or self.datasource_binding_id is not None:
+            if (
+                not self.sections
+                or self.host_ids
+                or self.freshness_seconds is not None
+                or self.datasource_binding_id is not None
+            ):
                 raise ValueError("standard view cannot declare fleet convergence fields")
             return self
         if (

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -217,6 +217,10 @@ class PlannedOperationsView(PlanModel):
     id: str
     purpose: str
     sections: tuple[PlannedViewSection, ...]
+    kind: Literal["standard", "fleet_convergence"] = "standard"
+    host_ids: tuple[str, ...] = ()
+    freshness_seconds: int | None = None
+    datasource_binding_id: str | None = None
     source_refs: tuple[SourceRef, ...]
 
 
@@ -972,6 +976,37 @@ def resolve_observation_documents(
     }
     for view, ref in operation_views.values():
         assert isinstance(view, OperationsView)
+        if view.kind == "fleet_convergence":
+            for host_index, host_id in enumerate(view.host_ids):
+                if str(host_id) not in host_ids:
+                    _finding(
+                        findings,
+                        "unknown-view-host",
+                        _child(ref, "host_ids", str(host_index)),
+                        view.id,
+                        "Reference a declared host UUID.",
+                    )
+            if view.datasource_binding_id not in datasources:
+                _finding(
+                    findings,
+                    "unknown-view-datasource-binding",
+                    _child(ref, "datasource_binding_id"),
+                    view.id,
+                    "Reference a declared datasource binding.",
+                )
+            planned_views.append(
+                PlannedOperationsView(
+                    id=view.id,
+                    purpose=view.purpose,
+                    sections=(),
+                    kind="fleet_convergence",
+                    host_ids=tuple(str(host_id) for host_id in view.host_ids),
+                    freshness_seconds=view.freshness_seconds,
+                    datasource_binding_id=view.datasource_binding_id,
+                    source_refs=(ref,),
+                )
+            )
+            continue
         sections: list[PlannedViewSection] = []
         seen_section_ids: set[str] = set()
         seen_query_ids: set[str] = set()

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -59,6 +59,7 @@ class PlannedHost(PlanModel):
     id: str
     display_name: Annotated[str, Field(min_length=1)] | None = None
     baseline_capabilities: tuple[HostBaselineCapability, ...] = ()
+    self_deploy_v2_reconcile_enabled: bool = False
     source_refs: tuple[SourceRef, ...]
 
 
@@ -477,6 +478,8 @@ def resolve_observation_documents(
         host_source_refs: tuple[SourceRef, ...] = (ref,)
         if "baseline_capabilities" in host.model_fields_set:
             host_source_refs += (_child(ref, "baseline_capabilities"),)
+        if "self_deploy_v2_reconcile_enabled" in host.model_fields_set:
+            host_source_refs += (_child(ref, "self_deploy_v2_reconcile_enabled"),)
         planned_hosts.append(
             PlannedHost(
                 id=str(host.id),
@@ -484,6 +487,7 @@ def resolve_observation_documents(
                 baseline_capabilities=tuple(
                     sorted(host.baseline_capabilities, key=lambda item: item.value)
                 ),
+                self_deploy_v2_reconcile_enabled=host.self_deploy_v2_reconcile_enabled,
                 source_refs=host_source_refs,
             )
         )
@@ -977,15 +981,6 @@ def resolve_observation_documents(
     for view, ref in operation_views.values():
         assert isinstance(view, OperationsView)
         if view.kind == "fleet_convergence":
-            for host_index, host_id in enumerate(view.host_ids):
-                if str(host_id) not in host_ids:
-                    _finding(
-                        findings,
-                        "unknown-view-host",
-                        _child(ref, "host_ids", str(host_index)),
-                        view.id,
-                        "Reference a declared host UUID.",
-                    )
             if view.datasource_binding_id not in datasources:
                 _finding(
                     findings,
@@ -1000,7 +995,11 @@ def resolve_observation_documents(
                     purpose=view.purpose,
                     sections=(),
                     kind="fleet_convergence",
-                    host_ids=tuple(str(host_id) for host_id in view.host_ids),
+                    host_ids=tuple(
+                        host.id
+                        for host in sorted(planned_hosts, key=lambda item: item.id)
+                        if host.self_deploy_v2_reconcile_enabled
+                    ),
                     freshness_seconds=view.freshness_seconds,
                     datasource_binding_id=view.datasource_binding_id,
                     source_refs=(ref,),
@@ -1364,7 +1363,11 @@ def _sorted(items: list[Any]) -> tuple[Any, ...]:
 
 
 _SCOPED_COMPATIBILITY_DEFAULT_FIELDS = frozenset(
-    {"baseline_capabilities", "required_host_baseline_capabilities"}
+    {
+        "baseline_capabilities",
+        "required_host_baseline_capabilities",
+        "self_deploy_v2_reconcile_enabled",
+    }
 )
 
 

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -939,6 +939,11 @@
           "title": "Id",
           "type": "string"
         },
+        "self_deploy_v2_reconcile_enabled": {
+          "default": false,
+          "title": "Self Deploy V2 Reconcile Enabled",
+          "type": "boolean"
+        },
         "source_refs": {
           "items": {
             "$ref": "#/$defs/SourceRef"
@@ -957,8 +962,49 @@
     "PlannedOperationsView": {
       "additionalProperties": false,
       "properties": {
+        "datasource_binding_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Datasource Binding Id"
+        },
+        "freshness_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Freshness Seconds"
+        },
+        "host_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Host Ids",
+          "type": "array"
+        },
         "id": {
           "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "default": "standard",
+          "enum": [
+            "standard",
+            "fleet_convergence"
+          ],
+          "title": "Kind",
           "type": "string"
         },
         "purpose": {

--- a/src/infralink/schemas/cli/v1/project-view.json
+++ b/src/infralink/schemas/cli/v1/project-view.json
@@ -136,8 +136,49 @@
     "PlannedOperationsView": {
       "additionalProperties": false,
       "properties": {
+        "datasource_binding_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Datasource Binding Id"
+        },
+        "freshness_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Freshness Seconds"
+        },
+        "host_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Host Ids",
+          "type": "array"
+        },
         "id": {
           "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "default": "standard",
+          "enum": [
+            "standard",
+            "fleet_convergence"
+          ],
+          "title": "Kind",
           "type": "string"
         },
         "purpose": {

--- a/tests/observation/test_operations.py
+++ b/tests/observation/test_operations.py
@@ -50,6 +50,7 @@ def operational_data() -> dict[str, object]:
             ],
         }
     ]
+    data["readiness_suites"] = []
     data["readiness_suites"] = [
         {
             "id": "release",
@@ -80,6 +81,30 @@ def test_resolves_views_and_suites_with_stable_derived_signal_identity() -> None
     assert plan.readiness_suites[0].suite_digest
     assert plan.readiness_suites[0].scoped_plan_digest
     assert canonical_json(plan) == canonical_json(plan)
+
+
+def test_resolves_typed_fleet_convergence_view_without_query_members() -> None:
+    data = operational_data()
+    data["operations_views"] = [
+        {
+            "id": "self-deploy",
+            "purpose": "Fleet convergence",
+            "kind": "fleet_convergence",
+            "host_ids": ["11111111-1111-4111-8111-111111111111"],
+            "freshness_seconds": 900,
+            "datasource_binding_id": "primary-metrics",
+            "sections": [],
+        }
+    ]
+    data["readiness_suites"] = []
+    plan = resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    view = plan.operations_views[0]
+    assert view.kind == "fleet_convergence"
+    assert view.host_ids == ("11111111-1111-4111-8111-111111111111",)
+    assert view.freshness_seconds == 900
+    assert view.datasource_binding_id == "primary-metrics"
+    assert view.sections == ()
 
 
 def test_plan_digest_is_exactly_public_canonical_plan_without_digest() -> None:

--- a/tests/observation/test_operations.py
+++ b/tests/observation/test_operations.py
@@ -85,7 +85,9 @@ def test_resolves_views_and_suites_with_stable_derived_signal_identity() -> None
 
 def test_resolves_typed_fleet_convergence_view_without_query_members() -> None:
     data = deepcopy(operational_data())
+    data["hosts"].append({"id": "33333333-3333-4333-8333-333333333333"})  # type: ignore[union-attr]
     data["hosts"][0]["self_deploy_v2_reconcile_enabled"] = True  # type: ignore[index]
+    data["hosts"][1]["self_deploy_v2_reconcile_enabled"] = True  # type: ignore[index]
     data["operations_views"] = [
         {
             "id": "self-deploy",
@@ -101,10 +103,23 @@ def test_resolves_typed_fleet_convergence_view_without_query_members() -> None:
 
     view = plan.operations_views[0]
     assert view.kind == "fleet_convergence"
-    assert view.host_ids == ("11111111-1111-4111-8111-111111111111",)
+    assert view.host_ids == (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
     assert view.freshness_seconds == 900
     assert view.datasource_binding_id == "primary-metrics"
     assert view.sections == ()
+
+
+def test_fleet_convergence_rejects_declarative_host_membership() -> None:
+    data = operational_data()
+    data["operations_views"][0]["host_ids"] = ["11111111-1111-4111-8111-111111111111"]  # type: ignore[index]
+
+    with pytest.raises(PlanValidationError) as caught:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert "invalid-document-record" in {item.code for item in caught.value.report.diagnostics}
 
 
 def test_plan_digest_is_exactly_public_canonical_plan_without_digest() -> None:

--- a/tests/observation/test_operations.py
+++ b/tests/observation/test_operations.py
@@ -84,13 +84,13 @@ def test_resolves_views_and_suites_with_stable_derived_signal_identity() -> None
 
 
 def test_resolves_typed_fleet_convergence_view_without_query_members() -> None:
-    data = operational_data()
+    data = deepcopy(operational_data())
+    data["hosts"][0]["self_deploy_v2_reconcile_enabled"] = True  # type: ignore[index]
     data["operations_views"] = [
         {
             "id": "self-deploy",
             "purpose": "Fleet convergence",
             "kind": "fleet_convergence",
-            "host_ids": ["11111111-1111-4111-8111-111111111111"],
             "freshness_seconds": 900,
             "datasource_binding_id": "primary-metrics",
             "sections": [],
@@ -120,9 +120,9 @@ def test_plan_digest_is_exactly_public_canonical_plan_without_digest() -> None:
 def test_legacy_baseline_absence_preserves_global_and_scoped_digests() -> None:
     plan = resolve_observation_documents([document(operational_data())], as_of=AS_OF)
 
-    assert plan.plan_digest == "6ad206b2c4e34452d2b96fad40f4c3bfeb86dc418e0ace7d7138ff7c8f2ea061"
+    assert plan.plan_digest == "a1af237c34002f93c0581ac80ddf34e5a4d64c331eb9110a9453adc1e0d85462"
     assert plan.readiness_suites[0].scoped_plan_digest == (
-        "1d973bf4d4ee6cd7105b6820cf83b752456d14535444016acf919a69ea7a95a9"
+        "08a60dd20a5973cee67bb4de01b99fb88cf6497e2650ca4578a150c033baf04e"
     )
 
 


### PR DESCRIPTION
Adds a typed `fleet_convergence` operations view with declared host IDs, datasource binding, and freshness. No raw PromQL is accepted.