### PR TITLE
fix(cli): prefer declared host controller revision

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2145,26 +2145,39 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
 
 
 def _controller_refresh_extra_vars(registry_path: Path, target: Any) -> tuple[str, dict[str, Any]]:
-    """Read only the selected candidate declaration and its locked runtime SHA."""
-    lock = registry_path.parent / "operations" / "infra-management.lock"
-    try:
-        runtime_revision = lock.read_text(encoding="utf-8").strip()
-    except OSError:
-        runtime_revision = ""
-    if re.fullmatch(r"[0-9a-f]{40}", runtime_revision) is None:
-        raise CliFailure(
-            code=ErrorCode.CONFIGURATION_REQUIRED,
-            message="Selected candidate does not bind an exact controller runtime revision",
-            exit_code=ExitCode.INPUT_ERROR,
-            fix="Publish a selected registry candidate with operations/infra-management.lock",
-            details={"path": str(lock)},
-        )
+    """Read the host controller revision, falling back to the fleet lock."""
     manifest_path = registry_path / target.uuid / "manifest.yml"
     try:
         document = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
         declaration = document["hosts"][target.uuid]
     except (OSError, KeyError, TypeError, yaml.YAMLError):
         declaration = None
+    deployment_path = registry_path / target.uuid / "operations" / "deployment.yml"
+    if deployment_path.is_file():
+        try:
+            deployment = yaml.safe_load(deployment_path.read_text(encoding="utf-8"))
+            runtime_revision = deployment["infra_management"]["revision"]
+        except (OSError, KeyError, TypeError, yaml.YAMLError):
+            runtime_revision = ""
+        revision_source = deployment_path
+    else:
+        lock = registry_path.parent / "operations" / "infra-management.lock"
+        try:
+            runtime_revision = lock.read_text(encoding="utf-8").strip()
+        except OSError:
+            runtime_revision = ""
+        revision_source = lock
+    if (
+        not isinstance(runtime_revision, str)
+        or re.fullmatch(r"[0-9a-f]{40}", runtime_revision) is None
+    ):
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected host does not bind an exact controller runtime revision",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare infra_management.revision in the host deployment or publish a valid fleet fallback lock",
+            details={"path": str(revision_source)},
+        )
     required_true = (
         "self_deploy_v2_reconcile_enabled",
         "self_deploy_v2_reconcile_packaged",

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2153,11 +2153,14 @@ def _controller_refresh_extra_vars(registry_path: Path, target: Any) -> tuple[st
     except (OSError, KeyError, TypeError, yaml.YAMLError):
         declaration = None
     deployment_path = registry_path / target.uuid / "operations" / "deployment.yml"
-    if deployment_path.is_file():
-        try:
-            deployment = yaml.safe_load(deployment_path.read_text(encoding="utf-8"))
-            runtime_revision = deployment["infra_management"]["revision"]
-        except (OSError, KeyError, TypeError, yaml.YAMLError):
+    if os.path.lexists(deployment_path):
+        if deployment_path.is_file():
+            try:
+                deployment = yaml.safe_load(deployment_path.read_text(encoding="utf-8"))
+                runtime_revision = deployment["infra_management"]["revision"]
+            except (OSError, KeyError, TypeError, yaml.YAMLError):
+                runtime_revision = ""
+        else:
             runtime_revision = ""
         revision_source = deployment_path
     else:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -1262,3 +1262,11 @@ def test_controller_refresh_prefers_the_explicit_host_runtime_over_global_lock(
     runtime_revision, _ = _controller_refresh_extra_vars(registry, target)
 
     assert runtime_revision == explicit_revision
+
+    deployment.unlink()
+    deployment.mkdir()
+    with pytest.raises(CliFailure) as malformed:
+        _controller_refresh_extra_vars(registry, target)
+
+    assert malformed.value.code == ErrorCode.CONFIGURATION_REQUIRED
+    assert malformed.value.details == {"path": str(deployment)}

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -1221,3 +1221,44 @@ def test_host_bootstrap_controller_refresh_failure_does_not_reprobe_or_start_ser
     assert payload["error"]["code"] == "provider_unavailable"
     assert payload["error"]["details"]["host"] == HOST_ID
     assert probes == 1
+
+
+def test_controller_refresh_prefers_the_explicit_host_runtime_over_global_lock(
+    tmp_path: Path,
+) -> None:
+    """A host declaration may advance without changing the fleet-wide fallback."""
+    from infralink.cli.main import _controller_refresh_extra_vars
+
+    registry_root = tmp_path / "registry"
+    registry = registry_root / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "hosts:\n"
+        f"  {HOST_ID}:\n"
+        f"    canonical_name: {HOST_NAME}\n"
+        "    self_deploy_v2_reconcile_enabled: true\n"
+        "    self_deploy_v2_reconcile_packaged: true\n"
+        "    self_deploy_v2_promotion_policy_enabled: true\n"
+        "    self_deploy_legacy_cron_enabled: false\n"
+        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
+        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
+        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
+        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
+        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
+        "    self_deploy_v2_promotion_channel: core-v2\n"
+        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
+        encoding="utf-8",
+    )
+    explicit_revision = "b" * 40
+    deployment = registry / HOST_ID / "operations" / "deployment.yml"
+    deployment.parent.mkdir()
+    deployment.write_text(f"infra_management:\n  revision: {explicit_revision}\n", encoding="utf-8")
+    lock = registry_root / "operations" / "infra-management.lock"
+    lock.parent.mkdir()
+    lock.write_text("a" * 40 + "\n", encoding="utf-8")
+    target = type("Target", (), {"uuid": HOST_ID, "canonical_name": HOST_NAME})()
+
+    runtime_revision, _ = _controller_refresh_extra_vars(registry, target)
+
+    assert runtime_revision == explicit_revision


### PR DESCRIPTION
Uses `hosts/<uuid>/operations/deployment.yml` `infra_management.revision` as the exact controller source for that host. The fleet `operations/infra-management.lock` remains a fallback only when no host deployment declaration exists. Invalid explicit declarations fail closed.\n\nRegression covers a Watchtower-shaped explicit revision overriding a stale global lock.