### PR TITLE
fix(doctor): probe active controller units

### DIFF
--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -32,7 +32,7 @@ _OPERATION_ID = re.compile(
 _LEGACY_OPERATION_ID = re.compile(r"^op_[A-Za-z0-9_-]{8,128}$")
 _FINGERPRINT = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
 _CHANNEL = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
-_UNIT = "self-deploy-v2-reconcile.service"
+_UNIT = "infralink-host-reconcile.service"
 _JOURNAL_SEPARATOR = "__INFRALINK_JOURNAL__"
 _DIAGNOSTIC_CODE = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
 _DIAGNOSTIC_STAGES = frozenset({"inspect", "validate", "plan", "apply", "verify", "record"})
@@ -140,186 +140,6 @@ fi
 printf 'signature_verification=%s\\n' "$verification"
 """
 
-_ACTIVE_VERIFIER_REMOTE = """set -eu
-unit=$1
-host_uuid=$2
-
-# The unit drop-in is the active public bootstrap contract. Do not read its
-# EnvironmentFile: it may contain credentials needed only by reconciliation.
-unit_body=$(systemctl cat "$unit" 2>/dev/null) || exit 0
-extract_public_unit_value() {
-    name=$1
-    value=$(printf '%s\\n' "$unit_body" | awk -v name="$name" '
-        $0 ~ "^Environment=\\\"" name "=" {
-            line=$0
-            sub("^Environment=\\\"" name "=", "", line)
-            if (line !~ /"$/ || seen++) exit 2
-            sub(/"$/, "", line)
-            print line
-        }
-        END { if (seen > 1) exit 2 }
-    ') || exit 2
-    printf '%s' "$value"
-}
-
-runtime=$(extract_public_unit_value SELF_DEPLOY_V2_RUNTIME_ROOT)
-origin=$(extract_public_unit_value SELF_DEPLOY_REGISTRY_ORIGIN)
-[ -n "$runtime" ] && [ -n "$origin" ] || exit 0
-case "$runtime" in
-    /var/lib/self-deploy-v2/runtime/*)
-        revision=${runtime#/var/lib/self-deploy-v2/runtime/}
-        case "$revision" in '' | *[!0-9a-f]*) exit 2 ;; esac
-        [ "${#revision}" -eq 40 ] || exit 2
-        ;;
-    *) exit 2 ;;
-esac
-[ -x "$runtime/.venv/bin/python" ] || exit 0
-
-"$runtime/.venv/bin/python" -P - "$runtime" "$origin" "$host_uuid" <<'PY'
-import hashlib
-import re
-import subprocess
-import sys
-from pathlib import Path
-from urllib.parse import urlsplit
-
-runtime = Path(sys.argv[1])
-origin = sys.argv[2]
-host_uuid = sys.argv[3]
-try:
-    from lib.self_deploy.registry_layout import REGISTRY_ROOT
-    from lib.self_deploy.release_admission_authority import (
-        ReleaseAdmissionAuthorityError,
-        _channel_pointer,
-        _trust,
-    )
-except ImportError:
-    # A pre-authority runtime cannot provide this public capability.
-    raise SystemExit(0)
-
-try:
-    parsed = urlsplit(origin)
-    if (
-        parsed.scheme not in {"http", "https"}
-        or not parsed.hostname
-        or parsed.username
-        or parsed.password
-        or parsed.query
-        or parsed.fragment
-    ):
-        raise ValueError
-    trust = _trust()
-except ReleaseAdmissionAuthorityError:
-    # The active public contract is malformed; fail closed without diagnostics.
-    raise SystemExit(2)
-except (AttributeError, TypeError):
-    # A partial or pre-authority runtime cannot provide this capability.
-    raise SystemExit(0)
-
-try:
-    if (
-        trust.host_uuid != host_uuid
-        or trust.remote != origin
-        or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", trust.channel)
-    ):
-        raise ValueError
-except AttributeError:
-    raise SystemExit(0)
-except ValueError:
-    # The active public contract is malformed; fail closed without diagnostics.
-    raise SystemExit(2)
-
-print(f"runtime_revision={runtime.name}")
-print(f"registry_remote={trust.remote}")
-print("registry_ref=refs/heads/main")
-
-try:
-    signers = trust.allowed_signers
-    if not isinstance(signers, bytes):
-        raise ValueError
-    digest = hashlib.sha256(signers).hexdigest()
-    first = next(
-        (
-            line.split()
-            for line in signers.decode("utf-8", "strict").splitlines()
-            if len(line.split()) >= 3
-        ),
-        None,
-    )
-except AttributeError:
-    # A partial authority cannot expose signer evidence.
-    raise SystemExit(0)
-except (TypeError, UnicodeError, ValueError):
-    # Present signer evidence is malformed; fail closed.
-    raise SystemExit(2)
-if first is None:
-    raise SystemExit(2)
-try:
-    rendered = subprocess.run(
-        ["ssh-keygen", "-lf", "-", "-E", "sha256"],
-        input=" ".join(first) + "\\n",
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        timeout=5,
-    )
-    fingerprint = next((part for part in rendered.stdout.split() if part.startswith("SHA256:")), "")
-except (OSError, subprocess.TimeoutExpired):
-    raise SystemExit(2)
-if rendered.returncode != 0 or not fingerprint:
-    raise SystemExit(2)
-print(f"allowed_signer_principal={first[0]}")
-print(f"allowed_signer_fingerprint={fingerprint}")
-print(f"allowed_signers_sha256={digest}")
-
-try:
-    remote = subprocess.run(
-        ["git", "-C", str(REGISTRY_ROOT), "remote", "get-url", "origin"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        timeout=5,
-    )
-    if remote.returncode != 0 or remote.stdout.strip() != trust.remote:
-        raise ValueError
-    tip = subprocess.run(
-        ["git", "-C", str(REGISTRY_ROOT), "rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        timeout=5,
-    )
-    if tip.returncode != 0 or re.fullmatch(r"[0-9a-f]{40}", tip.stdout.strip()) is None:
-        raise ValueError
-    fetched_tip = tip.stdout.strip()
-    _channel_pointer(REGISTRY_ROOT, fetched_tip, trust)
-except ReleaseAdmissionAuthorityError:
-    # A present authority rejected malformed public release data; fail closed.
-    raise SystemExit(2)
-except (OSError, subprocess.TimeoutExpired, ValueError):
-    print("git_ssh_signature_capable=false")
-    print("signature_verification=unavailable")
-    raise SystemExit(0)
-except (AttributeError, TypeError):
-    # The installed authority does not expose the required public verifier API.
-    raise SystemExit(0)
-
-version = subprocess.run(["git", "--version"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, timeout=5)
-parts = version.stdout.strip().split()
-numbers = parts[-1].split(".") if version.returncode == 0 and parts else []
-try:
-    capable = int(numbers[0]) > 2 or (int(numbers[0]) == 2 and int(numbers[1]) >= 34)
-except (IndexError, ValueError):
-    capable = False
-print(f"git_ssh_signature_capable={'true' if capable else 'false'}")
-print(f"fetched_tip={fetched_tip}")
-print("signature_verification=passed")
-PY
-"""
-
 
 @dataclass(frozen=True)
 class ApplyRequest:
@@ -333,7 +153,7 @@ class ApplyRequest:
     host_key_fingerprint: str
     unit: str
     verifier_layout: VerifierLayout | None = None
-    verifier_source: Literal["active", "legacy", "unavailable"] = "unavailable"
+    verifier_source: Literal["legacy", "unavailable"] = "unavailable"
 
 
 @dataclass(frozen=True)
@@ -394,10 +214,6 @@ class SshOperationProvider:
         """Read only the declared, public facts behind V2 Git signature verification."""
         if request.verifier_source == "unavailable":
             return HostVerifierDiagnostic(unavailable=list(_VERIFIER_UNAVAILABLE_FACTS))
-        if request.verifier_source == "active":
-            return _parse_verifier_diagnostics(
-                self._run(request, _ACTIVE_VERIFIER_REMOTE, active_verifier=True), None
-            )
         if request.verifier_layout is None:
             raise _provider_failure("Declared host verifier contract is invalid")
         return _parse_verifier_diagnostics(
@@ -412,7 +228,6 @@ class SshOperationProvider:
         invocation: str | None = None,
         *,
         verifier: VerifierLayout | None = None,
-        active_verifier: bool = False,
     ) -> dict[str, Any]:
         remote_args = (
             [
@@ -424,8 +239,6 @@ class SshOperationProvider:
                 verifier.registry_ref or "",
             ]
             if verifier is not None
-            else ["active-verifier", request.unit, request.host_uuid]
-            if active_verifier
             else [request.unit]
             if invocation is None
             else [request.unit, invocation]
@@ -465,7 +278,7 @@ class SshOperationProvider:
             ) from None
         if completed.returncode != 0:
             raise _provider_failure("Declared host rejected the reconcile operation")
-        if verifier is not None or active_verifier:
+        if verifier is not None:
             return _parse_verifier_output(completed.stdout)
         values = _parse_properties(completed.stdout)
         if not values.get("InvocationID"):
@@ -515,7 +328,7 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
         raise _registry_failure("Host apply manifest does not match the target host", manifest_path)
     manifest_request = _manifest_request(host.uuid, host.canonical_name, host_data, manifest_path)
     if manifest_request is not None:
-        return replace(manifest_request, verifier_source="active")
+        return manifest_request
     return _with_legacy_verifier_layout(
         _contract_request(registry_path, host), registry_path, host.uuid
     )

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -16,16 +16,16 @@ if id devops >/dev/null 2>&1; then printf 'devops_account=1\\n'; else printf 'de
 if test -s /home/devops/.ssh/authorized_keys; then printf 'devops_authorized_access=1\\n'; else printf 'devops_authorized_access=0\\n'; fi
 if test -r /etc/environment && grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/environment; then printf 'bws_config=1\\n'; else printf 'bws_config=0\\n'; fi
 if python3 -c 'import yaml, jinja2' >/dev/null 2>&1; then printf 'self_deploy_dependencies=1\\n'; else printf 'self_deploy_dependencies=0\\n'; fi
-if test -d /var/lib/self-deploy-v2/runtime && systemctl cat self-deploy-v2-reconcile.timer >/dev/null 2>&1; then
+if test -d /var/lib/infralink/registry && systemctl cat infralink-host-reconcile.timer >/dev/null 2>&1; then
   printf 'self_deploy_runtime=1\\nself_deploy_mode=v2_reconcile\\n'
 elif test -x /opt/infra/scripts/self-deploy.sh && test -f /etc/cron.d/self-deploy; then
   printf 'self_deploy_runtime=1\\nself_deploy_mode=legacy_pull\\n'
 else
   printf 'self_deploy_runtime=0\\nself_deploy_mode=\\n'
 fi
-if systemctl cat self-deploy-v2-reconcile.timer >/dev/null 2>&1; then
-  if systemctl is-enabled self-deploy-v2-reconcile.timer >/dev/null 2>&1; then printf 'self_deploy_timer_enabled=1\\n'; else printf 'self_deploy_timer_enabled=0\\n'; fi
-  if systemctl is-active self-deploy-v2-reconcile.timer >/dev/null 2>&1; then printf 'self_deploy_timer_active=1\\n'; else printf 'self_deploy_timer_active=0\\n'; fi
+if systemctl cat infralink-host-reconcile.timer >/dev/null 2>&1; then
+  if systemctl is-enabled infralink-host-reconcile.timer >/dev/null 2>&1; then printf 'self_deploy_timer_enabled=1\\n'; else printf 'self_deploy_timer_enabled=0\\n'; fi
+  if systemctl is-active infralink-host-reconcile.timer >/dev/null 2>&1; then printf 'self_deploy_timer_active=1\\n'; else printf 'self_deploy_timer_active=0\\n'; fi
 else
   if test -f /etc/cron.d/self-deploy; then
     printf 'self_deploy_timer_enabled=1\\nself_deploy_timer_active=1\\n'
@@ -33,12 +33,12 @@ else
     printf 'self_deploy_timer_enabled=0\\nself_deploy_timer_active=0\\n'
   fi
 fi
-if systemctl cat self-deploy-v2-reconcile.service >/dev/null 2>&1; then
-  reconcile_result="$(systemctl show self-deploy-v2-reconcile.service -p Result --value 2>/dev/null || true)"
-  reconcile_exit_status="$(systemctl show self-deploy-v2-reconcile.service -p ExecMainStatus --value 2>/dev/null || true)"
-  reconcile_active_state="$(systemctl show self-deploy-v2-reconcile.service -p ActiveState --value 2>/dev/null || true)"
-  reconcile_sub_state="$(systemctl show self-deploy-v2-reconcile.service -p SubState --value 2>/dev/null || true)"
-  reconcile_exit_timestamp_monotonic="$(systemctl show self-deploy-v2-reconcile.service -p ExecMainExitTimestampMonotonic --value 2>/dev/null || true)"
+if systemctl cat infralink-host-reconcile.service >/dev/null 2>&1; then
+  reconcile_result="$(systemctl show infralink-host-reconcile.service -p Result --value 2>/dev/null || true)"
+  reconcile_exit_status="$(systemctl show infralink-host-reconcile.service -p ExecMainStatus --value 2>/dev/null || true)"
+  reconcile_active_state="$(systemctl show infralink-host-reconcile.service -p ActiveState --value 2>/dev/null || true)"
+  reconcile_sub_state="$(systemctl show infralink-host-reconcile.service -p SubState --value 2>/dev/null || true)"
+  reconcile_exit_timestamp_monotonic="$(systemctl show infralink-host-reconcile.service -p ExecMainExitTimestampMonotonic --value 2>/dev/null || true)"
   printf 'self_deploy_reconcile_result=%s\n' "$reconcile_result"
   printf 'self_deploy_reconcile_exit_status=%s\n' "$reconcile_exit_status"
   printf 'self_deploy_reconcile_active_state=%s\n' "$reconcile_active_state"

--- a/src/infralink/local_doctor_agent.py
+++ b/src/infralink/local_doctor_agent.py
@@ -189,8 +189,8 @@ def load_signed_runtime_config(
 def collect_local_readiness_probe() -> HostReadinessProbe:
     """Gather the same bounded readiness facts locally, without SSH or remote execution."""
     try:
-        runtime_v2 = Path("/var/lib/self-deploy-v2/runtime").is_dir() and _unit_exists(
-            "self-deploy-v2-reconcile.timer"
+        runtime_v2 = Path("/var/lib/infralink/registry").is_dir() and _unit_exists(
+            "infralink-host-reconcile.timer"
         )
         legacy = (
             Path("/opt/infra/scripts/self-deploy.sh").is_file()
@@ -284,8 +284,8 @@ def _systemctl_state(command: str, unit: str) -> bool:
 def _timer_state(runtime_v2: bool) -> tuple[bool, bool]:
     if runtime_v2:
         return (
-            _systemctl_state("is-enabled", "self-deploy-v2-reconcile.timer"),
-            _systemctl_state("is-active", "self-deploy-v2-reconcile.timer"),
+            _systemctl_state("is-enabled", "infralink-host-reconcile.timer"),
+            _systemctl_state("is-active", "infralink-host-reconcile.timer"),
         )
     legacy = Path("/etc/cron.d/self-deploy").is_file()
     return legacy, legacy
@@ -294,7 +294,7 @@ def _timer_state(runtime_v2: bool) -> tuple[bool, bool]:
 def _reconcile_state(
     runtime_v2: bool,
 ) -> tuple[str | None, int | None, str | None, str | None, int | None]:
-    if not runtime_v2 or not _unit_exists("self-deploy-v2-reconcile.service"):
+    if not runtime_v2 or not _unit_exists("infralink-host-reconcile.service"):
         return None, None, None, None, None
     names = (
         "Result",
@@ -314,7 +314,7 @@ def _reconcile_state(
 
 def _systemctl_show(name: str) -> str:
     completed = subprocess.run(
-        ["systemctl", "show", "self-deploy-v2-reconcile.service", "-p", name, "--value"],
+        ["systemctl", "show", "infralink-host-reconcile.service", "-p", name, "--value"],
         text=True,
         capture_output=True,
         check=False,

--- a/tests/fixtures/core_v2_release_path/admission.json
+++ b/tests/fixtures/core_v2_release_path/admission.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-admission.v2",
   "channel": "core-v2",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "e503cface4a057505f0a7052ab9435989feb1963",
   "signer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",
   "signature": "ssh-ed25519 fixture-admission-signature"
 }

--- a/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/contract.yml
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/hosts/9157ddeb-cb6d-4d55-8252-9db358f5d932/operations/contract.yml
@@ -9,7 +9,7 @@ transport:
   user: root
   host_key_fingerprint: SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 reconcile:
-  unit: self-deploy-v2-reconcile.service
+  unit: infralink-host-reconcile.service
 verifier:
   registry:
     remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git

--- a/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
+++ b/tests/fixtures/core_v2_release_path/candidate-registry/release-selection.json
@@ -1,3 +1,3 @@
 {
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7"
+  "registry_commit": "e503cface4a057505f0a7052ab9435989feb1963"
 }

--- a/tests/fixtures/core_v2_release_path/candidate.json
+++ b/tests/fixtures/core_v2_release_path/candidate.json
@@ -2,7 +2,7 @@
   "schema_version": "infralink.release-candidate.v1",
   "channel": "core-v2",
   "main_registry_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "e503cface4a057505f0a7052ab9435989feb1963",
   "runtime_revision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "registry_tree": "candidate-registry/hosts",
   "consumer_host_uuid": "9157ddeb-cb6d-4d55-8252-9db358f5d932",

--- a/tests/fixtures/core_v2_release_path/pointer.json
+++ b/tests/fixtures/core_v2_release_path/pointer.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "infralink.release-pointer.v2",
   "channel": "core-v2",
-  "registry_commit": "428dc0d3c3914e00ad91311539f98505ea1e17a7",
+  "registry_commit": "e503cface4a057505f0a7052ab9435989feb1963",
   "candidate": "candidate.json",
   "signature": "ssh-ed25519 fixture-pointer-signature"
 }

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -9,12 +9,11 @@ import yaml
 from click.testing import CliRunner
 
 from infralink.cli.main import cli
-from infralink.cli.operation_contracts import HostVerifierDiagnostic
 from tests.cli_helpers import assert_schema
 
 HOST_ID = "32a3324f-c3d0-4a4f-9587-52c099bcb3fb"
 HOST_NAME = "relaxgg-db-es1"
-UNIT = "self-deploy-v2-reconcile.service"
+UNIT = "infralink-host-reconcile.service"
 INVOCATION = "8d6c4ad60e4a4b589fe35ad9e1760d56"
 FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 MANIFEST_FINGERPRINT = "SHA256:Pnpjf51QfL7khY8GiWuWNp/5G9Twt321Dd5Dk8dB50w"
@@ -194,244 +193,6 @@ def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
     }
 
 
-def test_host_verifier_derives_public_v2_trust_facts_from_active_unit_contract(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    public_output = "\n".join(
-        (
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/main",
-            "runtime_revision=" + "a" * 40,
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=passed",
-            "identity=PRIVATE-KEY-MUST-NOT-LEAK",
-            "token=SECRET-MUST-NOT-LEAK",
-        )
-    )
-    calls: list[list[str]] = []
-    scripts: list[str] = []
-
-    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(args)
-        scripts.append(str(kwargs["input"]))
-        return _completed(public_output)
-
-    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code == 0
-    assert_schema(payload, "host-verifier")
-    assert payload["result"] == {
-        "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
-        "verifier": {
-            "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref": "refs/heads/main",
-            "runtime_revision": "a" * 40,
-            "allowed_signer": {
-                "principal": "infra",
-                "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-                "sha256": "c" * 64,
-            },
-            "git_ssh_signature_capable": True,
-            "fetched_tip": "d" * 40,
-            "signature_verification": "passed",
-        },
-    }
-    assert "PRIVATE-KEY-MUST-NOT-LEAK" not in response.output
-    assert "SECRET-MUST-NOT-LEAK" not in response.output
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
-    script = scripts[0]
-    assert "systemctl start" not in script
-    assert 'systemctl cat "$unit"' in script
-    assert "BWS_ACCESS_TOKEN" not in script
-    assert "/etc/environment" not in script
-    assert "release-admission-shadow-source" not in script
-    assert "trust.host_uuid != host_uuid" in script
-    assert "except (AttributeError, TypeError):" in script
-    assert "signers = trust.allowed_signers" in script
-    assert "if not isinstance(signers, bytes):" in script
-    assert "except AttributeError:" in script
-    assert "if first is None:" in script
-    assert "if rendered.returncode != 0 or not fingerprint:" in script
-
-
-def test_host_verifier_ignores_stale_release_admission_shadow_metadata(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    _release_admission_layout(registry)
-    _git(registry.parent, "add", ".")
-    _git(registry.parent, "commit", "--quiet", "-m", "declared release admission layout")
-    calls: list[list[str]] = []
-    scripts: list[str] = []
-
-    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(args)
-        scripts.append(str(kwargs["input"]))
-        return _completed(
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
-            "runtime_revision=" + "a" * 40 + "\n"
-            "allowed_signer_principal=infra\n"
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
-            "allowed_signers_sha256=" + "c" * 64 + "\n"
-            "git_ssh_signature_capable=true\n"
-            "fetched_tip=" + "d" * 40 + "\n"
-            "signature_verification=unavailable\n"
-        )
-
-    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code == 1
-    assert_schema(payload, "host-verifier")
-    assert payload["result"]["verifier"]["unavailable"] == ["registry_ref"]
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
-    assert "release-admission-shadow-source" not in scripts[0]
-    assert "/var/lib/release-admission/registry-objects/citadel" not in scripts[0]
-
-
-def test_host_verifier_rejects_false_green_without_observed_remote_and_ref(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    scripts: list[str] = []
-
-    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        scripts.append(str(kwargs["input"]))
-        return _completed(
-            "runtime_revision=" + "a" * 40 + "\n"
-            "allowed_signer_principal=infra\n"
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
-            "allowed_signers_sha256=" + "c" * 64 + "\n"
-            "git_ssh_signature_capable=true\n"
-            "signature_verification=unavailable\n"
-        )
-
-    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code == 1
-    assert payload["result"]["verifier"]["unavailable"] == [
-        "registry_remote",
-        "registry_ref",
-        "fetched_tip",
-    ]
-    assert '"remote", "get-url", "origin"' in scripts[0]
-    assert "refs/remotes/origin/main^{commit}" in scripts[0]
-    assert "rev-parse --verify HEAD^{commit}" not in scripts[0]
-
-
-def test_host_verifier_rejects_passed_signature_without_observed_remote_and_ref(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run",
-        lambda *args, **kwargs: _completed(
-            "runtime_revision=" + "a" * 40 + "\n"
-            "allowed_signer_principal=infra\n"
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
-            "allowed_signers_sha256=" + "c" * 64 + "\n"
-            "git_ssh_signature_capable=true\n"
-            "signature_verification=passed\n"
-        ),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["error"]["code"] == "provider_unavailable"
-
-
-def test_host_verifier_marks_all_facts_unavailable_without_a_declared_layout(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _registry_checkout(tmp_path)
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run",
-        lambda *args, **kwargs: pytest.fail("verifier must not guess undeclared paths"),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code == 1
-    assert_schema(payload, "host-verifier")
-    assert payload["result"]["verifier"] == {
-        "unavailable": [
-            "registry_remote",
-            "registry_ref",
-            "runtime_revision",
-            "allowed_signer",
-            "git_ssh_signature_capable",
-            "fetched_tip",
-            "signature_verification",
-        ]
-    }
-
-
-def test_host_verifier_ignores_secret_bearing_shadow_metadata_before_ssh(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    _release_admission_layout(registry)
-    source = registry / HOST_ID / "operations" / "release-admission-shadow-source.yml"
-    source.write_text(
-        source.read_text(encoding="utf-8").replace(
-            "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "https://secret@gitea.example.invalid/relaxgg/infra-registry.git",
-        ),
-        encoding="utf-8",
-    )
-    calls: list[list[str]] = []
-
-    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-        calls.append(args)
-        return _completed("signature_verification=unavailable\n")
-
-    monkeypatch.setattr("infralink.cli.operations.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["result"]["verifier"]["signature_verification"] == "unavailable"
-    assert calls[0][calls[0].index("--") + 1 :] == ["active-verifier", UNIT, HOST_ID]
-    assert "secret@gitea" not in response.output
-
-
 def test_host_verifier_uses_explicit_legacy_layout_without_path_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -474,29 +235,13 @@ def test_host_verifier_uses_explicit_legacy_layout_without_path_fallback(
     ]
 
 
-def test_host_verifier_retains_valid_partial_facts_and_names_unavailable_fields(
+def test_host_verifier_marks_controller_hosts_unavailable_without_running_stale_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
-    partial_output = "\n".join(
-        (
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/main",
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=failed",
-        )
-    )
     monkeypatch.setattr(
         "infralink.cli.operations.subprocess.run",
-        lambda *args, **kwargs: _completed(partial_output),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
+        lambda *args, **kwargs: pytest.fail("retired verifier must not open SSH"),
     )
 
     response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
@@ -504,176 +249,15 @@ def test_host_verifier_retains_valid_partial_facts_and_names_unavailable_fields(
     payload = yaml.safe_load(response.output)
     assert response.exit_code == 1
     assert_schema(payload, "host-verifier")
-    assert payload["result"] == {
-        "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
-        "verifier": {
-            "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref": "refs/heads/main",
-            "allowed_signer": {
-                "principal": "infra",
-                "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-                "sha256": "c" * 64,
-            },
-            "git_ssh_signature_capable": True,
-            "fetched_tip": "d" * 40,
-            "signature_verification": "failed",
-            "unavailable": ["runtime_revision"],
-        },
-    }
-
-
-def test_host_verifier_rejects_a_malformed_public_fact_instead_of_marking_it_unavailable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    malformed = "NOT-A-GIT-REVISION"
-    remote_output = "\n".join(
-        (
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/main",
-            f"runtime_revision={malformed}",
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=failed",
-        )
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert malformed not in response.output
-
-
-def test_host_verifier_rejects_and_omits_a_remote_with_secret_material(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    secret = "PRIVATE-REGISTRY-TOKEN"
-    remote_output = "\n".join(
-        (
-            f"registry_remote=https://{secret}@gitea.example.invalid/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/main",
-            "runtime_revision=" + "a" * 40,
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=failed",
-        )
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert secret not in response.output
-
-
-def test_host_verifier_rejects_duplicate_public_fact_with_secret_material(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    secret = "DUPLICATE-REGISTRY-TOKEN"
-    remote_output = "\n".join(
-        (
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            f"registry_remote=https://{secret}@gitea.example.invalid/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/main",
-            "runtime_revision=" + "a" * 40,
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=passed",
-        )
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert secret not in response.output
-
-
-def test_host_verifier_rejects_a_non_main_registry_ref(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    registry = _manifest_registry_checkout(tmp_path)
-    remote_output = "\n".join(
-        (
-            "registry_remote=ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-            "registry_ref=refs/heads/release",
-            "runtime_revision=" + "a" * 40,
-            "allowed_signer_principal=infra",
-            "allowed_signer_fingerprint=SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-            "allowed_signers_sha256=" + "c" * 64,
-            "git_ssh_signature_capable=true",
-            "fetched_tip=" + "d" * 40,
-            "signature_verification=passed",
-        )
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations.subprocess.run", lambda *args, **kwargs: _completed(remote_output)
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda request: nullcontext(Path("/tmp/known-hosts")),
-    )
-
-    response = CliRunner().invoke(cli, ["--registry", str(registry), "host", "verifier", HOST_ID])
-
-    payload = yaml.safe_load(response.output)
-    assert response.exit_code != 0
-    assert payload["error"]["code"] == "provider_unavailable"
-
-
-def test_host_verifier_contract_allows_only_the_fixed_main_ref() -> None:
-    with pytest.raises(ValueError):
-        HostVerifierDiagnostic.model_validate(
-            {
-                "registry_remote": "ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git",
-                "registry_ref": "refs/heads/release",
-                "runtime_revision": "a" * 40,
-                "allowed_signer": {
-                    "principal": "infra",
-                    "fingerprint": "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-                    "sha256": "c" * 64,
-                },
-                "git_ssh_signature_capable": True,
-                "fetched_tip": "d" * 40,
-                "signature_verification": "passed",
-            }
-        )
+    assert payload["result"]["verifier"]["unavailable"] == [
+        "registry_remote",
+        "registry_ref",
+        "runtime_revision",
+        "allowed_signer",
+        "git_ssh_signature_capable",
+        "fetched_tip",
+        "signature_verification",
+    ]
 
 
 def test_host_apply_reports_only_normalized_observed_fingerprints_on_key_mismatch(

--- a/tests/test_core_v2_release_path.py
+++ b/tests/test_core_v2_release_path.py
@@ -355,7 +355,7 @@ def test_release_path_rejects_an_unsigned_admission() -> None:
         )
 
 
-def test_host_verifier_uses_legacy_or_active_v2_contract_without_mixing_them(
+def test_host_verifier_marks_controller_manifests_unavailable_without_mixing_legacy_contracts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     legacy = _selected_release(tmp_path / "legacy")
@@ -403,13 +403,10 @@ def test_host_verifier_uses_legacy_or_active_v2_contract_without_mixing_them(
         cli, ["--registry", str(current_registry), "host", "verifier", HOST_ID]
     )
 
-    assert legacy_result.exit_code == current_result.exit_code == 0
+    assert legacy_result.exit_code == 0
+    assert current_result.exit_code == 1
     assert calls[0][calls[0].index("--") + 1] == "verifier"
-    assert calls[1][calls[1].index("--") + 1 :] == [
-        "active-verifier",
-        "self-deploy-v2-reconcile.service",
-        HOST_ID,
-    ]
+    assert len(calls) == 1
 
 
 def test_release_path_rejects_legacy_contract_when_a_partial_v2_manifest_is_selected(

--- a/tests/test_host_readiness.py
+++ b/tests/test_host_readiness.py
@@ -243,3 +243,11 @@ def test_ssh_transport_requires_a_nonempty_bws_token_in_etc_environment() -> Non
     assert "grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/environment" in _REMOTE_PROBE
     assert "bws.json" not in _REMOTE_PROBE
     assert "bws.conf" not in _REMOTE_PROBE
+
+
+def test_ssh_transport_probes_the_active_controller_units() -> None:
+    from infralink.host_transport import _REMOTE_PROBE
+
+    assert "infralink-host-reconcile.timer" in _REMOTE_PROBE
+    assert "infralink-host-reconcile.service" in _REMOTE_PROBE
+    assert "self-deploy-v2-reconcile" not in _REMOTE_PROBE

--- a/tests/test_local_doctor_agent.py
+++ b/tests/test_local_doctor_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -7,6 +8,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+import infralink.local_doctor_agent as agent
 from infralink.host_readiness import HostReadinessProbe
 from infralink.local_doctor import LocalDoctorResult
 from infralink.local_doctor_agent import (
@@ -19,9 +21,6 @@ from infralink.local_doctor_agent import (
 
 
 def test_local_probe_uses_the_active_controller_units() -> None:
-    import inspect
-    import infralink.local_doctor_agent as agent
-
     source = inspect.getsource(agent)
     assert "infralink-host-reconcile.timer" in source
     assert "infralink-host-reconcile.service" in source

--- a/tests/test_local_doctor_agent.py
+++ b/tests/test_local_doctor_agent.py
@@ -18,6 +18,16 @@ from infralink.local_doctor_agent import (
 )
 
 
+def test_local_probe_uses_the_active_controller_units() -> None:
+    import inspect
+    import infralink.local_doctor_agent as agent
+
+    source = inspect.getsource(agent)
+    assert "infralink-host-reconcile.timer" in source
+    assert "infralink-host-reconcile.service" in source
+    assert "self-deploy-v2-reconcile" not in source
+
+
 def _runtime_payload(tmp_path: Path) -> dict[str, object]:
     return {
         "schema_version": "infralink.local-doctor-runtime/v1",


### PR DESCRIPTION
Central and node-local doctor probes now use the only active V2 unit family: `infralink-host-reconcile.{timer,service}`. The abandoned `self-deploy-v2-*` units are no longer accepted as V2 runtime evidence.\n\nVerification: `pytest --no-cov -q tests/test_host_readiness.py tests/test_local_doctor_agent.py`.