### PR TITLE
docs: correct v0.5.0 CLI output contract

### DIFF
--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -7,7 +7,8 @@ derives membership from all matching declared service instances.
 ## Compatibility
 
 - Python 3.10, 3.11, and 3.12 on supported POSIX/Linux systems.
-- Every CLI invocation continues to emit one `infralink.cli/v1` JSON envelope.
+- Every CLI invocation emits one structured `infralink.cli/v1` envelope: YAML
+  by default, or JSON when `--output json` is specified.
 - Existing operations-view kinds remain unchanged. `host_metrics` is an
   additive, public observation schema kind.
 - Existing release tags and artifacts remain immutable historical records.


### PR DESCRIPTION
Correct the v0.5.0 release notes: the structured CLI envelope defaults to YAML; JSON is selected with `--output json`. This is a documentation-only release gate correction.