### PR TITLE
Default dependency contracts to Gatus

### DIFF
--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -362,7 +362,7 @@ class DependencyContract(StrictModel):
     port: Port
     required: bool = True
     health_signal_ref: QualifiedRef
-    execution_adapter: str | None = None
+    execution_adapter: str | None = "gatus"
 
 
 class Application(StrictModel):

--- a/tests/observation/test_models.py
+++ b/tests/observation/test_models.py
@@ -73,6 +73,35 @@ def test_host_baseline_capabilities_are_closed_and_explicit() -> None:
         Host(id="11111111-1111-4111-8111-111111111111", baseline_capabilities=["ssh"])
 
 
+def test_dependency_contract_defaults_to_gatus() -> None:
+    dependency = DependencyContract(
+        id="api-to-frontend",
+        source_service_id="11111111-1111-4111-8111-111111111111/api",
+        target_service_id="22222222-2222-4222-8222-222222222222/frontend",
+        target_endpoint_id="22222222-2222-4222-8222-222222222222/frontend/http",
+        protocol=EndpointProtocol.HTTP,
+        port=8080,
+        health_signal_ref="dependency/api-to-frontend/health/reachable",
+    )
+
+    assert dependency.execution_adapter == "gatus"
+
+
+def test_dependency_contract_preserves_explicit_adapter_or_legacy_null() -> None:
+    base = {
+        "id": "api-to-frontend",
+        "source_service_id": "11111111-1111-4111-8111-111111111111/api",
+        "target_service_id": "22222222-2222-4222-8222-222222222222/frontend",
+        "target_endpoint_id": "22222222-2222-4222-8222-222222222222/frontend/http",
+        "protocol": EndpointProtocol.HTTP,
+        "port": 8080,
+        "health_signal_ref": "dependency/api-to-frontend/health/reachable",
+    }
+
+    assert DependencyContract(**base, execution_adapter="edge-prober").execution_adapter == "edge-prober"
+    assert DependencyContract(**base, execution_adapter=None).execution_adapter is None
+
+
 @pytest.mark.parametrize(
     ("model", "field"),
     [

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -112,6 +112,7 @@ def test_resolves_two_hosts_and_exact_signal_namespaces_deterministically() -> N
     assert plan.dependencies[0].health_signal_refs == (
         "dependency/api-to-frontend/health/reachable",
     )
+    assert plan.dependencies[0].execution_adapter == "gatus"
     assert plan.schema_version == "infralink.plan.v1"
     assert plan.document_digests == ("contract.yml",)
 


### PR DESCRIPTION
Ordinary dependency contracts default to the Gatus execution adapter. Explicit adapters remain available for exceptions.