### PR TITLE
feat(doctor): verify declared firewall ingress

### DIFF
--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from ipaddress import ip_network
 from pathlib import Path
 from typing import Any, Literal
 from urllib.error import HTTPError, URLError
@@ -487,7 +488,60 @@ def _host_readiness(ctx: Context, target_ref: str, declaration_only: bool) -> An
     host = ctx.registry.get(target_ref)
     if host is None:
         return None
-    return evaluate_host_readiness(host, SshReadinessTransport())
+    return evaluate_host_readiness(
+        host, SshReadinessTransport(_declared_firewall_rules(ctx, str(host.uuid)))
+    )
+
+
+def _declared_firewall_rules(ctx: Context, host_uuid: str) -> tuple[str, ...]:
+    if ctx.registry_path is None or not ctx.registry_path.is_dir():
+        return ()
+    deployment_path = ctx.registry_path / host_uuid / "operations" / "deployment.yml"
+    try:
+        deployment = yaml.safe_load(deployment_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return ()
+    firewall = deployment.get("firewall") if isinstance(deployment, dict) else None
+    if not isinstance(firewall, dict):
+        return ()
+    rules: list[str] = []
+    management = firewall.get("management_ssh")
+    if isinstance(management, dict):
+        rules.extend(_firewall_rule_lines(management, "tcp"))
+    ingress = firewall.get("ingress")
+    if isinstance(ingress, list):
+        for entry in ingress:
+            if isinstance(entry, dict) and entry.get("protocol") in {"tcp", "udp"}:
+                rules.extend(_firewall_rule_lines(entry, str(entry["protocol"])))
+    return tuple(rules)
+
+
+def _firewall_rule_lines(entry: dict[str, Any], protocol: str) -> list[str]:
+    interface, sources = entry.get("interface"), entry.get("sources")
+    ports = entry.get("ports", [entry.get("port")])
+    if (
+        not isinstance(interface, str)
+        or not isinstance(sources, list)
+        or not isinstance(ports, list)
+    ):
+        return []
+    return [
+        f'iifname "{interface}" ip saddr {_nft_source(source)} {protocol} dport {port} accept'
+        for source in sources
+        for port in ports
+        if isinstance(source, str) and isinstance(port, int)
+    ]
+
+
+def _nft_source(source: str) -> str:
+    """Match nft's canonical display, which suppresses an IPv4 /32 suffix."""
+    try:
+        network = ip_network(source, strict=True)
+    except ValueError:
+        return source
+    return (
+        str(network.network_address) if network.prefixlen == network.max_prefixlen else str(network)
+    )
 
 
 def _apply_host_readiness(result: DoctorResult, readiness: Any) -> DoctorResult:

--- a/src/infralink/host_readiness.py
+++ b/src/infralink/host_readiness.py
@@ -35,6 +35,9 @@ class HostReadinessProbe:
     self_deploy_reconcile_active_state: str | None = None
     self_deploy_reconcile_sub_state: str | None = None
     self_deploy_reconcile_exit_timestamp_monotonic: int | None = None
+    firewall_rules_expected: int = 0
+    firewall_rules_matched: int = 0
+    firewall_observable: bool = True
 
 
 @dataclass(frozen=True)
@@ -232,6 +235,27 @@ class HostReadinessEvaluator:
             )
             for requirement in BASELINE_REQUIREMENTS
         ]
+        if probe.firewall_rules_expected:
+            firewall_passed = (
+                probe.reachable
+                and probe.firewall_observable
+                and probe.firewall_rules_matched == probe.firewall_rules_expected
+            )
+            checks.append(
+                ReadinessCheck(
+                    id="declared_firewall",
+                    required=True,
+                    passed=firewall_passed,
+                    description="Declared firewall ingress is active.",
+                    detail=None
+                    if firewall_passed
+                    else (
+                        "firewall_unobservable"
+                        if not probe.firewall_observable
+                        else f"{probe.firewall_rules_matched}/{probe.firewall_rules_expected}_rules_matched"
+                    ),
+                )
+            )
         actions = [
             BootstrapAction(
                 id=requirement.action_id,
@@ -242,6 +266,17 @@ class HostReadinessEvaluator:
             if next(check for check in checks if check.id == requirement.id).required
             and not outcomes[requirement.id][0]
         ]
+        if (
+            probe.firewall_rules_expected
+            and not next(check for check in checks if check.id == "declared_firewall").passed
+        ):
+            actions.append(
+                BootstrapAction(
+                    id="reconcile_declared_firewall",
+                    check_id="declared_firewall",
+                    description="Run reconciliation to apply the declared firewall ingress.",
+                )
+            )
         return HostReadiness(
             ready=all(not check.required or check.passed for check in checks),
             checks=checks,

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from shlex import quote
 
 from infralink.host_readiness import HostReadinessProbe
 
@@ -64,6 +65,9 @@ fi
 class SshReadinessTransport:
     """Collect the bootstrap baseline over root SSH without remote mutation."""
 
+    def __init__(self, expected_firewall_rules: tuple[str, ...] = ()) -> None:
+        self._expected_firewall_rules = expected_firewall_rules
+
     def probe(self, address: str) -> HostReadinessProbe:
         if not address:
             return _unreachable("host_address_missing")
@@ -81,7 +85,7 @@ class SshReadinessTransport:
                     "sh",
                     "-s",
                 ],
-                input=_REMOTE_PROBE,
+                input=_REMOTE_PROBE + _firewall_probe(self._expected_firewall_rules),
                 text=True,
                 capture_output=True,
                 timeout=15,
@@ -122,7 +126,27 @@ class SshReadinessTransport:
             self_deploy_reconcile_exit_timestamp_monotonic=_optional_int(
                 values.get("self_deploy_reconcile_exit_timestamp_monotonic")
             ),
+            firewall_rules_expected=len(self._expected_firewall_rules),
+            firewall_rules_matched=_optional_int(values.get("firewall_rules_matched")) or 0,
+            firewall_observable=values.get("firewall_observable", "1") == "1",
         )
+
+
+def _firewall_probe(expected_rules: tuple[str, ...]) -> str:
+    if not expected_rules:
+        return "printf 'firewall_rules_matched=0\\nfirewall_observable=1\\n'\n"
+    checks = "\n".join(
+        f"if printf '%s\\n' \"$firewall_chain\" | grep -F -- {quote(rule)} >/dev/null; then firewall_rules_matched=$((firewall_rules_matched + 1)); fi"
+        for rule in expected_rules
+    )
+    return f"""if firewall_chain=\"$(nft list chain inet infralink_filter input 2>/dev/null)\"; then
+  firewall_rules_matched=0
+{checks}
+  printf 'firewall_observable=1\\nfirewall_rules_matched=%s\\n' \"$firewall_rules_matched\"
+else
+  printf 'firewall_observable=0\\nfirewall_rules_matched=0\\n'
+fi
+"""
 
 
 def _parse_probe(stdout: str) -> dict[str, str]:

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -469,6 +469,15 @@ def test_doctor_host_includes_fail_closed_live_bootstrap_readiness(
     assert plan_action["safe"] is True
 
 
+def test_doctor_normalizes_single_host_firewall_sources_for_nft() -> None:
+    from infralink.cli.doctor import _firewall_rule_lines
+
+    assert _firewall_rule_lines(
+        {"interface": "tailscale0", "sources": ["100.93.157.126/32"], "ports": [9300]},
+        "tcp",
+    ) == ['iifname "tailscale0" ip saddr 100.93.157.126 tcp dport 9300 accept']
+
+
 def test_doctor_host_fails_closed_when_latest_v2_reconcile_failed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_host_readiness.py
+++ b/tests/test_host_readiness.py
@@ -117,6 +117,18 @@ def test_v2_reconcile_success_satisfies_readiness() -> None:
     assert reconcile.passed is True
 
 
+def test_declared_firewall_fails_closed_when_a_rule_is_missing() -> None:
+    readiness = HostReadinessEvaluator().evaluate(
+        canonical_name="relaxgg-db-es1",
+        probe=_probe(firewall_rules_expected=2, firewall_rules_matched=1),
+    )
+
+    check = next(check for check in readiness.checks if check.id == "declared_firewall")
+    assert check.passed is False
+    assert check.detail == "1/2_rules_matched"
+    assert any(action.id == "reconcile_declared_firewall" for action in readiness.actions)
+
+
 def test_provisioning_host_without_declared_reconcile_does_not_require_timer_or_run() -> None:
     readiness = HostReadinessEvaluator().evaluate(
         canonical_name="relaxgg-db-es1",


### PR DESCRIPTION
Makes live host doctor fail closed when a registry-declared nftables ingress rule is absent. The SSH probe reads only the controller-owned `infralink_filter` chain and compares it with the normalized declaration.