### PR TITLE
fix(doctor): use latest Gatus evidence

### DIFF
--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -85,8 +85,8 @@ def _gatus_evidence(
         else:
             results = status.get("results")
             latest = (
-                results[0]
-                if isinstance(results, list) and results and isinstance(results[0], dict)
+                results[-1]
+                if isinstance(results, list) and results and isinstance(results[-1], dict)
                 else {}
             )
             success = latest.get("success")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -401,6 +401,72 @@ def test_configured_unhealthy_required_gatus_evidence_is_nonzero(
     assert payload["result"]["reason"] == "gatus_observation_unhealthy"
 
 
+def test_doctor_uses_the_latest_gatus_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan, bindings = _observation_inputs(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.doctor._fetch_gatus_statuses",
+        lambda url, token: [
+            {
+                "name": OBSERVATION_ID,
+                "results": [
+                    {"success": False, "timestamp": "2026-08-09T00:00:00Z"},
+                    {"success": True, "timestamp": "2026-08-09T00:01:00Z"},
+                ],
+            }
+        ],
+    )
+
+    result = _invoke(
+        "--observation-plan",
+        str(plan),
+        "--adapter-bindings",
+        str(bindings),
+        "--gatus-url",
+        "http://gatus.test",
+        "edge",
+        OBSERVATION_ID,
+    )
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert payload["result"]["status"] == "healthy"
+    assert payload["result"]["evidence_summary"][0]["latest_observed_at"] == "2026-08-09T00:01:00Z"
+
+
+def test_doctor_rejects_a_malformed_latest_gatus_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan, bindings = _observation_inputs(tmp_path)
+    monkeypatch.setattr(
+        "infralink.cli.doctor._fetch_gatus_statuses",
+        lambda url, token: [
+            {
+                "name": OBSERVATION_ID,
+                "results": [{"success": True}, "malformed"],
+            }
+        ],
+    )
+
+    result = _invoke(
+        "--observation-plan",
+        str(plan),
+        "--adapter-bindings",
+        str(bindings),
+        "--gatus-url",
+        "http://gatus.test",
+        "edge",
+        OBSERVATION_ID,
+    )
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 1
+    assert payload["result"]["status"] == "unknown"
+    assert payload["result"]["reason"] == "no_live_observation_evidence"
+    assert payload["result"]["evidence"][0]["reason"] == "gatus_result_missing"
+
+
 def test_doctor_unknown_host_returns_a_bounded_canonical_discovery_action(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Doctor now determines health from the most recent retained Gatus result, not the oldest sample. Includes regression coverage for a failed-then-successful history and a malformed newest result.