### PR TITLE
feat(observation): project logical service aggregates

### DIFF
--- a/src/infralink/observation/codes.py
+++ b/src/infralink/observation/codes.py
@@ -26,6 +26,7 @@ DUPLICATE_IDENTITY_KINDS = frozenset(
         "dependency",
         "endpoint",
         "host",
+        "logical-service",
         "observation-backend",
         "profile",
         "provider-alias",

--- a/src/infralink/observation/codes.py
+++ b/src/infralink/observation/codes.py
@@ -55,6 +55,8 @@ PLANNER_DIAGNOSTIC_CODES = _DYNAMIC_DUPLICATE_CODES | frozenset(
         "invalid-dependency-health-signal-ref",
         "invalid-document-record",
         "invalid-document-section",
+        "logical-service-component-signal-unknown",
+        "logical-service-component-unresolved",
         "missing-service-host",
         "missing-required-host-baseline-capability",
         "host-metrics-profile-capability-required",

--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -209,6 +209,28 @@ class SecretSlot(StrictModel):
     purpose: Annotated[str, Field(min_length=1)]
 
 
+class LogicalServiceComponent(StrictModel):
+    """One required same-host component of an operator-facing service."""
+
+    profile_id: CanonicalId
+    signal_id: CanonicalId
+
+
+class LogicalService(StrictModel):
+    """A profile-owned aggregate of ordinary component profiles."""
+
+    id: CanonicalId
+    display_name: Annotated[str, Field(min_length=1)] | None = None
+    components: Annotated[list[LogicalServiceComponent], Field(min_length=1)]
+
+    @model_validator(mode="after")
+    def reject_duplicate_component_profiles(self) -> LogicalService:
+        profile_ids = [component.profile_id for component in self.components]
+        if len(profile_ids) != len(set(profile_ids)):
+            raise ValueError("duplicate logical service component profile")
+        return self
+
+
 class ServiceProfile(StrictModel):
     id: CanonicalId
     display_name: Annotated[str, Field(min_length=1)] | None = None
@@ -219,6 +241,7 @@ class ServiceProfile(StrictModel):
     signals: list[LogicalSignal] = Field(default_factory=list)
     secret_slots: list[SecretSlot] = Field(default_factory=list)
     required_host_baseline_capabilities: list[HostBaselineCapability] = Field(default_factory=list)
+    logical_service: LogicalService | None = None
 
     @model_validator(mode="after")
     def validate_endpoint_references(self) -> ServiceProfile:
@@ -226,6 +249,10 @@ class ServiceProfile(StrictModel):
             set(self.required_host_baseline_capabilities)
         ):
             raise ValueError("duplicate host baseline capability in service profile")
+        if self.logical_service is not None and self.id not in {
+            component.profile_id for component in self.logical_service.components
+        }:
+            raise ValueError("logical service must include its owning profile")
         endpoint_id_list = [endpoint.id for endpoint in self.endpoints]
         if len(endpoint_id_list) != len(set(endpoint_id_list)):
             raise ValueError("duplicate endpoint id in service profile")

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -84,6 +84,16 @@ class PlannedServiceProfile(PlanModel):
     source_refs: tuple[SourceRef, ...]
 
 
+class PlannedLogicalService(PlanModel):
+    id: str
+    host_id: str
+    primary_service_id: str
+    display_name: Annotated[str, Field(min_length=1)] | None = None
+    component_service_ids: tuple[str, ...]
+    health_signal_refs: tuple[str, ...]
+    source_refs: tuple[SourceRef, ...]
+
+
 class PlannedEndpoint(PlanModel):
     id: str
     service_id: str
@@ -258,6 +268,7 @@ class Plan(PlanModel):
     service_profiles: tuple[PlannedServiceProfile, ...]
     hosts: tuple[PlannedHost, ...]
     services: tuple[PlannedService, ...]
+    logical_services: tuple[PlannedLogicalService, ...] = ()
     endpoints: tuple[PlannedEndpoint, ...]
     applications: tuple[PlannedApplication, ...]
     dependencies: tuple[PlannedDependency, ...]
@@ -715,6 +726,65 @@ def resolve_observation_documents(
     endpoint_map = _index_planned(planned_endpoints, "endpoint", findings)
     signal_map = _index_planned(planned_signals, "signal", findings)
     service_ids = {service.id for service in planned_services}
+    services_by_host_profile: dict[tuple[str, str], list[PlannedService]] = {}
+    for service in planned_services:
+        services_by_host_profile.setdefault((service.host_id, service.profile_id), []).append(service)
+    planned_logical_services: list[PlannedLogicalService] = []
+    for primary in planned_services:
+        profile = service_profiles[primary.id]
+        aggregate = profile.logical_service
+        if aggregate is None:
+            continue
+        component_services: list[str] = []
+        health_signal_refs: list[str] = []
+        profile_ref = next(
+            ref for candidate, ref in profiles.values() if candidate.id == profile.id
+        )
+        for component_index, component in enumerate(aggregate.components):
+            component_ref = _child(
+                _child(profile_ref, "logical_service"), "components", str(component_index)
+            )
+            matches = services_by_host_profile.get((primary.host_id, component.profile_id), [])
+            if len(matches) != 1:
+                _finding(
+                    findings,
+                    "logical-service-component-unresolved",
+                    _child(component_ref, "profile_id"),
+                    f"{primary.host_id}/{aggregate.id}/{component.profile_id}",
+                    "Declare exactly one same-host instance for each logical service component profile.",
+                )
+                continue
+            component_service = matches[0]
+            component_profile = service_profiles[component_service.id]
+            signal = next(
+                (item for item in component_profile.signals if item.id == component.signal_id),
+                None,
+            )
+            if signal is None:
+                _finding(
+                    findings,
+                    "logical-service-component-signal-unknown",
+                    _child(component_ref, "signal_id"),
+                    f"{primary.host_id}/{aggregate.id}/{component.profile_id}/{component.signal_id}",
+                    "Reference a signal declared by the component profile.",
+                )
+                continue
+            component_services.append(component_service.id)
+            health_signal_refs.append(
+                f"service/{component_service.id}/{signal.capability_id}/{signal.id}"
+            )
+        if len(component_services) == len(aggregate.components):
+            planned_logical_services.append(
+                PlannedLogicalService(
+                    id=f"{primary.host_id}/{aggregate.id}",
+                    host_id=primary.host_id,
+                    primary_service_id=primary.id,
+                    display_name=aggregate.display_name or primary.display_name,
+                    component_service_ids=tuple(component_services),
+                    health_signal_refs=tuple(health_signal_refs),
+                    source_refs=(profile_ref, service_refs[primary.id]),
+                )
+            )
     planned_dependencies: list[PlannedDependency] = []
     for edge, ref in dependencies.values():
         assert isinstance(edge, DependencyContract)
@@ -1351,6 +1421,7 @@ def resolve_observation_documents(
         service_profiles=_sorted(planned_profiles),
         hosts=_sorted(planned_hosts),
         services=_sorted(planned_services),
+        logical_services=_sorted(planned_logical_services),
         endpoints=_sorted(planned_endpoints),
         applications=_sorted(planned_apps),
         dependencies=_sorted(planned_dependencies),

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -441,6 +441,22 @@ def resolve_observation_documents(
         )
 
     profiles = _unique(parsed["service_profiles"], "profile", findings)
+    logical_service_ids: set[str] = set()
+    for profile, ref in profiles.values():
+        assert isinstance(profile, ServiceProfile)
+        if profile.logical_service is None:
+            continue
+        logical_service_id = profile.logical_service.id
+        if logical_service_id in logical_service_ids:
+            _finding(
+                findings,
+                "duplicate-logical-service-id",
+                _child(_child(ref, "logical_service"), "id"),
+                logical_service_id,
+                "Give every logical service aggregate a unique identity.",
+            )
+        else:
+            logical_service_ids.add(logical_service_id)
     hosts = _unique(parsed["hosts"], "host", findings)
     instance_entries = parsed["service_instances"]
     aliases = _unique(parsed["provider_aliases"], "provider-alias", findings)
@@ -728,18 +744,20 @@ def resolve_observation_documents(
     service_ids = {service.id for service in planned_services}
     services_by_host_profile: dict[tuple[str, str], list[PlannedService]] = {}
     for service in planned_services:
-        services_by_host_profile.setdefault((service.host_id, service.profile_id), []).append(service)
+        services_by_host_profile.setdefault((service.host_id, service.profile_id), []).append(
+            service
+        )
     planned_logical_services: list[PlannedLogicalService] = []
     for primary in planned_services:
         profile = service_profiles[primary.id]
         aggregate = profile.logical_service
         if aggregate is None:
             continue
-        component_services: list[str] = []
-        health_signal_refs: list[str] = []
+        resolved_components: list[tuple[str, str, tuple[SourceRef, ...]]] = []
         profile_ref = next(
             ref for candidate, ref in profiles.values() if candidate.id == profile.id
         )
+        aggregate_source_refs: list[SourceRef] = [profile_ref, service_refs[primary.id]]
         for component_index, component in enumerate(aggregate.components):
             component_ref = _child(
                 _child(profile_ref, "logical_service"), "components", str(component_index)
@@ -756,6 +774,7 @@ def resolve_observation_documents(
                 continue
             component_service = matches[0]
             component_profile = service_profiles[component_service.id]
+            component_profile_ref = profiles[component.profile_id][1]
             signal = next(
                 (item for item in component_profile.signals if item.id == component.signal_id),
                 None,
@@ -769,20 +788,28 @@ def resolve_observation_documents(
                     "Reference a signal declared by the component profile.",
                 )
                 continue
-            component_services.append(component_service.id)
-            health_signal_refs.append(
-                f"service/{component_service.id}/{signal.capability_id}/{signal.id}"
+            resolved_components.append(
+                (
+                    component_service.id,
+                    f"service/{component_service.id}/{signal.capability_id}/{signal.id}",
+                    (component_ref, component_profile_ref, service_refs[component_service.id]),
+                )
             )
-        if len(component_services) == len(aggregate.components):
+        if len(resolved_components) == len(aggregate.components):
+            resolved_components.sort(key=lambda item: item[0])
+            component_services = tuple(item[0] for item in resolved_components)
+            health_signal_refs = tuple(item[1] for item in resolved_components)
+            for _, _, source_refs in resolved_components:
+                aggregate_source_refs.extend(source_refs)
             planned_logical_services.append(
                 PlannedLogicalService(
                     id=f"{primary.host_id}/{aggregate.id}",
                     host_id=primary.host_id,
                     primary_service_id=primary.id,
                     display_name=aggregate.display_name or primary.display_name,
-                    component_service_ids=tuple(component_services),
-                    health_signal_refs=tuple(health_signal_refs),
-                    source_refs=(profile_ref, service_refs[primary.id]),
+                    component_service_ids=component_services,
+                    health_signal_refs=health_signal_refs,
+                    source_refs=tuple(aggregate_source_refs),
                 )
             )
     planned_dependencies: list[PlannedDependency] = []

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -441,9 +441,11 @@ def resolve_observation_documents(
         )
 
     profiles = _unique(parsed["service_profiles"], "profile", findings)
+    profile_entries: dict[str, tuple[ServiceProfile, SourceRef]] = {}
     logical_service_ids: set[str] = set()
     for profile, ref in profiles.values():
         assert isinstance(profile, ServiceProfile)
+        profile_entries[profile.id] = (profile, ref)
         if profile.logical_service is None:
             continue
         logical_service_id = profile.logical_service.id
@@ -754,9 +756,7 @@ def resolve_observation_documents(
         if aggregate is None:
             continue
         resolved_components: list[tuple[str, str, tuple[SourceRef, ...]]] = []
-        profile_ref = next(
-            ref for candidate, ref in profiles.values() if candidate.id == profile.id
-        )
+        profile_ref = profile_entries[profile.id][1]
         aggregate_source_refs: list[SourceRef] = [profile_ref, service_refs[primary.id]]
         for component_index, component in enumerate(aggregate.components):
             component_ref = _child(
@@ -774,12 +774,12 @@ def resolve_observation_documents(
                 continue
             component_service = matches[0]
             component_profile = service_profiles[component_service.id]
-            component_profile_ref = profiles[component.profile_id][1]
-            signal = next(
+            component_profile_ref = profile_entries[component.profile_id][1]
+            component_signal = next(
                 (item for item in component_profile.signals if item.id == component.signal_id),
                 None,
             )
-            if signal is None:
+            if component_signal is None:
                 _finding(
                     findings,
                     "logical-service-component-signal-unknown",
@@ -791,7 +791,10 @@ def resolve_observation_documents(
             resolved_components.append(
                 (
                     component_service.id,
-                    f"service/{component_service.id}/{signal.capability_id}/{signal.id}",
+                    (
+                        f"service/{component_service.id}/"
+                        f"{component_signal.capability_id}/{component_signal.id}"
+                    ),
                     (component_ref, component_profile_ref, service_refs[component_service.id]),
                 )
             )

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -503,6 +503,14 @@
           "title": "Hosts",
           "type": "array"
         },
+        "logical_services": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/PlannedLogicalService"
+          },
+          "title": "Logical Services",
+          "type": "array"
+        },
         "opaque_identities": {
           "items": {
             "$ref": "#/$defs/OpaqueIdentity"
@@ -957,6 +965,67 @@
         "source_refs"
       ],
       "title": "PlannedHost",
+      "type": "object"
+    },
+    "PlannedLogicalService": {
+      "additionalProperties": false,
+      "properties": {
+        "component_service_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Component Service Ids",
+          "type": "array"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
+        "health_signal_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Health Signal Refs",
+          "type": "array"
+        },
+        "host_id": {
+          "title": "Host Id",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "primary_service_id": {
+          "title": "Primary Service Id",
+          "type": "string"
+        },
+        "source_refs": {
+          "items": {
+            "$ref": "#/$defs/SourceRef"
+          },
+          "title": "Source Refs",
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "host_id",
+        "primary_service_id",
+        "component_service_ids",
+        "health_signal_refs",
+        "source_refs"
+      ],
+      "title": "PlannedLogicalService",
       "type": "object"
     },
     "PlannedOperationsView": {

--- a/src/infralink/schemas/observation/v1/dependency.json
+++ b/src/infralink/schemas/observation/v1/dependency.json
@@ -12,7 +12,7 @@
               "type": "null"
             }
           ],
-          "default": null,
+          "default": "gatus",
           "title": "Execution Adapter"
         },
         "health_signal_ref": {

--- a/src/infralink/schemas/observation/v1/profile.json
+++ b/src/infralink/schemas/observation/v1/profile.json
@@ -197,6 +197,66 @@
       "title": "LogEvaluator",
       "type": "string"
     },
+    "LogicalService": {
+      "additionalProperties": false,
+      "description": "A profile-owned aggregate of ordinary component profiles.",
+      "properties": {
+        "components": {
+          "items": {
+            "$ref": "#/$defs/LogicalServiceComponent"
+          },
+          "minItems": 1,
+          "title": "Components",
+          "type": "array"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
+        "id": {
+          "pattern": "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "components"
+      ],
+      "title": "LogicalService",
+      "type": "object"
+    },
+    "LogicalServiceComponent": {
+      "additionalProperties": false,
+      "description": "One required same-host component of an operator-facing service.",
+      "properties": {
+        "profile_id": {
+          "pattern": "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
+          "title": "Profile Id",
+          "type": "string"
+        },
+        "signal_id": {
+          "pattern": "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
+          "title": "Signal Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile_id",
+        "signal_id"
+      ],
+      "title": "LogicalServiceComponent",
+      "type": "object"
+    },
     "LogicalSignal": {
       "additionalProperties": false,
       "description": "A vendor-neutral assertion derived from one declared capability.",
@@ -398,6 +458,17 @@
           "pattern": "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
           "title": "Id",
           "type": "string"
+        },
+        "logical_service": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LogicalService"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "logs": {
           "items": {

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -117,6 +117,57 @@ def test_resolves_two_hosts_and_exact_signal_namespaces_deterministically() -> N
     assert plan.document_digests == ("contract.yml",)
 
 
+def test_projects_a_same_host_logical_service_from_declared_components() -> None:
+    data = base_data()
+    data["service_profiles"][0]["logical_service"] = {  # type: ignore[index]
+        "id": "web-stack",
+        "display_name": "Web Stack",
+        "components": [
+            {"profile_id": "web", "signal_id": "up"},
+            {"profile_id": "proxy", "signal_id": "up"},
+        ],
+    }
+    data["service_profiles"].append(  # type: ignore[index]
+        {
+            "id": "proxy",
+            "endpoints": [{"id": "http", "protocol": "http", "port": 8081}],
+            "health": [{"id": "ready", "endpoint_id": "http", "evaluator": "http-status"}],
+            "signals": [
+                {"id": "up", "capability_id": "ready", "evaluator": "capability-state"}
+            ],
+        }
+    )
+    data["service_instances"].extend(  # type: ignore[index]
+        [
+            {
+                "id": "api-proxy",
+                "host_id": "11111111-1111-4111-8111-111111111111",
+                "profile_id": "proxy",
+            },
+            {
+                "id": "frontend-proxy",
+                "host_id": "22222222-2222-4222-8222-222222222222",
+                "profile_id": "proxy",
+            },
+        ]
+    )
+
+    plan = resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert [item.id for item in plan.logical_services] == [
+        "11111111-1111-4111-8111-111111111111/web-stack",
+        "22222222-2222-4222-8222-222222222222/web-stack",
+    ]
+    assert plan.logical_services[0].component_service_ids == (
+        "11111111-1111-4111-8111-111111111111/api",
+        "11111111-1111-4111-8111-111111111111/api-proxy",
+    )
+    assert plan.logical_services[0].health_signal_refs == (
+        "service/11111111-1111-4111-8111-111111111111/api/ready/up",
+        "service/11111111-1111-4111-8111-111111111111/api-proxy/ready/up",
+    )
+
+
 def test_projects_explicit_host_and_service_display_names_without_identity_changes() -> None:
     data = base_data()
     data["hosts"][0]["display_name"] = "Operations API"  # type: ignore[index]

--- a/tests/observation/test_planner.py
+++ b/tests/observation/test_planner.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime, timezone
 from types import MappingProxyType
 
@@ -132,9 +133,7 @@ def test_projects_a_same_host_logical_service_from_declared_components() -> None
             "id": "proxy",
             "endpoints": [{"id": "http", "protocol": "http", "port": 8081}],
             "health": [{"id": "ready", "endpoint_id": "http", "evaluator": "http-status"}],
-            "signals": [
-                {"id": "up", "capability_id": "ready", "evaluator": "capability-state"}
-            ],
+            "signals": [{"id": "up", "capability_id": "ready", "evaluator": "capability-state"}],
         }
     )
     data["service_instances"].extend(  # type: ignore[index]
@@ -166,6 +165,111 @@ def test_projects_a_same_host_logical_service_from_declared_components() -> None
         "service/11111111-1111-4111-8111-111111111111/api/ready/up",
         "service/11111111-1111-4111-8111-111111111111/api-proxy/ready/up",
     )
+    assert [ref.pointer for ref in plan.logical_services[0].source_refs] == [
+        "/service_profiles/0",
+        "/service_instances/1",
+        "/service_profiles/0/logical_service/components/0",
+        "/service_profiles/0",
+        "/service_instances/1",
+        "/service_profiles/0/logical_service/components/1",
+        "/service_profiles/1",
+        "/service_instances/2",
+    ]
+    reordered_data = deepcopy(data)
+    reordered_data["service_profiles"][0]["logical_service"]["components"].reverse()  # type: ignore[index]
+
+    reordered_plan = resolve_observation_documents([document(reordered_data)], as_of=AS_OF)
+
+    assert [item.component_service_ids for item in reordered_plan.logical_services] == [
+        item.component_service_ids for item in plan.logical_services
+    ]
+    assert [item.health_signal_refs for item in reordered_plan.logical_services] == [
+        item.health_signal_refs for item in plan.logical_services
+    ]
+    assert reordered_plan.plan_digest == plan.plan_digest
+
+
+def test_rejects_duplicate_logical_service_ids() -> None:
+    data = base_data()
+    logical_service = {
+        "id": "web-stack",
+        "components": [{"profile_id": "web", "signal_id": "up"}],
+    }
+    data["service_profiles"][0]["logical_service"] = logical_service  # type: ignore[index]
+    data["service_profiles"].append(  # type: ignore[index]
+        {
+            "id": "proxy",
+            "endpoints": [{"id": "http", "protocol": "http", "port": 8081}],
+            "health": [{"id": "ready", "endpoint_id": "http", "evaluator": "http-status"}],
+            "signals": [{"id": "up", "capability_id": "ready", "evaluator": "capability-state"}],
+            "logical_service": {
+                "id": "web-stack",
+                "components": [{"profile_id": "proxy", "signal_id": "up"}],
+            },
+        }
+    )
+
+    with pytest.raises(PlanValidationError) as error:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert {item.code for item in error.value.report.diagnostics} == {
+        "duplicate-logical-service-id"
+    }
+
+
+def test_rejects_missing_or_ambiguous_logical_service_components() -> None:
+    data = base_data()
+    data["service_profiles"][0]["logical_service"] = {  # type: ignore[index]
+        "id": "web-stack",
+        "components": [
+            {"profile_id": "web", "signal_id": "up"},
+            {"profile_id": "proxy", "signal_id": "up"},
+        ],
+    }
+    data["service_profiles"].append(  # type: ignore[index]
+        {
+            "id": "proxy",
+            "endpoints": [{"id": "http", "protocol": "http", "port": 8081}],
+            "health": [{"id": "ready", "endpoint_id": "http", "evaluator": "http-status"}],
+            "signals": [{"id": "up", "capability_id": "ready", "evaluator": "capability-state"}],
+        }
+    )
+    data["service_instances"].extend(  # type: ignore[index]
+        [
+            {
+                "id": "api-proxy-a",
+                "host_id": "11111111-1111-4111-8111-111111111111",
+                "profile_id": "proxy",
+            },
+            {
+                "id": "api-proxy-b",
+                "host_id": "11111111-1111-4111-8111-111111111111",
+                "profile_id": "proxy",
+            },
+        ]
+    )
+
+    with pytest.raises(PlanValidationError) as error:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert {item.code for item in error.value.report.diagnostics} == {
+        "logical-service-component-unresolved"
+    }
+
+
+def test_rejects_unknown_logical_service_component_signal() -> None:
+    data = base_data()
+    data["service_profiles"][0]["logical_service"] = {  # type: ignore[index]
+        "id": "web-stack",
+        "components": [{"profile_id": "web", "signal_id": "missing"}],
+    }
+
+    with pytest.raises(PlanValidationError) as error:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert {item.code for item in error.value.report.diagnostics} == {
+        "logical-service-component-signal-unknown"
+    }
 
 
 def test_projects_explicit_host_and_service_display_names_without_identity_changes() -> None:


### PR DESCRIPTION
Implements the typed, additive foundation for infra-registry #403. A primary service profile may declare an operator-facing logical service with required same-host component profiles and readiness signals. The projection emits component service IDs and health signal refs without changing Compose or firewall ownership.