### PR TITLE
feat(doctor): inspect logical service aggregates

### DIFF
--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -313,6 +313,40 @@ def _target(
             raise _missing(ctx, "profile", target_ref, observation_plan, adapter_bindings)
         return DoctorTarget(type="profile", id=target_ref), {"profile_id": target_ref}, target_ref
 
+    logical_service = next(
+        (
+            item
+            for item in (plan or {}).get("logical_services", [])
+            if isinstance(item, dict) and item.get("id") == target_ref
+        ),
+        None,
+    )
+    if logical_service is not None:
+        host_id = logical_service.get("host_id")
+        component_service_ids = logical_service.get("component_service_ids")
+        if not isinstance(host_id, str) or not isinstance(component_service_ids, list):
+            raise _missing(ctx, "service", target_ref, observation_plan, adapter_bindings)
+        components = [item for item in component_service_ids if isinstance(item, str)]
+        if len(components) != len(component_service_ids):
+            raise _missing(ctx, "service", target_ref, observation_plan, adapter_bindings)
+        host = ctx.registry.get(host_id)
+        aggregate_name = target_ref.rsplit("/", 1)[-1]
+        return (
+            DoctorTarget(
+                type="service",
+                id=target_ref,
+                canonical_name=(
+                    f"{host.canonical_name}/{aggregate_name}" if host is not None else None
+                ),
+            ),
+            {
+                "host_id": host_id,
+                "component_service_ids": components,
+                "component_count": len(components),
+            },
+            target_ref,
+        )
+
     service_ids = {
         service_id
         for host in ctx.registry
@@ -356,6 +390,18 @@ def _coverage(
     target_type: DoctorKind | None,
     target_id: str,
 ) -> tuple[DoctorCoverage, list[DoctorEvidence]]:
+    logical_service_components = next(
+        (
+            {
+                component
+                for component in item.get("component_service_ids", [])
+                if isinstance(component, str)
+            }
+            for item in plan.get("logical_services", [])
+            if isinstance(item, dict) and item.get("id") == target_id
+        ),
+        None,
+    )
     profile_services = {
         item["id"]
         for item in plan.get("services", [])
@@ -369,7 +415,14 @@ def _coverage(
         if isinstance(item, dict)
         and (
             target_type is None
-            or _dependency_matches(item, target_type, target_id, profile_services)
+            or (
+                (
+                    (item.get("source_service_id") in logical_service_components)
+                    != (item.get("target_service_id") in logical_service_components)
+                )
+                if logical_service_components is not None
+                else _dependency_matches(item, target_type, target_id, profile_services)
+            )
         )
     ]
     binding_by_identity = {

--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -112,10 +112,10 @@ def _gatus_evidence(
 def _result_status(
     coverage: DoctorCoverage | None, evidence: list[DoctorEvidence], gatus_url: str | None
 ) -> tuple[Literal["healthy", "unhealthy", "unavailable", "unknown"], str | None]:
-    if gatus_url is None and any(item.adapter == "gatus" for item in evidence):
-        return "unknown", "gatus_not_configured"
     if coverage is not None and not coverage.valid:
         return "unknown", "observer_coverage_incomplete"
+    if gatus_url is None and any(item.adapter == "gatus" for item in evidence):
+        return "unknown", "gatus_not_configured"
     statuses = {item.status for item in evidence}
     if "unavailable" in statuses:
         reasons = {item.reason for item in evidence if item.status == "unavailable"}
@@ -390,17 +390,31 @@ def _coverage(
     target_type: DoctorKind | None,
     target_id: str,
 ) -> tuple[DoctorCoverage, list[DoctorEvidence]]:
-    logical_service_components = next(
+    logical_service = next(
         (
-            {
-                component
-                for component in item.get("component_service_ids", [])
-                if isinstance(component, str)
-            }
+            item
             for item in plan.get("logical_services", [])
             if isinstance(item, dict) and item.get("id") == target_id
         ),
         None,
+    )
+    logical_service_components = (
+        {
+            component
+            for component in logical_service.get("component_service_ids", [])
+            if isinstance(component, str)
+        }
+        if logical_service is not None
+        else None
+    )
+    logical_service_signal_refs = (
+        {
+            signal_ref
+            for signal_ref in logical_service.get("health_signal_refs", [])
+            if isinstance(signal_ref, str)
+        }
+        if logical_service is not None
+        else set()
     )
     profile_services = {
         item["id"]
@@ -418,7 +432,7 @@ def _coverage(
             or (
                 (
                     (item.get("source_service_id") in logical_service_components)
-                    != (item.get("target_service_id") in logical_service_components)
+                    or (item.get("target_service_id") in logical_service_components)
                 )
                 if logical_service_components is not None
                 else _dependency_matches(item, target_type, target_id, profile_services)
@@ -465,6 +479,45 @@ def _coverage(
                 reason=reason,
             )
         )
+    observed_signal_refs = {
+        signal_ref
+        for dependency in dependencies
+        for signal_ref in dependency.get("health_signal_refs", [])
+        if isinstance(signal_ref, str)
+    }
+    for signal_ref in sorted(logical_service_signal_refs - observed_signal_refs):
+        required += 1
+        signal_bindings = [
+            binding
+            for binding in (bindings or {}).get("bindings", [])
+            if isinstance(binding, dict)
+            and binding.get("renderer_kind") == "gatus"
+            and binding.get("signal_ref") == signal_ref
+            and isinstance(binding.get("output_identity"), str)
+        ]
+        if len(signal_bindings) == 1:
+            binding = signal_bindings[0]
+            bound += 1
+            evidence.append(
+                DoctorEvidence(
+                    id=binding["output_identity"],
+                    adapter="gatus",
+                    signal_refs=[signal_ref],
+                    status="unknown",
+                    reason="no_live_observation_evidence",
+                )
+            )
+        else:
+            unbound += 1
+            evidence.append(
+                DoctorEvidence(
+                    id=f"logical-service/{target_id}/{signal_ref}",
+                    adapter=None,
+                    signal_refs=[signal_ref],
+                    status="unknown",
+                    reason="observer_binding_undeclared",
+                )
+            )
     return (
         DoctorCoverage(
             required=required,

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -212,7 +212,10 @@ COMMAND_METADATA: dict[str, dict[str, Any]] = {
     "check": {"description": "Run health checks for edges.", "usage": "infralink check"},
     "doctor": {
         "description": "Validate declared observation coverage and inspect declared evidence.",
-        "usage": "infralink doctor [host|service|edge|profile <ref>] [--validate]",
+        "usage": (
+            "infralink doctor [host|service|edge|profile <ref>] [--validate]; "
+            "logical services use service <host-uuid>/<service-id>"
+        ),
     },
     "diagram": {
         "description": "Generate topology diagrams.",

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -293,6 +293,18 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         ],
         "examples": ["infralink resolve 058e29ff-57b9-47c8-b6fa-0914ac03e25c"],
     },
+    ("doctor",): {
+        "description": "Inspect declared observation coverage and live evidence.",
+        "arguments": [
+            {"name": "target_type", "type": "choice", "required": False},
+            {"name": "target_ref", "type": "string", "required": False},
+        ],
+        "options": [],
+        "examples": [
+            "infralink doctor host cyberstorm-watchtower",
+            "infralink doctor service <host-uuid>/<logical-service-id>",
+        ],
+    },
     ("app", "list"): {
         "description": "List application groupings.",
         "arguments": [],

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -89,6 +89,17 @@ def test_global_doctor_requires_declared_observation_inputs() -> None:
     assert payload["command"]["resolved"]["gatus_configured"] is False
 
 
+def test_doctor_help_discloses_host_qualified_logical_service_targets() -> None:
+    result = CliRunner().invoke(cli, ["help", "doctor"])
+    payload = yaml.safe_load(result.output)
+
+    assert result.exit_code == 0
+    assert payload["result"]["examples"] == [
+        "infralink doctor host cyberstorm-watchtower",
+        "infralink doctor service <host-uuid>/<logical-service-id>",
+    ]
+
+
 def test_doctor_validate_host_summarizes_normal_unknown_evidence_without_network_calls(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -223,7 +223,7 @@ def test_doctor_service_resolves_a_host_qualified_logical_service(tmp_path: Path
             "host_id": HOST_ID,
             "primary_service_id": f"{HOST_ID}/postgresql",
             "component_service_ids": [f"{HOST_ID}/postgresql", f"{HOST_ID}/proxy"],
-            "health_signal_refs": [f"dependency/{OBSERVATION_ID}/health/reachable"],
+            "health_signal_refs": [f"service/{HOST_ID}/postgresql/ready/up"],
             "source_refs": [],
         }
     ]
@@ -239,6 +239,26 @@ def test_doctor_service_resolves_a_host_qualified_logical_service(tmp_path: Path
             "health_signal_refs": ["dependency/database-stack-internal/health/reachable"],
         }
     )
+    binding_payload = yaml.safe_load(bindings.read_text(encoding="utf-8"))
+    binding_payload["bindings"].append(
+        {
+            "id": "gatus-database-stack-internal",
+            "renderer_kind": "gatus",
+            "observation_backend_id": "core-health",
+            "output_identity": "database-stack-internal",
+            "signal_ref": "dependency/database-stack-internal/health/reachable",
+        }
+    )
+    binding_payload["bindings"].append(
+        {
+            "id": "gatus-postgresql-ready",
+            "renderer_kind": "gatus",
+            "observation_backend_id": "core-health",
+            "output_identity": "postgresql-ready",
+            "signal_ref": f"service/{HOST_ID}/postgresql/ready/up",
+        }
+    )
+    bindings.write_text(yaml.safe_dump(binding_payload, sort_keys=False), encoding="utf-8")
     plan.write_text(json.dumps(payload), encoding="utf-8")
 
     result = _invoke(
@@ -264,12 +284,52 @@ def test_doctor_service_resolves_a_host_qualified_logical_service(tmp_path: Path
         "component_count": 2,
     }
     assert response["result"]["coverage"] == {
-        "required": 1,
-        "bound": 1,
+        "required": 3,
+        "bound": 3,
         "unbound": 0,
         "unsupported": 0,
         "valid": True,
     }
+
+
+def test_doctor_logical_service_fails_coverage_without_component_health_binding(
+    tmp_path: Path,
+) -> None:
+    plan, bindings = _observation_inputs(tmp_path)
+    payload = json.loads(plan.read_text(encoding="utf-8"))
+    logical_service_id = f"{HOST_ID}/database-stack"
+    payload["logical_services"] = [
+        {
+            "id": logical_service_id,
+            "host_id": HOST_ID,
+            "primary_service_id": f"{HOST_ID}/postgresql",
+            "component_service_ids": [f"{HOST_ID}/postgresql"],
+            "health_signal_refs": [f"service/{HOST_ID}/postgresql/ready/up"],
+            "source_refs": [],
+        }
+    ]
+    plan.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _invoke(
+        "--observation-plan",
+        str(plan),
+        "--adapter-bindings",
+        str(bindings),
+        "service",
+        logical_service_id,
+        "--validate",
+    )
+    response = json.loads(result.output)
+
+    assert result.exit_code == 1
+    assert response["result"]["coverage"] == {
+        "required": 2,
+        "bound": 1,
+        "unbound": 1,
+        "unsupported": 0,
+        "valid": False,
+    }
+    assert response["result"]["reason"] == "observer_coverage_incomplete"
 
 
 def test_doctor_validate_requires_an_explicit_observation_plan() -> None:

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -213,6 +213,65 @@ def test_doctor_profile_resolves_declared_observation_profile_not_service_or_rol
     assert payload["result"]["coverage"]["valid"] is True
 
 
+def test_doctor_service_resolves_a_host_qualified_logical_service(tmp_path: Path) -> None:
+    plan, bindings = _observation_inputs(tmp_path)
+    payload = json.loads(plan.read_text(encoding="utf-8"))
+    logical_service_id = f"{HOST_ID}/database-stack"
+    payload["logical_services"] = [
+        {
+            "id": logical_service_id,
+            "host_id": HOST_ID,
+            "primary_service_id": f"{HOST_ID}/postgresql",
+            "component_service_ids": [f"{HOST_ID}/postgresql", f"{HOST_ID}/proxy"],
+            "health_signal_refs": [f"dependency/{OBSERVATION_ID}/health/reachable"],
+            "source_refs": [],
+        }
+    ]
+    payload["services"].append({"id": f"{HOST_ID}/proxy", "profile_id": "proxy"})
+    payload["dependencies"].append(
+        {
+            "id": "database-stack-internal",
+            "source_service_id": f"{HOST_ID}/postgresql",
+            "target_service_id": f"{HOST_ID}/proxy",
+            "target_endpoint_id": f"{HOST_ID}/proxy/http",
+            "required": True,
+            "execution_adapter": "gatus",
+            "health_signal_refs": ["dependency/database-stack-internal/health/reachable"],
+        }
+    )
+    plan.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _invoke(
+        "--observation-plan",
+        str(plan),
+        "--adapter-bindings",
+        str(bindings),
+        "service",
+        logical_service_id,
+        "--validate",
+    )
+    response = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert response["result"]["target"] == {
+        "type": "service",
+        "id": logical_service_id,
+        "canonical_name": "database.example.com/database-stack",
+    }
+    assert response["result"]["declared"] == {
+        "host_id": HOST_ID,
+        "component_service_ids": [f"{HOST_ID}/postgresql", f"{HOST_ID}/proxy"],
+        "component_count": 2,
+    }
+    assert response["result"]["coverage"] == {
+        "required": 1,
+        "bound": 1,
+        "unbound": 0,
+        "unsupported": 0,
+        "valid": True,
+    }
+
+
 def test_doctor_validate_requires_an_explicit_observation_plan() -> None:
     result = _invoke("host", "database.example.com", "--validate")
     payload = json.loads(result.output)


### PR DESCRIPTION
## Summary
- resolve a host-qualified logical aggregate through the existing `doctor service` command
- report its component services and evaluate only declared edges crossing the aggregate boundary
- preserve existing service-name and profile behavior

## Verification
- `/root/.local/bin/ruff format --check src tests scripts`
- `/root/.local/bin/ruff check src tests scripts`
- `/root/.local/bin/mypy src scripts`
- `/root/.local/bin/pytest -q --no-cov tests/test_cli_doctor.py`