### PR TITLE
Preflight declared host SSH identity

### DIFF
--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -21,6 +21,7 @@ from infralink.cli.contracts import (
     DoctorResult,
     DoctorTarget,
     HostReadinessCheck,
+    HostReadinessResult,
 )
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
 from infralink.cli.host_readiness import evaluate_host_readiness
@@ -595,33 +596,66 @@ def _host_readiness(ctx: Context, target_ref: str, declaration_only: bool) -> An
     host = ctx.registry.get(target_ref)
     if host is None:
         return None
-    readiness = evaluate_host_readiness(
-        host, SshReadinessTransport(_declared_firewall_rules(ctx, str(host.uuid)))
+    fingerprint_check: HostReadinessCheck | None = None
+    manifest_path = (
+        ctx.registry_path / str(host.uuid) / "manifest.yml" if ctx.registry_path else None
     )
-    if not bool(getattr(host, "self_deploy_v2_reconcile_enabled", False)):
-        return readiness
     try:
-        from infralink.cli.operations import resolve_apply_request, validate_target_ssh_identity
+        manifest = (
+            yaml.safe_load(manifest_path.read_text(encoding="utf-8")) if manifest_path else {}
+        )
+        declared_v2 = bool(
+            manifest.get("hosts", {})
+            .get(str(host.uuid), {})
+            .get("self_deploy_v2_target_ssh_host_fingerprint")
+        )
+    except (OSError, TypeError, yaml.YAMLError):
+        declared_v2 = False
+    if declared_v2:
+        try:
+            from infralink.cli.operations import pinned_target_ssh_identity, resolve_apply_request
 
-        if ctx.registry_path is None:
-            raise ValueError
-        validate_target_ssh_identity(resolve_apply_request(ctx.registry_path, host))
-        check = HostReadinessCheck(
-            id="ssh_host_fingerprint",
-            required=True,
-            passed=True,
-            description="Declared SSH host key matches the live target.",
+            if ctx.registry_path is None:
+                raise ValueError
+            request = resolve_apply_request(ctx.registry_path, host)
+            with pinned_target_ssh_identity(request) as known_hosts:
+                readiness = evaluate_host_readiness(
+                    host,
+                    SshReadinessTransport(
+                        _declared_firewall_rules(ctx, str(host.uuid)), known_hosts
+                    ),
+                )
+            fingerprint_check = HostReadinessCheck(
+                id="ssh_host_fingerprint",
+                required=True,
+                passed=True,
+                description="Declared SSH host key matches the live target.",
+            )
+        except (CliFailure, ValueError):
+            return HostReadinessResult(
+                transport="root_ssh",
+                ready=False,
+                checks=[
+                    HostReadinessCheck(
+                        id="ssh_host_fingerprint",
+                        required=True,
+                        passed=False,
+                        description="Declared SSH host key matches the live target.",
+                        detail="ssh_host_fingerprint_mismatch",
+                    )
+                ],
+                actions=[],
+            )
+    if fingerprint_check is None:
+        readiness = evaluate_host_readiness(
+            host, SshReadinessTransport(_declared_firewall_rules(ctx, str(host.uuid)))
         )
-    except (CliFailure, ValueError):
-        check = HostReadinessCheck(
-            id="ssh_host_fingerprint",
-            required=True,
-            passed=False,
-            description="Declared SSH host key matches the live target.",
-            detail="ssh_host_fingerprint_mismatch",
+    return (
+        readiness
+        if fingerprint_check is None
+        else readiness.model_copy(
+            update={"ready": readiness.ready, "checks": [*readiness.checks, fingerprint_check]}
         )
-    return readiness.model_copy(
-        update={"ready": readiness.ready and check.passed, "checks": [*readiness.checks, check]}
     )
 
 

--- a/src/infralink/cli/doctor.py
+++ b/src/infralink/cli/doctor.py
@@ -20,6 +20,7 @@ from infralink.cli.contracts import (
     DoctorEvidenceSummary,
     DoctorResult,
     DoctorTarget,
+    HostReadinessCheck,
 )
 from infralink.cli.errors import CliFailure, ErrorCode, ExitCode
 from infralink.cli.host_readiness import evaluate_host_readiness
@@ -594,8 +595,33 @@ def _host_readiness(ctx: Context, target_ref: str, declaration_only: bool) -> An
     host = ctx.registry.get(target_ref)
     if host is None:
         return None
-    return evaluate_host_readiness(
+    readiness = evaluate_host_readiness(
         host, SshReadinessTransport(_declared_firewall_rules(ctx, str(host.uuid)))
+    )
+    if not bool(getattr(host, "self_deploy_v2_reconcile_enabled", False)):
+        return readiness
+    try:
+        from infralink.cli.operations import resolve_apply_request, validate_target_ssh_identity
+
+        if ctx.registry_path is None:
+            raise ValueError
+        validate_target_ssh_identity(resolve_apply_request(ctx.registry_path, host))
+        check = HostReadinessCheck(
+            id="ssh_host_fingerprint",
+            required=True,
+            passed=True,
+            description="Declared SSH host key matches the live target.",
+        )
+    except (CliFailure, ValueError):
+        check = HostReadinessCheck(
+            id="ssh_host_fingerprint",
+            required=True,
+            passed=False,
+            description="Declared SSH host key matches the live target.",
+            detail="ssh_host_fingerprint_mismatch",
+        )
+    return readiness.model_copy(
+        update={"ready": readiness.ready and check.passed, "checks": [*readiness.checks, check]}
     )
 
 

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2313,6 +2313,7 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
     from infralink.cli.operations import (
         operation_provider,
         resolve_apply_request,
+        validate_target_ssh_identity,
         wait_for_terminal,
     )
 
@@ -2339,6 +2340,7 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
                 fix="Use a Git checkout containing the selected registry revision",
                 details={"registry": str(ctx.registry_path)},
             )
+        validate_target_ssh_identity(request)
         _emit(
             ok_envelope(
                 _context_for(path=["host", "apply"]),
@@ -2351,6 +2353,7 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
                         reconcile_mode="timer",
                         action_categories=["registry_checkout", "render", "reconcile"],
                     ),
+                    ssh_host_identity="passed",
                 ),
                 [
                     action(
@@ -2408,6 +2411,7 @@ def host_apply(ctx: Context, host_ref: str, dry_run: bool, wait: bool, timeout: 
         ),
         target=doctor_target,
         dispatch=HostDispatch(provider="ssh", status="accepted"),
+        ssh_host_identity="passed",
         failure=record.failure,
     )
     actions = []

--- a/src/infralink/cli/operation_contracts.py
+++ b/src/infralink/cli/operation_contracts.py
@@ -76,6 +76,9 @@ class HostApplyResult(ContractModel):
     dry_run: bool = Field(default=False, exclude_if=lambda value: not value)
     plan: HostApplyPlan | None = Field(default=None, exclude_if=lambda value: value is None)
     dispatch: HostDispatch | None = Field(default=None, exclude_if=lambda value: value is None)
+    ssh_host_identity: Literal["passed"] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
     target_status: TargetReconcileStatus | None = Field(
         default=None, exclude_if=lambda value: value is None
     )

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -454,6 +454,13 @@ def validate_target_ssh_identity(request: ApplyRequest) -> None:
         return
 
 
+@contextmanager
+def pinned_target_ssh_identity(request: ApplyRequest) -> Iterator[Path]:
+    """Yield a temporary known-hosts file bound to the declared target key."""
+    with _pinned_known_hosts(request) as known_hosts:
+        yield known_hosts
+
+
 def inspect_verifier(request: ApplyRequest) -> HostVerifierDiagnostic:
     """Return fixed, read-only V2 verifier facts over the declared SSH transport."""
     return SshOperationProvider().inspect_verifier(request)

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -448,6 +448,12 @@ def operation_provider() -> OperationProvider:
     return SshOperationProvider()
 
 
+def validate_target_ssh_identity(request: ApplyRequest) -> None:
+    """Validate the declared target key without opening an SSH session."""
+    with _pinned_known_hosts(request):
+        return
+
+
 def inspect_verifier(request: ApplyRequest) -> HostVerifierDiagnostic:
     """Return fixed, read-only V2 verifier facts over the declared SSH transport."""
     return SshOperationProvider().inspect_verifier(request)

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import subprocess
-from shlex import quote
 from pathlib import Path
+from shlex import quote
 
 from infralink.host_readiness import HostReadinessProbe
 

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from shlex import quote
+from pathlib import Path
 
 from infralink.host_readiness import HostReadinessProbe
 
@@ -65,26 +66,43 @@ fi
 class SshReadinessTransport:
     """Collect the bootstrap baseline over root SSH without remote mutation."""
 
-    def __init__(self, expected_firewall_rules: tuple[str, ...] = ()) -> None:
+    def __init__(
+        self, expected_firewall_rules: tuple[str, ...] = (), known_hosts: Path | None = None
+    ) -> None:
         self._expected_firewall_rules = expected_firewall_rules
+        self._known_hosts = known_hosts
 
     def probe(self, address: str) -> HostReadinessProbe:
         if not address:
             return _unreachable("host_address_missing")
         try:
-            completed = subprocess.run(
+            command = [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "LogLevel=ERROR",
+            ]
+            if self._known_hosts is not None:
+                command.extend(
+                    [
+                        "-o",
+                        "StrictHostKeyChecking=yes",
+                        "-o",
+                        f"UserKnownHostsFile={self._known_hosts}",
+                    ]
+                )
+            command.extend(
                 [
-                    "ssh",
-                    "-o",
-                    "BatchMode=yes",
-                    "-o",
-                    "ConnectTimeout=10",
-                    "-o",
-                    "LogLevel=ERROR",
                     f"root@{address}",
                     "sh",
                     "-s",
-                ],
+                ]
+            )
+            completed = subprocess.run(
+                command,
                 input=_REMOTE_PROBE + _firewall_probe(self._expected_firewall_rules),
                 text=True,
                 capture_output=True,

--- a/src/infralink/schemas/cli/v1/host-apply.json
+++ b/src/infralink/schemas/cli/v1/host-apply.json
@@ -258,6 +258,19 @@
           ],
           "default": null
         },
+        "ssh_host_identity": {
+          "anyOf": [
+            {
+              "const": "passed",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ssh Host Identity"
+        },
         "target": {
           "$ref": "#/$defs/DoctorTarget"
         },

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -181,7 +181,9 @@ def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
     tmp_path: Path, host_id: str, canonical_name: str, address: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
-    monkeypatch.setattr("infralink.cli.operations.validate_target_ssh_identity", lambda request: None)
+    monkeypatch.setattr(
+        "infralink.cli.operations.validate_target_ssh_identity", lambda request: None
+    )
 
     response = CliRunner().invoke(
         cli, ["--registry", str(registry), "host", "apply", host_id, "--dry-run"]

--- a/tests/test_cli_host_apply.py
+++ b/tests/test_cli_host_apply.py
@@ -178,9 +178,10 @@ def _explicit_legacy_verifier_layout(registry: Path) -> None:
 
 @pytest.mark.parametrize(("host_id", "canonical_name", "address"), CORE_HOSTS)
 def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
-    tmp_path: Path, host_id: str, canonical_name: str, address: str
+    tmp_path: Path, host_id: str, canonical_name: str, address: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     registry = _manifest_registry_checkout(tmp_path)
+    monkeypatch.setattr("infralink.cli.operations.validate_target_ssh_identity", lambda request: None)
 
     response = CliRunner().invoke(
         cli, ["--registry", str(registry), "host", "apply", host_id, "--dry-run"]
@@ -191,6 +192,7 @@ def test_host_apply_dry_run_derives_each_core_transport_from_its_manifest(
     assert_schema(payload, "host-apply")
     assert payload["result"] == {
         "dry_run": True,
+        "ssh_host_identity": "passed",
         "target": {"type": "host", "id": host_id, "canonical_name": canonical_name},
         "plan": {
             "registry_revision": _git(registry.parent, "rev-parse", "HEAD"),
@@ -526,6 +528,7 @@ def test_host_apply_starts_only_declared_reconcile_unit_and_returns_opaque_run_r
             "id": f"ssh/{HOST_ID}/{INVOCATION}",
             "state": "applying",
         },
+        "ssh_host_identity": "passed",
         "target": {"type": "host", "id": HOST_ID, "canonical_name": HOST_NAME},
         "dispatch": {"provider": "ssh", "status": "accepted"},
     }


### PR DESCRIPTION
Closes #131.\n\n- shares declared SSH fingerprint validation with host apply dry-run and transport\n- surfaces compact dispatch and SSH identity facts in the HATEOAS result\n- adds the same identity check to normal V2 host doctor readiness\n\nVerified: `python3 -m pytest --no-cov tests/test_cli_doctor.py tests/test_cli_host_apply.py -q`.