### PR TITLE
feat: bootstrap declared Tailnet controller hosts

### DIFF
--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -62,9 +62,11 @@ class Action(ContractModel):
 
 
 BootstrapActionId = Literal[
+    "bootstrap_infralink_controller",
     "create_devops_account",
     "configure_devops_authorized_access",
     "install_docker",
+    "install_git",
     "install_jq",
     "install_bws_cli",
     "install_self_deploy_dependencies",
@@ -72,6 +74,24 @@ BootstrapActionId = Literal[
     "install_self_deploy_runtime",
     "enable_self_deploy_timer",
 ]
+
+
+class HostControllerBootstrapSecretRef(ContractModel):
+    """A registry-owned BWS secret reference, never a secret value."""
+
+    project: str = Field(min_length=1, max_length=255)
+    id: str = Field(
+        pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    )
+
+
+class HostControllerBootstrapState(ContractModel):
+    """Non-secret desired inputs for the sole host controller bootstrap path."""
+
+    controller_image: str = Field(min_length=1, max_length=512)
+    registry_read_identity_secret: HostControllerBootstrapSecretRef
+    registry_repo_url: str = Field(min_length=1, max_length=1024)
+    registry_ref: str = Field(pattern=r"^[A-Za-z0-9._/-]{1,255}$")
 
 
 class HostBootstrapV2State(ContractModel):
@@ -107,6 +127,7 @@ class HostBootstrapRequest(ContractModel):
     canonical_name: str = Field(min_length=1, max_length=255)
     bootstrap_actions: list[BootstrapActionId] = Field(min_length=1, max_length=9)
     v2: HostBootstrapV2State | None = None
+    controller_bootstrap: HostControllerBootstrapState | None = None
 
     @model_validator(mode="after")
     def require_v2_state_for_v2_materialization(self) -> HostBootstrapRequest:
@@ -115,6 +136,13 @@ class HostBootstrapRequest(ContractModel):
             & set(self.bootstrap_actions)
         ) and self.v2 is None:
             raise ValueError("V2 bootstrap actions require declared V2 state")
+        if (
+            "bootstrap_infralink_controller" in self.bootstrap_actions
+            and self.controller_bootstrap is None
+        ):
+            raise ValueError(
+                "controller bootstrap action requires declared controller bootstrap state"
+            )
         return self
 
     def ansible_extra_vars(self) -> dict[str, Any]:
@@ -127,6 +155,15 @@ class HostBootstrapRequest(ContractModel):
         }
         if self.v2 is not None:
             values.update(self.v2.model_dump())
+        if self.controller_bootstrap is not None:
+            values.update(
+                {
+                    "controller_image": self.controller_bootstrap.controller_image,
+                    "registry_read_identity_secret_uuid": self.controller_bootstrap.registry_read_identity_secret.id,
+                    "registry_repo_url": self.controller_bootstrap.registry_repo_url,
+                    "registry_ref": self.controller_bootstrap.registry_ref,
+                }
+            )
         return values
 
 

--- a/src/infralink/cli/host_readiness.py
+++ b/src/infralink/cli/host_readiness.py
@@ -16,6 +16,8 @@ class ReadinessTransport(Protocol):
 def evaluate_host_readiness(
     host: Any,
     transport: ReadinessTransport | None,
+    *,
+    address: str | None = None,
 ) -> HostReadinessResult:
     """Return one typed baseline evaluation; no command owns its own checks."""
     canonical_name = str(host.canonical_name)
@@ -35,14 +37,26 @@ def evaluate_host_readiness(
         )
         transport_name = "declaration_only"
     else:
-        address = getattr(host, "tailscale_ip", None) or getattr(host, "public_ip", None) or ""
-        probe = transport.probe(str(address))
+        selected_address = (
+            address
+            if address is not None
+            else getattr(host, "tailscale_ip", None) or getattr(host, "public_ip", None) or ""
+        )
+        probe = transport.probe(str(selected_address))
         transport_name = "root_ssh"
-    requires_v2_registry_layout = bool(
-        getattr(host, "self_deploy_v2_registry_layout_enabled", False)
+    requires_v2_registry_layout = bool(getattr(host, "self_deploy_v2_registry_layout_enabled", False))
+    requires_controller_reconcile = bool(getattr(host, "controller_bootstrap", None))
+    # Canonical controller bootstrap hosts must prove the normal reconcile loop;
+    # they do not carry legacy V2 declaration flags.
+    require_reconcile = bool(
+        getattr(host, "self_deploy_v2_reconcile_enabled", False)
+        or requires_controller_reconcile
     )
-    require_reconcile = bool(getattr(host, "self_deploy_v2_reconcile_enabled", True))
-    probe = replace(probe, requires_v2_registry_layout=requires_v2_registry_layout)
+    probe = replace(
+        probe,
+        requires_v2_registry_layout=requires_v2_registry_layout,
+        requires_controller_reconcile=requires_controller_reconcile,
+    )
     readiness = HostReadinessEvaluator().evaluate(
         canonical_name=canonical_name,
         probe=probe,

--- a/src/infralink/cli/host_readiness.py
+++ b/src/infralink/cli/host_readiness.py
@@ -44,13 +44,14 @@ def evaluate_host_readiness(
         )
         probe = transport.probe(str(selected_address))
         transport_name = "root_ssh"
-    requires_v2_registry_layout = bool(getattr(host, "self_deploy_v2_registry_layout_enabled", False))
+    requires_v2_registry_layout = bool(
+        getattr(host, "self_deploy_v2_registry_layout_enabled", False)
+    )
     requires_controller_reconcile = bool(getattr(host, "controller_bootstrap", None))
     # Canonical controller bootstrap hosts must prove the normal reconcile loop;
     # they do not carry legacy V2 declaration flags.
     require_reconcile = bool(
-        getattr(host, "self_deploy_v2_reconcile_enabled", False)
-        or requires_controller_reconcile
+        getattr(host, "self_deploy_v2_reconcile_enabled", False) or requires_controller_reconcile
     )
     probe = replace(
         probe,

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -33,9 +33,12 @@ from infralink.cli.contracts import (
     HelpNavigationAction,
     HelpResult,
     HelpSubcommand,
+    HostBootstrapAction,
     HostBootstrapPlanResult,
     HostBootstrapRequest,
-    HostBootstrapV2State,
+    HostControllerBootstrapState,
+    HostReadinessCheck,
+    HostReadinessResult,
     InfoResult,
     InfoSources,
     InfoSummary,
@@ -63,6 +66,7 @@ from infralink.cli.output import (
     error_envelope,
     ok_envelope,
 )
+from infralink.host_readiness import HostReadinessProbe
 from infralink.host_transport import SshReadinessTransport
 
 # Topology sources are intentionally explicit. Examples are demo/test fixtures,
@@ -76,22 +80,6 @@ _ENVELOPE_EMITTED: ContextVar[bool] = ContextVar("infralink_envelope_emitted", d
 _DEFER_ENVELOPE: ContextVar[bool] = ContextVar("infralink_defer_envelope", default=False)
 _PENDING_ENVELOPE: ContextVar[str | None] = ContextVar("infralink_pending_envelope", default=None)
 _CONTROL_ROOT = Path(os.environ.get("INFRALINK_CONTROL_ROOT", "/opt/infra"))
-BASELINE_EXECUTOR_ACTIONS: frozenset[str] = frozenset(
-    {
-        "create_devops_account",
-        "configure_devops_authorized_access",
-        "install_docker",
-        "install_jq",
-        "install_bws_cli",
-        "install_self_deploy_dependencies",
-        "enable_self_deploy_timer",
-        "migrate_v2_registry_layout",
-        "install_self_deploy_runtime",
-    }
-)
-_V2_BOOTSTRAP_ACTIONS: frozenset[str] = frozenset(
-    {"migrate_v2_registry_layout", "install_self_deploy_runtime"}
-)
 _CONTROLLER_REFRESH_PLAYBOOK = "ansible/playbooks/infralink_controller_refresh.yml"
 _CONTROLLER_REFRESH_SOURCE_REMOTE = "https://github.com/relax-dot-gg/infra-management.git"
 
@@ -349,15 +337,17 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         "examples": ["infralink host show host-1"],
     },
     ("host", "bootstrap"): {
-        "description": "Plan host bootstrap actions or refresh a failed V2 controller.",
+        "description": "Plan or apply a declared Tailnet host bootstrap.",
         "arguments": [{"name": "host_id", "type": "string", "required": True}],
         "options": [
+            {"name": "ssh_host", "type": "text", "required": True},
+            {"name": "bws_token_stdin", "type": "boolean", "required": False},
             {"name": "plan", "type": "boolean", "required": False},
             {"name": "apply", "type": "boolean", "required": False},
         ],
         "examples": [
-            "infralink host bootstrap host-1 --plan",
-            "infralink host bootstrap host-1 --apply",
+            "infralink host bootstrap host-1 --ssh-host 100.64.0.1",
+            "printf '%s\\n' \"$HOST_BWS_TOKEN\" | infralink host bootstrap host-1 --ssh-host 100.64.0.1 --bws-token-stdin --apply",
         ],
     },
     ("host", "apply"): {
@@ -1785,6 +1775,17 @@ def host_show(
 @host.command(name="bootstrap")
 @click.argument("host_id")
 @click.option(
+    "--ssh-host",
+    required=True,
+    metavar="TAILNET_IPV4",
+    help="Declared Tailnet IPv4 address used for the bootstrap SSH connection.",
+)
+@click.option(
+    "--bws-token-stdin",
+    is_flag=True,
+    help="Read the host machine BWS token from standard input.",
+)
+@click.option(
     "--plan",
     "plan_only",
     is_flag=True,
@@ -1797,103 +1798,69 @@ def host_show(
     help="Apply failed host baseline actions or the declared V2 controller refresh.",
 )
 @pass_context
-def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: bool) -> int:
+def host_bootstrap(
+    ctx: Context,
+    host_id: str,
+    ssh_host: str,
+    bws_token_stdin: bool,
+    plan_only: bool,
+    apply_changes: bool,
+) -> int:
     """Plan required bootstrap actions or refresh a failed V2 controller."""
     target = ctx.registry.get(host_id)
     if target is None:
         raise entity_not_found("host", host_id)
-    readiness = evaluate_host_readiness(target, SshReadinessTransport())
-    if plan_only == apply_changes:
-        raise click.UsageError("pass exactly one of --plan or --apply")
-    v2_bootstrap_declared = bool(getattr(target, "self_deploy_v2_registry_layout_enabled", False))
-    required_v2_actions = (
-        [item.id for item in readiness.actions if item.id in _V2_BOOTSTRAP_ACTIONS]
-        if v2_bootstrap_declared
-        else []
-    )
-    if required_v2_actions:
-        _bootstrap_apply_request(ctx, target, required_v2_actions)
-    automated_actions = [
-        item.id
-        for item in readiness.actions
-        if item.id in BASELINE_EXECUTOR_ACTIONS
-        and (item.id not in _V2_BOOTSTRAP_ACTIONS or v2_bootstrap_declared)
-    ]
-    refresh_controller = any(
-        item.id == "inspect_self_deploy_reconcile" for item in readiness.actions
-    )
-    controller_runtime_revision: str | None = None
-    if refresh_controller and ctx.registry_path is not None and ctx.registry_path.is_dir():
-        controller_runtime_revision, _ = _controller_refresh_extra_vars(ctx.registry_path, target)
-    if (
-        apply_changes
-        and refresh_controller
-        and ctx.registry_path is not None
-        and ctx.registry_path.is_dir()
-    ):
-        _apply_controller_refresh(ctx, target, controller_runtime_revision)
-        readiness = evaluate_host_readiness(target, SshReadinessTransport())
-    elif apply_changes and automated_actions:
-        request = _bootstrap_apply_request(ctx, target, automated_actions)
-        control_root = _CONTROL_ROOT
-        playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
-        if not playbook.is_file():
-            raise CliFailure(
-                code=ErrorCode.PROVIDER_UNAVAILABLE,
-                message="Bastion host-bootstrap capability is not installed",
-                exit_code=ExitCode.PROVIDER_ERROR,
-                fix="Install the current infra-management host-bootstrap capability on Bastion",
-                details={"capability": "host_bootstrap"},
-            )
-        completed = subprocess.run(
-            [
-                "ansible-playbook",
-                "-i",
-                f"{request.host_address},",
-                "-u",
-                "root",
-                str(playbook),
-                "-e",
-                json.dumps(request.ansible_extra_vars(), sort_keys=True),
-            ],
-            cwd=control_root,
-            text=True,
-            capture_output=True,
-            check=False,
+    if plan_only and apply_changes:
+        raise click.UsageError("pass at most one of --plan or --apply")
+    address = _bootstrap_tailnet_address(target, ssh_host)
+    if apply_changes and not bws_token_stdin:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Host bootstrap apply requires a BWS token on standard input",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Pipe the host machine token to infralink host bootstrap --bws-token-stdin --apply",
+            details={"host": target.uuid, "requirement": "bws_token_stdin"},
         )
-        if completed.returncode != 0:
-            raise CliFailure(
-                code=ErrorCode.PROVIDER_UNAVAILABLE,
-                message="Host baseline apply failed",
-                exit_code=ExitCode.PROVIDER_ERROR,
-                fix="Verify the declared bootstrap executor and rerun host bootstrap --apply",
-                details=_bootstrap_failure_details(target.uuid, completed),
+    projects = _bootstrap_declared_bws_projects(ctx, target)
+    token = _read_bootstrap_bws_token() if bws_token_stdin else None
+    controller_state = _controller_bootstrap_state(ctx.registry_path, target)
+    if token is not None:
+        _validate_bootstrap_bws_access(
+            ctx, projects, token, controller_secret=controller_state.registry_read_identity_secret
+        )
+    with _bootstrap_pinned_transport(ctx, target, address) as transport:
+        probe = transport.probe(address)
+        _require_remote_tailnet_identity(target, probe, address)
+        readiness = _bootstrap_operator_readiness(
+            evaluate_host_readiness(target, _BootstrapProbeTransport(probe), address=address)
+        )
+        if token is None:
+            readiness = _readiness_with_bws_token_required(readiness)
+        automated_actions = _bootstrap_executor_actions(readiness)
+        if apply_changes and automated_actions:
+            readiness = _apply_bootstrap_request(
+                ctx,
+                target,
+                address,
+                automated_actions,
+                controller_state,
+                token,
+                transport.known_hosts,
             )
-        readiness = evaluate_host_readiness(target, SshReadinessTransport())
     actions = [
         action(
             "reinspect-readiness",
-            [*_root_source_argv(ctx), "host", "bootstrap", target.uuid, "--plan"],
+            [
+                *_root_source_argv(ctx),
+                "host",
+                "bootstrap",
+                target.uuid,
+                "--ssh-host",
+                address,
+            ],
             "Reinspect live host readiness",
         )
     ]
-    if any(item.id == "inspect_self_deploy_reconcile" for item in readiness.actions):
-        if controller_runtime_revision is not None:
-            actions.append(
-                action(
-                    "refresh-controller",
-                    [*_root_source_argv(ctx), "host", "bootstrap", target.uuid, "--apply"],
-                    f"Refresh controller runtime {controller_runtime_revision}",
-                    safe=False,
-                )
-            )
-        actions.append(
-            action(
-                "verifier",
-                [*_root_source_argv(ctx), "host", "verifier", target.uuid],
-                "Inspect the read-only self-deploy verifier facts",
-            )
-        )
     result = HostBootstrapPlanResult(
         host=DoctorTarget(type="host", id=target.uuid, canonical_name=target.canonical_name),
         readiness=readiness,
@@ -1908,53 +1875,451 @@ def host_bootstrap(ctx: Context, host_id: str, plan_only: bool, apply_changes: b
     return 0 if readiness.ready or plan_only else 1
 
 
+_TAILNET_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _bootstrap_tailnet_address(target: Any, ssh_host: str) -> str:
+    """Accept only the exact registry-owned Tailnet SSH target."""
+    try:
+        supplied = ipaddress.ip_address(ssh_host)
+        declared = ipaddress.ip_address(str(target.tailscale_ip))
+    except ValueError:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Host bootstrap requires a declared Tailnet IPv4 address",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare the host Tailnet IPv4 and pass it with --ssh-host",
+            details={"host": target.uuid},
+        ) from None
+    if (
+        not isinstance(supplied, ipaddress.IPv4Address)
+        or supplied not in _TAILNET_NETWORK
+        or supplied != declared
+    ):
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap SSH host must exactly match the declared Tailnet IPv4",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Pass the registry tailscale_ip with --ssh-host",
+            details={"host": target.uuid, "declared_tailscale_ip": str(declared)},
+        )
+    return str(supplied)
+
+
+def _bootstrap_declared_bws_projects(ctx: Context, target: Any) -> tuple[str, ...]:
+    """Resolve the new explicit BWS access contract, without legacy fallbacks."""
+    projects = tuple(getattr(target, "bws_projects", ()))
+    machine_account = getattr(target, "bws_machine_account", None)
+    if not projects or not isinstance(machine_account, str) or not machine_account.strip():
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Host bootstrap requires bws_projects and bws_machine_account",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare the host machine account and one or more canonical bws_projects",
+            details={"host": target.uuid},
+        )
+    if len(set(projects)) != len(projects) or any(
+        not isinstance(item, str) or not item for item in projects
+    ):
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Host bootstrap bws_projects must be a unique nonempty list",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Correct the host bws_projects declaration",
+            details={"host": target.uuid},
+        )
+    return projects
+
+
+def _read_bootstrap_bws_token() -> str:
+    token = sys.stdin.read().strip()
+    if not token:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="BWS token standard input was empty",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Pipe the host machine token to host bootstrap --bws-token-stdin --apply",
+            details={"requirement": "bws_token_stdin"},
+        )
+    return token
+
+
+def _bws_project_catalog(ctx: Context) -> dict[str, str]:
+    if ctx.registry_path is None:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap BWS validation requires a registry directory checkout",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Use the checked-out registry hosts directory",
+        )
+    catalog = ctx.registry_path.parent / "ansible" / "inventory" / "bws_projects.yml"
+    try:
+        data = yaml.safe_load(catalog.read_text(encoding="utf-8"))
+        raw_projects = data["projects"]
+        projects = {
+            alias: entry["uuid"]
+            for alias, entry in raw_projects.items()
+            if isinstance(alias, str)
+            and isinstance(entry, dict)
+            and isinstance(entry.get("uuid"), str)
+        }
+    except (OSError, TypeError, KeyError, yaml.YAMLError):
+        projects = {}
+    if not projects:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap BWS project catalog is unavailable",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Provide a valid ansible/inventory/bws_projects.yml in the selected registry",
+        )
+    return projects
+
+
+def _validate_bootstrap_bws_access(
+    ctx: Context, aliases: tuple[str, ...], token: str, *, controller_secret: Any | None = None
+) -> None:
+    catalog = _bws_project_catalog(ctx)
+    missing = [alias for alias in aliases if alias not in catalog]
+    if missing:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Declared BWS project is absent from the registry catalog",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare only catalogued BWS project aliases",
+            details={"projects": missing},
+        )
+    environment = {**os.environ, "BWS_ACCESS_TOKEN": token}
+    for alias in aliases:
+        completed = subprocess.run(
+            ["bws", "project", "get", catalog[alias], "--output", "none"],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=20,
+            env=environment,
+        )
+        if completed.returncode != 0:
+            raise CliFailure(
+                code=ErrorCode.PROVIDER_AUTHORIZATION_FAILED,
+                message="BWS token cannot access a declared bootstrap project",
+                exit_code=ExitCode.PROVIDER_ERROR,
+                fix="Grant the declared machine account access to every bws_projects entry",
+                details={"project": alias},
+            )
+    if controller_secret is not None:
+        expected_project = catalog.get(controller_secret.project)
+        if expected_project is None:
+            raise CliFailure(
+                code=ErrorCode.CONFIGURATION_REQUIRED,
+                message="Controller bootstrap secret project is absent from the registry catalog",
+                exit_code=ExitCode.INPUT_ERROR,
+                fix="Declare a catalogued project for controller_bootstrap.registry_read_identity_secret",
+                details={"project": controller_secret.project},
+            )
+        completed = subprocess.run(
+            ["bws", "secret", "get", controller_secret.id, "--output", "json"],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=20,
+            env=environment,
+        )
+        try:
+            secret = json.loads(completed.stdout) if completed.returncode == 0 else {}
+            actual_project = secret.get("projectId")
+        except json.JSONDecodeError:
+            actual_project = None
+        if actual_project != expected_project:
+            raise CliFailure(
+                code=ErrorCode.PROVIDER_AUTHORIZATION_FAILED,
+                message="BWS token cannot read the declared controller registry secret",
+                exit_code=ExitCode.PROVIDER_ERROR,
+                fix="Grant the host machine account access to the declared secret project",
+                details={"project": controller_secret.project, "secret_id": controller_secret.id},
+            )
+
+
+class _BootstrapProbeTransport:
+    """Reuse one pinned SSH observation without issuing a second connection."""
+
+    def __init__(self, probe: HostReadinessProbe) -> None:
+        self._probe = probe
+
+    def probe(self, _address: str) -> HostReadinessProbe:
+        return self._probe
+
+
+@contextmanager
+def _bootstrap_pinned_transport(
+    ctx: Context, target: Any, address: str
+) -> Iterator[SshReadinessTransport]:
+    """Bootstrap uses the same declared SSH identity contract as reconcile."""
+    from infralink.cli.operations import _pinned_known_hosts, resolve_apply_request
+
+    if ctx.registry_path is None or not ctx.registry_path.is_dir():
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap requires a directory registry checkout",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Use the selected registry hosts directory",
+            details={"host": target.uuid},
+        )
+    request = resolve_apply_request(ctx.registry_path, target)
+    if request.address != address:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap SSH address differs from the declared pinned host identity",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Correct the declared Tailnet address and SSH fingerprint",
+            details={"host": target.uuid},
+        )
+    with _pinned_known_hosts(request) as known_hosts:
+        yield SshReadinessTransport(known_hosts=known_hosts)
+
+
+def _require_remote_tailnet_identity(target: Any, probe: HostReadinessProbe, address: str) -> None:
+    # The SSH probe intentionally exposes only addresses, never Tailnet auth material.
+    if not probe.reachable:
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Bootstrap SSH connection failed",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Install the authorized key and verify root SSH over the declared Tailnet address",
+            details={"host": target.uuid, "ssh_host": address},
+        )
+    if address not in probe.tailscale_ips:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Remote host is not enrolled at its declared Tailnet address",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Enroll Tailscale manually and correct the host declaration before bootstrap",
+            details={"host": target.uuid, "declared_tailscale_ip": address},
+        )
+    expected_name = target.tailscale_name or target.canonical_name
+    if not probe.tailscale_running or probe.tailscale_name != expected_name:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Remote Tailscale identity does not match the declared host",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Start Tailscale and correct its host name before bootstrap",
+            details={"host": target.uuid, "expected_name": expected_name},
+        )
+
+
+def _readiness_with_bws_token_required(readiness: HostReadinessResult) -> HostReadinessResult:
+    return readiness.model_copy(
+        update={
+            "ready": False,
+            "checks": [
+                *readiness.checks,
+                HostReadinessCheck(
+                    id="bws_token",
+                    required=True,
+                    passed=False,
+                    description="A host machine BWS token was supplied for bootstrap validation.",
+                    detail="bws_token_required",
+                ),
+            ],
+            "actions": [
+                *readiness.actions,
+                HostBootstrapAction(
+                    id="provide_bws_token",
+                    check_id="bws_token",
+                    description="Rerun bootstrap with --bws-token-stdin and provide the host machine token on standard input.",
+                ),
+            ],
+        }
+    )
+
+
+def _bootstrap_operator_readiness(readiness: HostReadinessResult) -> HostReadinessResult:
+    """Show only actionable prerequisites plus the one controller action."""
+    executable_prerequisites = {
+        "establish_root_ssh",
+        "correct_host_identity",
+        "initialize_machine_id",
+        "install_git",
+        "install_docker",
+        "install_tailscale",
+        "install_jq",
+        "install_bws_cli",
+        "install_self_deploy_dependencies",
+    }
+    checks = [
+        check
+        for check in readiness.checks
+        if check.id not in {"devops_account", "devops_authorized_access", "registry_layout"}
+    ]
+    actions = [item for item in readiness.actions if item.id in executable_prerequisites]
+    if not readiness.ready:
+        actions.append(
+            HostBootstrapAction(
+                id="bootstrap_infralink_controller",
+                check_id="controller_bootstrap",
+                description="Install the declared Infralink controller and reconcile timer.",
+            )
+        )
+    return readiness.model_copy(
+        update={
+            "checks": checks,
+            "actions": actions,
+            "ready": all(not check.required or check.passed for check in checks),
+        }
+    )
+
+
+def _bootstrap_executor_actions(readiness: HostReadinessResult) -> list[str]:
+    """Translate only declared bootstrap prerequisites into executor actions."""
+    executor_actions = {
+        "install_git",
+        "install_docker",
+        "install_jq",
+        "install_bws_cli",
+        "install_self_deploy_dependencies",
+    }
+    actions = [item.id for item in readiness.actions if item.id in executor_actions]
+    if not readiness.ready:
+        actions.append("bootstrap_infralink_controller")
+    return actions
+
+
+def _bootstrap_execution_env(token: str | None) -> dict[str, str]:
+    if token is None:
+        return dict(os.environ)
+    return {**os.environ, "BWS_ACCESS_TOKEN": token}
+
+
+def _apply_bootstrap_request(
+    ctx: Context,
+    target: Any,
+    address: str,
+    actions: list[str],
+    controller_state: HostControllerBootstrapState,
+    token: str | None,
+    known_hosts: Path | None,
+) -> HostReadinessResult:
+    """Run the sole baseline executor with the probe's pinned host identity."""
+    if known_hosts is None:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Bootstrap requires a pinned SSH host key",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare ssh.host_key_fingerprint before bootstrap",
+            details={"host": target.uuid},
+        )
+    request = _bootstrap_apply_request(
+        ctx, target, actions, address=address, controller_state=controller_state
+    )
+    with _bootstrap_executor_source(_CONTROL_ROOT, actions) as (source, playbook):
+        completed = subprocess.run(
+            [
+                "ansible-playbook",
+                "-i",
+                f"{request.host_address},",
+                "-u",
+                "root",
+                "--ssh-common-args",
+                f"-o StrictHostKeyChecking=yes -o UserKnownHostsFile={known_hosts}",
+                str(playbook),
+                "-e",
+                json.dumps(request.ansible_extra_vars(), sort_keys=True),
+            ],
+            cwd=source,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=_bootstrap_execution_env(token),
+        )
+    if completed.returncode != 0:
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Host baseline apply failed",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Verify the declared bootstrap executor and rerun host bootstrap --apply",
+            details=_bootstrap_failure_details(target.uuid, completed),
+        )
+    return _bootstrap_operator_readiness(
+        evaluate_host_readiness(
+            target, SshReadinessTransport(known_hosts=known_hosts), address=address
+        )
+    )
+
+
+@contextmanager
+def _bootstrap_executor_source(
+    control_root: Path, actions: Sequence[str]
+) -> Iterator[tuple[Path, Path]]:
+    """Use a clean detached snapshot of the authoritative management main branch."""
+    manifest_path = "ansible/executors/infralink-host-baseline.json"
+    with _controller_refresh_source(
+        control_root,
+        None,
+        required_path=manifest_path,
+        capability="host_bootstrap",
+    ) as source:
+        try:
+            manifest = json.loads((source / manifest_path).read_text(encoding="utf-8"))
+            playbook_path = manifest["playbook"]
+            allowed_actions = manifest["allowed_actions"]
+        except (OSError, KeyError, TypeError, json.JSONDecodeError):
+            manifest = None
+            playbook_path = None
+            allowed_actions = None
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("schema_version") != "infralink.host-bootstrap-executor/v1"
+            or manifest.get("id") != "infra-management-host-baseline"
+            or playbook_path != "ansible/playbooks/infralink_host_baseline.yml"
+            or not isinstance(allowed_actions, list)
+            or not all(isinstance(action_id, str) for action_id in allowed_actions)
+            or not set(actions).issubset(allowed_actions)
+        ):
+            raise CliFailure(
+                code=ErrorCode.CONFIGURATION_REQUIRED,
+                message="Selected host bootstrap executor does not support the requested actions",
+                exit_code=ExitCode.INPUT_ERROR,
+                fix="Publish a valid immutable infralink host-bootstrap executor",
+                details={"capability": "host_bootstrap"},
+            )
+        playbook = source / playbook_path
+        if not playbook.is_file():
+            raise CliFailure(
+                code=ErrorCode.PROVIDER_UNAVAILABLE,
+                message="Selected host bootstrap executor playbook is unavailable",
+                exit_code=ExitCode.PROVIDER_ERROR,
+                fix="Publish the declared executor playbook at the selected revision",
+                details={"capability": "host_bootstrap"},
+            )
+        yield source, playbook
+
+
 def _bootstrap_apply_request(
-    ctx: Context, target: Any, automated_actions: list[str]
+    ctx: Context,
+    target: Any,
+    automated_actions: list[str],
+    *,
+    address: str | None = None,
+    controller_state: HostControllerBootstrapState | None = None,
 ) -> HostBootstrapRequest:
     """Resolve a bounded executor request before any remote mutation begins."""
-    address = target.tailscale_ip or target.public_ip
+    address = address or target.tailscale_ip
     if not address:
         raise CliFailure(
             code=ErrorCode.CONFIGURATION_REQUIRED,
             message="Host address is required for bootstrap",
             exit_code=ExitCode.INPUT_ERROR,
-            fix="Declare a Tailscale or public address for the host",
+            fix="Declare a Tailnet address for the host",
             details={"host": target.uuid},
         )
     try:
-        v2: HostBootstrapV2State | None = None
-        if _V2_BOOTSTRAP_ACTIONS & set(automated_actions):
-            if ctx.registry_path is None or not ctx.registry_path.is_dir():
-                raise CliFailure(
-                    code=ErrorCode.CONFIGURATION_REQUIRED,
-                    message="V2 bootstrap actions require a directory registry checkout",
-                    exit_code=ExitCode.INPUT_ERROR,
-                    fix="Provide the selected registry hosts directory with its operations lock",
-                    details={"host": target.uuid},
-                )
-            runtime_revision, desired = _controller_refresh_extra_vars(ctx.registry_path, target)
-            v2 = HostBootstrapV2State.model_validate(
-                {
-                    "self_deploy_v2_runtime_revision": runtime_revision,
-                    **{
-                        name: value
-                        for name, value in desired.items()
-                        if name
-                        not in {
-                            "uuid",
-                            "canonical_name",
-                            "self_deploy_v2_runtime_revision",
-                        }
-                    },
-                }
-            )
+        controller_bootstrap: HostControllerBootstrapState | None = controller_state
         return HostBootstrapRequest.model_validate(
             {
                 "host_address": str(address),
                 "host_uuid": target.uuid,
                 "canonical_name": target.canonical_name,
                 "bootstrap_actions": automated_actions,
-                "v2": v2,
+                "controller_bootstrap": controller_bootstrap,
             }
         )
     except CliFailure:
@@ -1967,6 +2332,54 @@ def _bootstrap_apply_request(
             fix="Declare complete V2 bootstrap state and rerun host bootstrap --plan",
             details={"host": target.uuid},
         ) from None
+
+
+def _controller_bootstrap_state(
+    registry_path: Path | None, target: Any
+) -> HostControllerBootstrapState:
+    if registry_path is None:
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Controller bootstrap requires a registry directory checkout",
+            exit_code=ExitCode.INPUT_ERROR,
+        )
+    manifest_path = registry_path / target.uuid / "manifest.yml"
+    deployment_path = registry_path / target.uuid / "operations" / "deployment.yml"
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))["hosts"][target.uuid]
+        bootstrap = manifest["controller_bootstrap"]
+        deployment = yaml.safe_load(deployment_path.read_text(encoding="utf-8"))
+        image = deployment["controller"]["image"]
+        state = HostControllerBootstrapState.model_validate(
+            {
+                "controller_image": _controller_image_reference(image),
+                "registry_read_identity_secret": bootstrap["registry_read_identity_secret"],
+                "registry_repo_url": bootstrap["registry_repo_url"],
+                "registry_ref": bootstrap["registry_ref"],
+            }
+        )
+    except (OSError, KeyError, TypeError, ValueError, yaml.YAMLError):
+        raise CliFailure(
+            code=ErrorCode.CONFIGURATION_REQUIRED,
+            message="Selected host declaration lacks canonical controller bootstrap state",
+            exit_code=ExitCode.INPUT_ERROR,
+            fix="Declare controller_bootstrap with registry key reference, repository, and ref",
+            details={"host": target.uuid},
+        ) from None
+    return state
+
+
+def _controller_image_reference(image: Any) -> str:
+    """Use the same head/branch selector semantics for bootstrap and reconcile."""
+    if not isinstance(image, dict):
+        raise ValueError("controller image must be a mapping")
+    repository = image.get("repository")
+    tag = image.get("tag")
+    if tag == "head":
+        tag = image.get("branch", "main")
+    if not isinstance(repository, str) or not repository or not isinstance(tag, str) or not tag:
+        raise ValueError("controller image reference is incomplete")
+    return f"{repository}:{tag}"
 
 
 def _bootstrap_failure_details(
@@ -2052,8 +2465,15 @@ def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str |
 
 
 @contextmanager
-def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Path]:
-    """Materialize the selected immutable controller tree, never the live checkout."""
+def _controller_refresh_source(
+    control_root: Path,
+    revision: str | None,
+    *,
+    required_path: str | None = None,
+    capability: str = "controller_refresh",
+) -> Iterator[Path]:
+    """Materialize an immutable management tree, never the live checkout."""
+    required_path = required_path or _CONTROLLER_REFRESH_PLAYBOOK
     status = subprocess.run(
         ["git", "-C", str(control_root), "status", "--porcelain"],
         text=True,
@@ -2064,10 +2484,10 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
     if status.returncode != 0 or status.stdout:
         raise CliFailure(
             code=ErrorCode.PROVIDER_UNAVAILABLE,
-            message="Bastion cannot materialize the selected immutable controller source",
+            message="Bastion cannot materialize the selected immutable management source",
             exit_code=ExitCode.PROVIDER_ERROR,
             fix="Clean and refresh the Bastion infra-management checkout at the selected revision",
-            details={"capability": "controller_refresh", "required_revision": revision},
+            details={"capability": capability, "required_revision": revision},
         )
     remote = subprocess.run(
         ["git", "-C", str(control_root), "remote", "get-url", "origin"],
@@ -2081,10 +2501,10 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
     ) != _controller_remote_identity(_CONTROLLER_REFRESH_SOURCE_REMOTE):
         raise CliFailure(
             code=ErrorCode.PROVIDER_UNAVAILABLE,
-            message="Bastion cannot fetch the selected immutable controller source",
+            message="Bastion cannot fetch the selected immutable management source",
             exit_code=ExitCode.PROVIDER_ERROR,
             fix="Configure the expected infra-management origin and rerun host bootstrap --apply",
-            details={"capability": "controller_refresh", "required_revision": revision},
+            details={"capability": capability, "required_revision": revision},
         )
     # `main` is transport only: the candidate-selected revision remains the
     # sole executable identity and must be reachable from the expected remote.
@@ -2104,6 +2524,23 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
         check=False,
         env=_isolated_git_environment(),
     )
+    if revision is None and fetched.returncode == 0:
+        resolved = subprocess.run(
+            ["git", "-C", str(control_root), "rev-parse", "origin/main"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=_isolated_git_environment(),
+        )
+        revision = resolved.stdout.strip() if resolved.returncode == 0 else ""
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise CliFailure(
+            code=ErrorCode.PROVIDER_UNAVAILABLE,
+            message="Bastion cannot resolve the immutable management source",
+            exit_code=ExitCode.PROVIDER_ERROR,
+            fix="Verify Bastion can read the expected infra-management origin and rerun host bootstrap --apply",
+            details={"capability": capability},
+        )
     present = subprocess.run(
         ["git", "-C", str(control_root), "cat-file", "-e", f"{revision}^{{commit}}"],
         text=True,
@@ -2121,10 +2558,10 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
     if fetched.returncode != 0 or present.returncode != 0 or selected_from_main.returncode != 0:
         raise CliFailure(
             code=ErrorCode.PROVIDER_UNAVAILABLE,
-            message="Bastion cannot fetch the selected immutable controller source",
+            message="Bastion cannot fetch the selected immutable management source",
             exit_code=ExitCode.PROVIDER_ERROR,
             fix="Verify Bastion can read the expected infra-management origin and rerun host bootstrap --apply",
-            details={"capability": "controller_refresh", "required_revision": revision},
+            details={"capability": capability, "required_revision": revision},
         )
     with tempfile.TemporaryDirectory(prefix="infralink-controller-refresh-") as temporary:
         source = Path(temporary) / "source"
@@ -2151,19 +2588,19 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
             check=False,
             env=_isolated_git_environment(),
         )
-        playbook = source / _CONTROLLER_REFRESH_PLAYBOOK
+        required = source / required_path
         if (
             created.returncode != 0
             or head.returncode != 0
             or head.stdout.strip() != revision
-            or not playbook.is_file()
+            or not required.is_file()
         ):
             raise CliFailure(
                 code=ErrorCode.PROVIDER_UNAVAILABLE,
-                message="Bastion could not materialize the selected controller source",
+                message="Bastion could not materialize the selected immutable management source",
                 exit_code=ExitCode.PROVIDER_ERROR,
                 fix="Refresh the Bastion infra-management clone with the selected controller revision",
-                details={"capability": "controller_refresh", "required_revision": revision},
+                details={"capability": capability, "required_revision": revision},
             )
         completed = False
         try:
@@ -2180,10 +2617,10 @@ def _controller_refresh_source(control_root: Path, revision: str) -> Iterator[Pa
             if completed and removed.returncode != 0:
                 raise CliFailure(
                     code=ErrorCode.ARTIFACT_IO_FAILED,
-                    message="Bastion could not remove the temporary controller source",
+                    message="Bastion could not remove the temporary management source",
                     exit_code=ExitCode.ARTIFACT_IO_ERROR,
                     fix="Remove the temporary controller worktree and rerun host bootstrap --apply",
-                    details={"capability": "controller_refresh", "required_revision": revision},
+                    details={"capability": capability, "required_revision": revision},
                 )
 
 

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2342,6 +2342,7 @@ def _controller_bootstrap_state(
             code=ErrorCode.CONFIGURATION_REQUIRED,
             message="Controller bootstrap requires a registry directory checkout",
             exit_code=ExitCode.INPUT_ERROR,
+            fix="Provide the registry hosts directory with --registry and rerun host bootstrap",
         )
     manifest_path = registry_path / target.uuid / "manifest.yml"
     deployment_path = registry_path / target.uuid / "operations" / "deployment.yml"

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -498,6 +498,24 @@ def resolve_apply_request(registry_path: Path, host: Any) -> ApplyRequest:
 def _manifest_request(
     host_uuid: str, canonical_name: str, data: dict[str, Any], path: Path
 ) -> ApplyRequest | None:
+    # Bootstrap-only hosts declare one pinned Tailnet SSH identity alongside the
+    # canonical controller bootstrap state.  They deliberately carry no legacy
+    # V2 promotion/reconcile fields or operations contract.
+    if "controller_bootstrap" in data:
+        ssh = data.get("ssh")
+        address = data.get("tailscale_ip")
+        if not isinstance(ssh, dict) or not isinstance(address, str):
+            raise _registry_failure("Controller bootstrap SSH declaration is invalid", path)
+        try:
+            parsed_address = ipaddress.ip_address(address)
+        except ValueError:
+            raise _registry_failure("Controller bootstrap Tailnet address is invalid", path) from None
+        if not isinstance(parsed_address, ipaddress.IPv4Address) or parsed_address not in ipaddress.ip_network("100.64.0.0/10"):
+            raise _registry_failure("Controller bootstrap Tailnet address is outside the tailnet range", path)
+        fingerprint = _normalize_manifest_fingerprint(ssh.get("host_key_fingerprint"))
+        if fingerprint is None:
+            raise _registry_failure("Controller bootstrap SSH fingerprint is invalid", path)
+        return ApplyRequest(host_uuid, canonical_name, address, 22, "root", fingerprint, _UNIT)
     if _MANIFEST_V2_APPLY_FIELDS.isdisjoint(data):
         return None
     if data.get("self_deploy_v2_reconcile_enabled") is not True:
@@ -582,7 +600,11 @@ def _normalize_manifest_fingerprint(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     parts = value.split()
-    if len(parts) != 2 or parts[0] != "ssh-rsa" or _FINGERPRINT.fullmatch(parts[1]) is None:
+    if (
+        len(parts) != 2
+        or parts[0] not in {"ssh-rsa", "ssh-ed25519"}
+        or _FINGERPRINT.fullmatch(parts[1]) is None
+    ):
         return None
     return parts[1]
 

--- a/src/infralink/cli/operations.py
+++ b/src/infralink/cli/operations.py
@@ -509,9 +509,15 @@ def _manifest_request(
         try:
             parsed_address = ipaddress.ip_address(address)
         except ValueError:
-            raise _registry_failure("Controller bootstrap Tailnet address is invalid", path) from None
-        if not isinstance(parsed_address, ipaddress.IPv4Address) or parsed_address not in ipaddress.ip_network("100.64.0.0/10"):
-            raise _registry_failure("Controller bootstrap Tailnet address is outside the tailnet range", path)
+            raise _registry_failure(
+                "Controller bootstrap Tailnet address is invalid", path
+            ) from None
+        if not isinstance(
+            parsed_address, ipaddress.IPv4Address
+        ) or parsed_address not in ipaddress.ip_network("100.64.0.0/10"):
+            raise _registry_failure(
+                "Controller bootstrap Tailnet address is outside the tailnet range", path
+            )
         fingerprint = _normalize_manifest_fingerprint(ssh.get("host_key_fingerprint"))
         if fingerprint is None:
             raise _registry_failure("Controller bootstrap SSH fingerprint is invalid", path)

--- a/src/infralink/core/registry.py
+++ b/src/infralink/core/registry.py
@@ -115,6 +115,16 @@ class Host:
         return tuple(self._schema.bws_extra_projects)
 
     @property
+    def bws_projects(self) -> tuple[str, ...]:
+        """Canonical Bitwarden project aliases required by a bootstrap target."""
+        return tuple(self._schema.bws_projects)
+
+    @property
+    def controller_bootstrap(self) -> dict[str, Any] | None:
+        """Canonical controller bootstrap declaration, when this host is provisioned."""
+        return self._schema.controller_bootstrap
+
+    @property
     def bootstrap_executor(self) -> dict[str, str] | None:
         """Declared immutable executor for an explicit host baseline apply."""
         if self._schema.bootstrap_executor is None:

--- a/src/infralink/core/schema.py
+++ b/src/infralink/core/schema.py
@@ -325,6 +325,8 @@ class HostSchema(NodeSchema):
     bws_project: str | None = None
     bws_machine_account: str | None = None
     bws_extra_projects: list[str] = Field(default_factory=list)
+    bws_projects: list[str] = Field(default_factory=list)
+    controller_bootstrap: dict[str, Any] | None = None
     bootstrap_executor: HostBootstrapExecutorSchema | None = None
 
     # Provider-specific metadata (hcloud_project, robot_id, etc.)

--- a/src/infralink/host_readiness.py
+++ b/src/infralink/host_readiness.py
@@ -30,6 +30,7 @@ class HostReadinessProbe:
     self_deploy_dependencies: bool = False
     registry_layout: str | None = None
     requires_v2_registry_layout: bool = False
+    requires_controller_reconcile: bool = False
     self_deploy_reconcile_result: str | None = None
     self_deploy_reconcile_exit_status: int | None = None
     self_deploy_reconcile_active_state: str | None = None
@@ -38,6 +39,9 @@ class HostReadinessProbe:
     firewall_rules_expected: int = 0
     firewall_rules_matched: int = 0
     firewall_observable: bool = True
+    tailscale_ips: tuple[str, ...] = ()
+    tailscale_running: bool = False
+    tailscale_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -120,9 +124,9 @@ BASELINE_REQUIREMENTS: tuple[BaselineRequirement, ...] = (
     ),
     BaselineRequirement(
         "self_deploy_dependencies",
-        "Self-deploy Python dependencies are installed.",
+        "Controller host interface is installed.",
         "install_self_deploy_dependencies",
-        "Install the self-deploy Python dependencies.",
+        "Install controller host prerequisites.",
     ),
     BaselineRequirement(
         "self_deploy_runtime",
@@ -138,7 +142,7 @@ BASELINE_REQUIREMENTS: tuple[BaselineRequirement, ...] = (
     ),
     BaselineRequirement(
         "self_deploy_reconcile",
-        "Latest V2 self-deploy reconciliation completed successfully.",
+        "Latest controller reconciliation completed successfully.",
         "inspect_self_deploy_reconcile",
         "Inspect and repair the latest self-deploy reconciliation failure.",
     ),
@@ -288,8 +292,14 @@ def _reconcile_outcome(probe: HostReadinessProbe) -> tuple[bool, str | None]:
     """Require a successful latest run for V2 without penalizing legacy hosts twice."""
     if not probe.reachable:
         return False, "self_deploy_reconcile_unavailable"
-    if probe.self_deploy_mode != "v2_reconcile":
+    if (
+        probe.self_deploy_mode != "v2_reconcile"
+        and not probe.requires_v2_registry_layout
+        and not probe.requires_controller_reconcile
+    ):
         return True, None
+    if probe.self_deploy_mode != "v2_reconcile":
+        return False, "self_deploy_reconcile_missing"
     if (
         probe.self_deploy_reconcile_result == "success"
         and probe.self_deploy_reconcile_exit_status == 0

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -14,10 +14,15 @@ printf 'machine_id='; cat /etc/machine-id 2>/dev/null || true
 for command in git docker tailscale jq bws; do
   if command -v \"$command\" >/dev/null 2>&1; then printf '%s=1\\n' \"$command\"; else printf '%s=0\\n' \"$command\"; fi
 done
+if command -v tailscale >/dev/null 2>&1; then
+  tailscale ip -4 2>/dev/null | while IFS= read -r ip; do printf 'tailscale_ip=%s\n' "$ip"; done
+  tailscale status --json 2>/dev/null | python3 -c 'import json,sys; state=json.load(sys.stdin); print("tailscale_running=" + ("1" if state.get("BackendState") == "Running" else "0")); print("tailscale_name=" + str(state.get("Self", {}).get("HostName", "")))' 2>/dev/null || printf 'tailscale_running=0\ntailscale_name=\n'
+fi
 if id devops >/dev/null 2>&1; then printf 'devops_account=1\\n'; else printf 'devops_account=0\\n'; fi
 if test -s /home/devops/.ssh/authorized_keys; then printf 'devops_authorized_access=1\\n'; else printf 'devops_authorized_access=0\\n'; fi
-if test -r /etc/environment && grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/environment; then printf 'bws_config=1\\n'; else printf 'bws_config=0\\n'; fi
-if python3 -c 'import yaml, jinja2' >/dev/null 2>&1; then printf 'self_deploy_dependencies=1\\n'; else printf 'self_deploy_dependencies=0\\n'; fi
+if test -r /etc/infralink/host.env && grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/infralink/host.env; then printf 'bws_config=1\\n'; else printf 'bws_config=0\\n'; fi
+# The controller image contains its renderer dependencies; the host needs only its launcher.
+if test -x /usr/local/sbin/infralink-host; then printf 'self_deploy_dependencies=1\\n'; else printf 'self_deploy_dependencies=0\\n'; fi
 if test -d /var/lib/infralink/registry && systemctl cat infralink-host-reconcile.timer >/dev/null 2>&1; then
   printf 'self_deploy_runtime=1\\nself_deploy_mode=v2_reconcile\\n'
 elif test -x /opt/infra/scripts/self-deploy.sh && test -f /etc/cron.d/self-deploy; then
@@ -71,6 +76,11 @@ class SshReadinessTransport:
     ) -> None:
         self._expected_firewall_rules = expected_firewall_rules
         self._known_hosts = known_hosts
+
+    @property
+    def known_hosts(self) -> Path | None:
+        """Pinned known-hosts file used by this transport, if declared."""
+        return self._known_hosts
 
     def probe(self, address: str) -> HostReadinessProbe:
         if not address:
@@ -147,6 +157,11 @@ class SshReadinessTransport:
             firewall_rules_expected=len(self._expected_firewall_rules),
             firewall_rules_matched=_optional_int(values.get("firewall_rules_matched")) or 0,
             firewall_observable=values.get("firewall_observable", "1") == "1",
+            tailscale_ips=tuple(values.get("tailscale_ip", "").split())
+            if values.get("tailscale_ip")
+            else (),
+            tailscale_running=values.get("tailscale_running") == "1",
+            tailscale_name=values.get("tailscale_name") or None,
         )
 
 
@@ -172,7 +187,7 @@ def _parse_probe(stdout: str) -> dict[str, str]:
     for line in stdout.splitlines():
         key, separator, value = line.partition("=")
         if separator and key:
-            values[key] = value
+            values[key] = f"{values[key]} {value}".strip() if key == "tailscale_ip" and key in values else value
     return values
 
 

--- a/src/infralink/host_transport.py
+++ b/src/infralink/host_transport.py
@@ -187,7 +187,11 @@ def _parse_probe(stdout: str) -> dict[str, str]:
     for line in stdout.splitlines():
         key, separator, value = line.partition("=")
         if separator and key:
-            values[key] = f"{values[key]} {value}".strip() if key == "tailscale_ip" and key in values else value
+            values[key] = (
+                f"{values[key]} {value}".strip()
+                if key == "tailscale_ip" and key in values
+                else value
+            )
     return values
 
 

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -22,6 +22,7 @@ from infralink.cli.main import (
     _apply_controller_refresh,
     _bootstrap_executor_actions,
     _bootstrap_tailnet_address,
+    _controller_bootstrap_state,
     _controller_refresh_source,
     _readiness_with_bws_token_required,
     _require_remote_tailnet_identity,
@@ -247,6 +248,18 @@ def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_act
         "install_bws_cli",
         "bootstrap_infralink_controller",
     ]
+
+
+def test_controller_bootstrap_requires_a_registry_with_a_structured_remediation() -> None:
+    target = type("Target", (), {"uuid": HOST_ID})()
+
+    with pytest.raises(CliFailure) as raised:
+        _controller_bootstrap_state(None, target)
+
+    assert raised.value.code is ErrorCode.CONFIGURATION_REQUIRED
+    assert raised.value.fix == (
+        "Provide the registry hosts directory with --registry and rerun host bootstrap"
+    )
 
 
 def test_bootstrap_dirty_control_checkout_cannot_run_the_privileged_executor(

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -2,24 +2,30 @@ from __future__ import annotations
 
 import json
 import os
-import shlex
 import subprocess
 import sys
-from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
-import yaml
 from click.testing import CliRunner
 
-from infralink.cli.contracts import HostBootstrapAction, HostReadinessResult
+from infralink.cli.contracts import (
+    HostBootstrapAction,
+    HostControllerBootstrapState,
+    HostReadinessResult,
+)
 from infralink.cli.errors import CliFailure, ErrorCode
 from infralink.cli.host_readiness import evaluate_host_readiness as evaluate_readiness
 from infralink.cli.main import (
-    BASELINE_EXECUTOR_ACTIONS,
     Context,
+    _apply_bootstrap_request,
     _apply_controller_refresh,
+    _bootstrap_executor_actions,
+    _bootstrap_tailnet_address,
     _controller_refresh_source,
+    _readiness_with_bws_token_required,
+    _require_remote_tailnet_identity,
+    _validate_bootstrap_bws_access,
     cli,
 )
 from infralink.host_readiness import HostReadinessProbe
@@ -123,6 +129,262 @@ def _configure_self_remote(monkeypatch: pytest.MonkeyPatch, repository: Path) ->
     _git(repository, "remote", "add", "origin", remote)
     monkeypatch.setattr("infralink.cli.main._CONTROLLER_REFRESH_SOURCE_REMOTE", remote)
     return remote
+
+
+def test_host_bootstrap_rejects_missing_secure_connection_inputs_before_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bootstrap has no implicit transport or credential source."""
+    monkeypatch.setattr(
+        "infralink.cli.main.evaluate_host_readiness",
+        lambda *_args: pytest.fail("bootstrap must validate inputs before SSH probing"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(ROOT / "examples" / "registry.yml"),
+            "host",
+            "bootstrap",
+            HOST_ID,
+        ],
+    )
+
+    assert result.exit_code == 2
+
+
+def test_host_bootstrap_apply_requires_stdin_token_before_any_probe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "infralink.cli.main._bootstrap_pinned_transport",
+        lambda *_args: pytest.fail("apply without a token must not start SSH"),
+    )
+
+    registry = tmp_path / "hosts"
+    manifest = registry / HOST_ID / "manifest.yml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        f"hosts:\n  {HOST_ID}:\n    canonical_name: {HOST_NAME}\n    tailscale_ip: 100.64.68.83\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--output",
+            "json",
+            "--registry",
+            str(registry),
+            "host",
+            "bootstrap",
+            HOST_ID,
+            "--ssh-host",
+            "100.64.68.83",
+            "--apply",
+        ],
+    )
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["error"]["details"] == {
+        "host": HOST_ID,
+        "requirement": "bws_token_stdin",
+    }
+
+
+def test_bootstrap_rejects_non_tailnet_or_mismatched_ssh_host_before_probe() -> None:
+    target = type("Target", (), {"uuid": HOST_ID, "tailscale_ip": "100.64.68.83"})()
+
+    with pytest.raises(CliFailure) as non_tailnet:
+        _bootstrap_tailnet_address(target, "192.0.2.10")
+    assert non_tailnet.value.code is ErrorCode.CONFIGURATION_REQUIRED
+
+    with pytest.raises(CliFailure) as mismatch:
+        _bootstrap_tailnet_address(target, "100.64.68.84")
+    assert mismatch.value.details == {
+        "host": HOST_ID,
+        "declared_tailscale_ip": "100.64.68.83",
+    }
+
+
+def test_bootstrap_dry_plan_marks_a_missing_token_as_required() -> None:
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=True,
+        checks=[],
+        actions=[],
+    )
+
+    planned = _readiness_with_bws_token_required(readiness)
+
+    assert not planned.ready
+    assert planned.checks[-1].detail == "bws_token_required"
+    assert planned.actions[-1].id == "provide_bws_token"
+
+
+def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_action() -> None:
+    readiness = HostReadinessResult(
+        transport="root_ssh",
+        ready=False,
+        checks=[],
+        actions=[
+            HostBootstrapAction(id="install_git", check_id="git", description="Git."),
+            HostBootstrapAction(id="install_docker", check_id="docker", description="Docker."),
+            HostBootstrapAction(id="install_jq", check_id="jq", description="jq."),
+            HostBootstrapAction(id="install_bws_cli", check_id="bws", description="BWS."),
+            HostBootstrapAction(
+                id="create_devops_account", check_id="devops", description="obsolete"
+            ),
+        ],
+    )
+    assert _bootstrap_executor_actions(readiness) == [
+        "install_git",
+        "install_docker",
+        "install_jq",
+        "install_bws_cli",
+        "bootstrap_infralink_controller",
+    ]
+
+
+def test_bootstrap_dirty_control_checkout_cannot_run_the_privileged_executor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bootstrap must execute only a detached source selected by the registry."""
+    control, revision = _controller_source_repository(tmp_path)
+    manifest = control / "ansible/executors/infralink-host-baseline.json"
+    playbook = control / "ansible/playbooks/infralink_host_baseline.yml"
+    manifest.parent.mkdir(parents=True)
+    playbook.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "infralink.host-bootstrap-executor/v1",
+                "id": "infra-management-host-baseline",
+                "playbook": "ansible/playbooks/infralink_host_baseline.yml",
+                "runtime_mode": "controller_bootstrap",
+                "required_inputs": [],
+                "allowed_actions": ["bootstrap_infralink_controller"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook.write_text("---\n- hosts: all\n", encoding="utf-8")
+    _git(control, "add", ".")
+    _git(control, "commit", "--quiet", "-m", "baseline executor")
+    _configure_self_remote(monkeypatch, control)
+    (control / "dirty").write_text("must never execute", encoding="utf-8")
+
+    commands: list[list[str]] = []
+    real_run = subprocess.run
+
+    def recording_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        if args[0] == "ansible-playbook":
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        return real_run(args, **kwargs)  # type: ignore[arg-type, no-any-return]
+
+    target = type(
+        "Target",
+        (),
+        {
+            "uuid": HOST_ID,
+            "canonical_name": HOST_NAME,
+        },
+    )()
+    controller = HostControllerBootstrapState.model_validate(
+        {
+            "controller_image": "ghcr.io/example/controller:main",
+            "registry_read_identity_secret": {
+                "project": "fleet",
+                "id": "11111111-1111-4111-8111-111111111111",
+            },
+            "registry_repo_url": "https://example.invalid/registry.git",
+            "registry_ref": "main",
+        }
+    )
+    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control)
+    monkeypatch.setattr("infralink.cli.main.subprocess.run", recording_run)
+    monkeypatch.setattr(
+        "infralink.cli.main.evaluate_host_readiness",
+        lambda *_args, **_kwargs: HostReadinessResult(
+            transport="root_ssh", ready=True, checks=[], actions=[]
+        ),
+    )
+
+    with pytest.raises(CliFailure) as failed:
+        _apply_bootstrap_request(
+            Context(),
+            target,
+            "100.64.68.83",
+            ["bootstrap_infralink_controller"],
+            controller,
+            "bws-token",
+            tmp_path / "known_hosts",
+        )
+
+    assert failed.value.code is ErrorCode.PROVIDER_UNAVAILABLE
+    assert not any(command[0] == "ansible-playbook" for command in commands)
+
+
+def test_bootstrap_rejects_remote_without_the_declared_tailnet_address() -> None:
+    target = type("Target", (), {"uuid": HOST_ID})()
+    probe = HostReadinessProbe(
+        reachable=True,
+        hostname=HOST_NAME,
+        machine_id="machine-id",
+        commands={},
+        devops_account=False,
+        devops_authorized_access=False,
+        bws_config=False,
+        self_deploy_runtime=False,
+        self_deploy_timer_enabled=False,
+        self_deploy_timer_active=False,
+        error=None,
+        tailscale_ips=("100.64.68.84",),
+    )
+
+    with pytest.raises(CliFailure) as mismatch:
+        _require_remote_tailnet_identity(target, probe, "100.64.68.83")
+
+    assert mismatch.value.code is ErrorCode.CONFIGURATION_REQUIRED
+    assert mismatch.value.details["declared_tailscale_ip"] == "100.64.68.83"
+
+
+def test_bootstrap_bws_validation_uses_only_environment_for_the_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry = tmp_path / "hosts"
+    catalog = registry.parent / "ansible/inventory/bws_projects.yml"
+    catalog.parent.mkdir(parents=True)
+    catalog.write_text(
+        "projects:\n  fleet:\n    uuid: 11111111-1111-4111-8111-111111111111\n",
+        encoding="utf-8",
+    )
+    context = type("Context", (), {"registry_path": registry})()
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    token = "bws-token-not-for-output"
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("infralink.cli.main.subprocess.run", fake_run)
+
+    _validate_bootstrap_bws_access(context, ("fleet",), token)
+
+    assert calls[0][0] == [
+        "bws",
+        "project",
+        "get",
+        "11111111-1111-4111-8111-111111111111",
+        "--output",
+        "none",
+    ]
+    assert token not in " ".join(calls[0][0])
+    assert calls[0][1]["env"]["BWS_ACCESS_TOKEN"] == token
 
 
 def test_controller_refresh_materializes_an_exact_detached_source(
@@ -439,846 +701,6 @@ def test_cli_readiness_enforces_declared_v2_registry_layout_migration() -> None:
     assert readiness.requires_v2_registry_layout is True
     assert layout.passed is False
     assert layout.detail == "legacy_nested"
-
-
-def test_host_bootstrap_plan_uses_the_same_failed_readiness_checks(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "infralink.cli.main.SshReadinessTransport.probe",
-        lambda self, address: HostReadinessProbe(
-            reachable=True,
-            hostname="database.example.com",
-            machine_id="machine-id",
-            commands={"git": True, "docker": False, "tailscale": True, "jq": False, "bws": False},
-            devops_account=False,
-            devops_authorized_access=False,
-            bws_config=False,
-            self_deploy_runtime=False,
-            self_deploy_timer_enabled=False,
-            self_deploy_timer_active=False,
-            error=None,
-        ),
-    )
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--plan",
-        ],
-    )
-    payload = json.loads(result.output)
-
-    assert result.exit_code == 0
-    assert payload["result"]["readiness"]["ready"] is False
-    assert [item["check_id"] for item in payload["result"]["readiness"]["actions"]] == [
-        "registry_layout",
-        "devops_account",
-        "devops_authorized_access",
-        "docker",
-        "jq",
-        "bws_cli",
-        "bws_config",
-        "self_deploy_dependencies",
-        "self_deploy_runtime",
-        "self_deploy_timer",
-    ]
-    # A bootstrap-plan response must link to an action that can be rerun using
-    # only the topology sources it already carries; full doctor also requires
-    # observation/Gatus configuration.
-    assert payload["next_actions"][0]["rel"] == "reinspect-readiness"
-    assert payload["next_actions"][0]["command"].endswith(
-        "host bootstrap d1b9e5d5-36b0-459d-a556-96622811fbd5 --plan"
-    )
-    assert payload["next_actions"][0]["safe"] is True
-
-    follow_up = CliRunner().invoke(cli, shlex.split(payload["next_actions"][0]["command"])[1:])
-    assert follow_up.exit_code == 0
-    assert json.loads(follow_up.output)["result"]["readiness"] == payload["result"]["readiness"]
-
-
-def test_host_bootstrap_plan_rejects_required_v2_action_with_incomplete_v2_declaration(
-    monkeypatch, tmp_path: Path
-) -> None:
-    registry = tmp_path / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        "    self_deploy_v2_registry_layout_enabled: true\n",
-        encoding="utf-8",
-    )
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="install_self_deploy_runtime",
-                check_id="self_deploy_runtime",
-                description="Install the self-deploy runtime.",
-            )
-        ],
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(registry),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--plan",
-        ],
-    )
-
-    assert result.exit_code == 3
-    payload = json.loads(result.output)
-    assert payload["error"]["code"] == "configuration_required"
-    assert payload["error"]["details"]["path"].endswith("operations/infra-management.lock")
-
-
-def test_host_bootstrap_links_verifier_when_reconcile_failed(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "infralink.cli.main.SshReadinessTransport.probe",
-        lambda self, address: HostReadinessProbe(
-            reachable=True,
-            hostname="database.example.com",
-            machine_id="machine-id",
-            commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": True},
-            devops_account=True,
-            devops_authorized_access=True,
-            bws_config=True,
-            self_deploy_dependencies=True,
-            self_deploy_runtime=True,
-            self_deploy_timer_enabled=True,
-            self_deploy_timer_active=True,
-            error=None,
-            self_deploy_mode="v2_reconcile",
-            registry_layout="v2_managed",
-            self_deploy_reconcile_result="exit-code",
-            self_deploy_reconcile_exit_status=1,
-        ),
-    )
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--plan",
-        ],
-    )
-
-    payload = json.loads(result.output)
-    assert result.exit_code == 0
-    verifier_action = next(item for item in payload["next_actions"] if item["rel"] == "verifier")
-    assert verifier_action["command"].endswith("host verifier d1b9e5d5-36b0-459d-a556-96622811fbd5")
-
-
-def test_host_bootstrap_help_marks_plan_required_and_shows_an_example() -> None:
-    result = CliRunner().invoke(cli, ["--output", "json", "help", "host", "bootstrap"])
-    payload = json.loads(result.output)
-
-    assert result.exit_code == 0
-    assert payload["result"]["options"] == [
-        {"name": "plan", "type": "boolean", "required": False},
-        {"name": "apply", "type": "boolean", "required": False},
-    ]
-    assert payload["result"]["examples"] == [
-        "infralink host bootstrap host-1 --plan",
-        "infralink host bootstrap host-1 --apply",
-    ]
-
-
-def test_real_module_apply_failure_emits_an_envelope_and_nonzero_exit() -> None:
-    environment = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "infralink",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--apply",
-        ],
-        cwd=ROOT,
-        env=environment,
-        text=True,
-        capture_output=True,
-        timeout=30,
-        check=False,
-    )
-
-    assert result.returncode == 4
-    payload = yaml.safe_load(result.stdout)
-    assert payload["ok"] is False
-    assert payload["error"]["code"] == "provider_unavailable"
-
-
-def test_host_bootstrap_apply_missing_bastion_executor_is_provider_unavailable(
-    monkeypatch, tmp_path: Path
-) -> None:
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", tmp_path)
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--apply",
-        ],
-    )
-
-    assert result.exit_code == 4
-    payload = json.loads(result.output)
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert payload["error"]["details"] == {"capability": "host_bootstrap"}
-
-
-def test_host_bootstrap_apply_never_sends_manual_secret_or_runtime_actions(
-    monkeypatch, tmp_path: Path
-) -> None:
-    readiness = HostReadinessProbe(
-        reachable=True,
-        hostname="database.example.com",
-        machine_id="machine-id",
-        commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": False},
-        devops_account=True,
-        devops_authorized_access=True,
-        bws_config=False,
-        self_deploy_runtime=False,
-        self_deploy_timer_enabled=False,
-        self_deploy_timer_active=False,
-        error=None,
-    )
-    monkeypatch.setattr(
-        "infralink.cli.main.evaluate_host_readiness",
-        lambda *_args: evaluate_readiness(
-            type(
-                "Host",
-                (),
-                {
-                    "canonical_name": "database.example.com",
-                    "tailscale_ip": "192.0.2.10",
-                    "public_ip": None,
-                },
-            )(),
-            type("Transport", (), {"probe": lambda _self, _address: readiness})(),
-        ),
-    )
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    calls: list[object] = []
-
-    class Completed:
-        returncode = 0
-        stdout = ""
-        stderr = ""
-
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda *args, **kwargs: calls.append((args, kwargs)) or Completed(),
-    )
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--apply",
-        ],
-    )
-
-    assert result.exit_code == 1
-    payload = json.loads(result.output)
-    guidance = {item["id"] for item in payload["result"]["readiness"]["actions"]}
-    assert "migrate_v2_registry_layout" in guidance
-    argv, _kwargs = calls[0]
-    serialized = " ".join(str(item) for item in argv[0])
-    forwarded = json.loads(argv[0][-1])["bootstrap_actions"]
-    assert set(forwarded) <= BASELINE_EXECUTOR_ACTIONS
-    assert "migrate_v2_registry_layout" not in forwarded
-    assert "install_bws_cli" in serialized
-    assert "configure_bws" not in serialized
-    assert "install_self_deploy_runtime" not in serialized
-    assert "enable_self_deploy_timer" in serialized
-
-
-def test_baseline_executor_mirrors_the_v2_timer_capability() -> None:
-    assert "enable_self_deploy_timer" in BASELINE_EXECUTOR_ACTIONS
-
-
-def test_host_bootstrap_apply_forwards_only_the_timer_action_when_it_alone_is_missing(
-    monkeypatch, tmp_path: Path
-) -> None:
-    readiness = HostReadinessProbe(
-        reachable=True,
-        hostname="database.example.com",
-        machine_id="machine-id",
-        commands={"git": True, "docker": True, "tailscale": True, "jq": True, "bws": True},
-        devops_account=True,
-        devops_authorized_access=True,
-        bws_config=True,
-        self_deploy_dependencies=True,
-        self_deploy_runtime=True,
-        self_deploy_timer_enabled=False,
-        self_deploy_timer_active=False,
-        error=None,
-    )
-    monkeypatch.setattr(
-        "infralink.cli.main.evaluate_host_readiness",
-        lambda *_args: evaluate_readiness(
-            type(
-                "Host",
-                (),
-                {
-                    "canonical_name": "database.example.com",
-                    "tailscale_ip": "192.0.2.10",
-                    "public_ip": None,
-                },
-            )(),
-            type("Transport", (), {"probe": lambda _self, _address: readiness})(),
-        ),
-    )
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    calls: list[object] = []
-
-    class Completed:
-        returncode = 0
-        stdout = ""
-        stderr = ""
-
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda *args, **kwargs: calls.append((args, kwargs)) or Completed(),
-    )
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--apply",
-        ],
-    )
-
-    # The executor succeeded, but this response still represents the pre-apply
-    # readiness probe and therefore remains negative until the next probe.
-    assert result.exit_code == 1
-    argv, _kwargs = calls[0]
-    assert json.loads(argv[0][-1])["bootstrap_actions"] == ["enable_self_deploy_timer"]
-
-
-def test_host_bootstrap_apply_forwards_a_bounded_v2_request_for_es1_layout_runtime_and_timer(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """The ES1-shaped plan must reach the baseline with its required V2 state."""
-    registry_root = tmp_path / "registry"
-    registry = registry_root / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        "    self_deploy_legacy_cron_enabled: false\n"
-        "    self_deploy_v2_registry_layout_enabled: true\n"
-        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
-        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
-        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        f"    self_deploy_v2_target_ssh_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        "    self_deploy_v2_promotion_channel: core-v2\n"
-        "    self_deploy_v2_promotion_policy_enabled: true\n"
-        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
-        "    self_deploy_v2_reconcile_enabled: true\n"
-        "    self_deploy_v2_reconcile_packaged: true\n"
-        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
-        "    self_deploy_registry_origin: http://100.73.228.90:3000/relaxgg/infra-registry.git\n",
-        encoding="utf-8",
-    )
-    runtime_revision = "b" * 40
-    operations = registry_root / "operations"
-    operations.mkdir()
-    (operations / "infra-management.lock").write_text(runtime_revision + "\n", encoding="utf-8")
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="migrate_v2_registry_layout",
-                check_id="registry_layout",
-                description="Migrate the host registry checkout to the V2-owned root.",
-            ),
-            HostBootstrapAction(
-                id="install_self_deploy_runtime",
-                check_id="self_deploy_runtime",
-                description="Install the self-deploy runtime.",
-            ),
-            HostBootstrapAction(
-                id="enable_self_deploy_timer",
-                check_id="self_deploy_timer",
-                description="Enable and start the self-deploy timer.",
-            ),
-        ],
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    calls: list[tuple[list[str], dict[str, object]]] = []
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda args, **kwargs: (
-            calls.append((args, kwargs))
-            or subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
-        ),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
-    )
-
-    assert result.exit_code == 1
-    ansible_calls = [call for call in calls if call[0][0] == "ansible-playbook"]
-    assert len(ansible_calls) == 1
-    extra_vars = json.loads(ansible_calls[0][0][-1])
-    assert set(extra_vars) == {
-        "bootstrap_actions",
-        "canonical_name",
-        "host_address",
-        "host_uuid",
-        "self_deploy_legacy_cron_enabled",
-        "self_deploy_registry_origin",
-        "self_deploy_v2_promotion_allowed_signers",
-        "self_deploy_v2_promotion_bws_project_id",
-        "self_deploy_v2_promotion_channel",
-        "self_deploy_v2_promotion_host_fingerprint",
-        "self_deploy_v2_promotion_policy_enabled",
-        "self_deploy_v2_promotion_registry_remote",
-        "self_deploy_v2_reconcile_enabled",
-        "self_deploy_v2_reconcile_packaged",
-        "self_deploy_v2_registry_read_identity_secret_uuid",
-        "self_deploy_v2_runtime_revision",
-    }
-    assert extra_vars["bootstrap_actions"] == [
-        "migrate_v2_registry_layout",
-        "install_self_deploy_runtime",
-        "enable_self_deploy_timer",
-    ]
-    assert extra_vars["host_uuid"] == HOST_ID
-    assert extra_vars["self_deploy_v2_runtime_revision"] == runtime_revision
-    assert (
-        extra_vars["self_deploy_registry_origin"]
-        == "http://100.73.228.90:3000/relaxgg/infra-registry.git"
-    )
-
-
-def test_host_bootstrap_apply_rejects_incomplete_v2_state_before_starting_ansible(
-    monkeypatch, tmp_path: Path
-) -> None:
-    registry = tmp_path / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        "    self_deploy_v2_registry_layout_enabled: true\n",
-        encoding="utf-8",
-    )
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="install_self_deploy_runtime",
-                check_id="self_deploy_runtime",
-                description="Install the self-deploy runtime.",
-            )
-        ],
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", tmp_path / "missing-controller")
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda *_args, **_kwargs: pytest.fail("incomplete V2 state must not start Ansible"),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
-    )
-
-    assert result.exit_code == 3
-    payload = json.loads(result.output)
-    assert payload["error"]["code"] == "configuration_required"
-    assert "host" not in payload["error"]["details"]
-    assert payload["error"]["details"]["path"].endswith("operations/infra-management.lock")
-
-
-def test_host_bootstrap_apply_failure_returns_only_bounded_redacted_task_count(
-    monkeypatch, tmp_path: Path
-) -> None:
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="install_jq",
-                check_id="jq",
-                description="Install jq.",
-            )
-        ],
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_host_baseline.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda args, **_kwargs: subprocess.CompletedProcess(
-            args=args,
-            returncode=2,
-            stdout=(
-                "TASK [Install jq] ********************************************************\n"
-                'fatal: [host]: FAILED! => {"msg": "token=not-for-output"}\n'
-                "TASK [Read BWS secret] ***************************************************\n"
-            ),
-            stderr="credential=not-for-output",
-        ),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        [
-            "--output",
-            "json",
-            "--registry",
-            str(ROOT / "examples" / "registry.yml"),
-            "--edges",
-            str(ROOT / "examples" / "edges.yml"),
-            "host",
-            "bootstrap",
-            "database.example.com",
-            "--apply",
-        ],
-    )
-
-    assert result.exit_code == 4
-    payload = json.loads(result.output)
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert payload["error"]["details"] == {
-        "host": HOST_ID,
-        "executor": "host_baseline",
-        "return_code": 2,
-        "task_count": 2,
-        "task_output_redacted": True,
-    }
-    assert "Install jq" not in result.output
-    assert "not-for-output" not in result.output
-
-
-def test_host_bootstrap_apply_refreshes_only_the_pinned_controller_runtime(
-    monkeypatch, tmp_path: Path
-) -> None:
-    registry_root = tmp_path / "registry"
-    registry = registry_root / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        f"    self_deploy_v2_target_ssh_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        "    self_deploy_v2_promotion_channel: core-v2\n"
-        "    self_deploy_v2_promotion_policy_enabled: true\n"
-        "    self_deploy_v2_reconcile_enabled: true\n"
-        "    self_deploy_v2_reconcile_packaged: true\n"
-        "    self_deploy_legacy_cron_enabled: false\n"
-        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
-        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
-        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
-        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
-        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
-        encoding="utf-8",
-    )
-    lock = registry_root / "operations" / "infra-management.lock"
-    lock.parent.mkdir()
-    runtime_revision = "b" * 40
-    lock.write_text(runtime_revision + "\n", encoding="utf-8")
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_controller_refresh.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    calls: list[tuple[list[str], dict[str, object]]] = []
-
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="inspect_self_deploy_reconcile",
-                check_id="self_deploy_reconcile",
-                description="Refresh the legacy controller runtime.",
-            )
-        ],
-        runtime_mode="legacy_pull",
-        registry_layout="legacy_nested",
-        self_deploy_reconcile_result="exit-code",
-        self_deploy_reconcile_exit_status=1,
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    monkeypatch.setattr(
-        "infralink.cli.main._controller_refresh_source",
-        lambda _root, _revision: nullcontext(control_root),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda args, **kwargs: (
-            calls.append((args, kwargs))
-            or subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
-        ),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
-    )
-
-    assert result.exit_code == 1
-    ansible_calls = [call for call in calls if call[0][0] == "ansible-playbook"]
-    assert len(ansible_calls) == 1
-    argv, kwargs = ansible_calls[0]
-    assert argv[:7] == [
-        "ansible-playbook",
-        "-i",
-        "100.64.68.83,",
-        "-u",
-        "root",
-        "--ssh-common-args",
-        "-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=yes "
-        f"-o UserKnownHostsFile={tmp_path / 'known_hosts'}",
-    ]
-    assert argv[7] == str(playbook)
-    assert kwargs["cwd"] == control_root
-    extra_vars = json.loads(argv[-1])
-    assert extra_vars["self_deploy_v2_runtime_revision"] == runtime_revision
-    assert extra_vars["uuid"] == HOST_ID
-    assert "bws_access_token" not in extra_vars
-    assert "BWS_ACCESS_TOKEN" not in " ".join(argv)
-
-
-def test_host_bootstrap_plan_reports_the_selected_controller_refresh_without_running_it(
-    monkeypatch, tmp_path: Path
-) -> None:
-    registry_root = tmp_path / "registry"
-    registry = registry_root / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        f"    self_deploy_v2_target_ssh_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        "    self_deploy_v2_promotion_channel: core-v2\n"
-        "    self_deploy_v2_promotion_policy_enabled: true\n"
-        "    self_deploy_v2_reconcile_enabled: true\n"
-        "    self_deploy_v2_reconcile_packaged: true\n"
-        "    self_deploy_legacy_cron_enabled: false\n"
-        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
-        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
-        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
-        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
-        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
-        encoding="utf-8",
-    )
-    lock = registry_root / "operations" / "infra-management.lock"
-    lock.parent.mkdir()
-    runtime_revision = "b" * 40
-    lock.write_text(runtime_revision + "\n", encoding="utf-8")
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="inspect_self_deploy_reconcile",
-                check_id="self_deploy_reconcile",
-                description="Refresh the legacy controller runtime.",
-            )
-        ],
-    )
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", lambda *_args: readiness)
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda *_args, **_kwargs: pytest.fail("host bootstrap --plan must not execute a runner"),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--plan"],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    refresh = next(item for item in payload["next_actions"] if item["rel"] == "refresh-controller")
-    assert refresh["safe"] is False
-    assert runtime_revision in refresh["description"]
-    assert refresh["command"].endswith(f"host bootstrap {HOST_ID} --apply")
-
-
-def test_host_bootstrap_controller_refresh_failure_does_not_reprobe_or_start_services(
-    monkeypatch, tmp_path: Path
-) -> None:
-    registry_root = tmp_path / "registry"
-    registry = registry_root / "hosts"
-    manifest = registry / HOST_ID / "manifest.yml"
-    manifest.parent.mkdir(parents=True)
-    manifest.write_text(
-        "hosts:\n"
-        f"  {HOST_ID}:\n"
-        f"    canonical_name: {HOST_NAME}\n"
-        "    tailscale_ip: 100.64.68.83\n"
-        f"    self_deploy_v2_promotion_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        f"    self_deploy_v2_target_ssh_host_fingerprint: ssh-rsa {HOST_FINGERPRINT}\n"
-        "    self_deploy_v2_promotion_channel: core-v2\n"
-        "    self_deploy_v2_promotion_policy_enabled: true\n"
-        "    self_deploy_v2_reconcile_enabled: true\n"
-        "    self_deploy_v2_reconcile_packaged: true\n"
-        "    self_deploy_legacy_cron_enabled: false\n"
-        "    self_deploy_v2_promotion_registry_remote: ssh://git@gitea.example.invalid:2222/relaxgg/infra-registry.git\n"
-        "    self_deploy_v2_promotion_bws_project_id: 11111111-1111-4111-8111-111111111111\n"
-        "    self_deploy_v2_registry_read_identity_secret_uuid: 22222222-2222-4222-8222-222222222222\n"
-        "    self_deploy_v2_promotion_allowed_signers: infra ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEjV/Mqc501uHt3OiM0aYthhtAHO1htXrDuEYh4UQOXI\n"
-        "    self_deploy_registry_origin: http://100.64.68.83:3000/relaxgg/infra-registry.git\n",
-        encoding="utf-8",
-    )
-    lock = registry_root / "operations" / "infra-management.lock"
-    lock.parent.mkdir()
-    lock.write_text("b" * 40 + "\n", encoding="utf-8")
-    control_root = tmp_path / "control"
-    playbook = control_root / "ansible/playbooks/infralink_controller_refresh.yml"
-    playbook.parent.mkdir(parents=True)
-    playbook.touch()
-    readiness = HostReadinessResult(
-        transport="root_ssh",
-        ready=False,
-        checks=[],
-        actions=[
-            HostBootstrapAction(
-                id="inspect_self_deploy_reconcile",
-                check_id="self_deploy_reconcile",
-                description="Refresh the legacy controller runtime.",
-            )
-        ],
-    )
-    probes = 0
-
-    def fake_readiness(*_args: object) -> HostReadinessResult:
-        nonlocal probes
-        probes += 1
-        return readiness
-
-    monkeypatch.setattr("infralink.cli.main.evaluate_host_readiness", fake_readiness)
-    monkeypatch.setattr("infralink.cli.main._CONTROL_ROOT", control_root)
-    monkeypatch.setattr(
-        "infralink.cli.main._controller_refresh_source",
-        lambda _root, _revision: nullcontext(control_root),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.operations._pinned_known_hosts",
-        lambda _request: __import__("contextlib").nullcontext(tmp_path / "known_hosts"),
-    )
-    monkeypatch.setattr(
-        "infralink.cli.main.subprocess.run",
-        lambda args, **_kwargs: subprocess.CompletedProcess(
-            args=args,
-            returncode=0 if args[0] == "git" else 1,
-            stdout="",
-            stderr="",
-        ),
-    )
-
-    result = CliRunner().invoke(
-        cli,
-        ["--output", "json", "--registry", str(registry), "host", "bootstrap", HOST_ID, "--apply"],
-    )
-
-    assert result.exit_code == 4
-    payload = json.loads(result.output)
-    assert payload["error"]["code"] == "provider_unavailable"
-    assert payload["error"]["details"]["host"] == HOST_ID
-    assert probes == 1
 
 
 def test_controller_refresh_prefers_the_explicit_host_runtime_over_global_lock(

--- a/tests/test_cli_secret_leaks.py
+++ b/tests/test_cli_secret_leaks.py
@@ -291,7 +291,9 @@ selection:
             0,
             True,
         ),
-        ("host", "bootstrap"): ([*source, "host", "bootstrap", TARGET_ID, "--plan"], 0, True),
+        # The fixture deliberately has a public documentation address; bootstrap
+        # now rejects it before any provider or secret interaction.
+        ("host", "bootstrap"): ([*source, "host", "bootstrap", TARGET_ID, "--plan"], 2, False),
         ("host", "apply"): ([*source, "host", "apply", TARGET_ID, "--dry-run"], 3, False),
         ("host", "status"): ([*source, "host", "status", TARGET_ID], 3, False),
         ("host", "logs"): ([*source, "host", "logs", TARGET_ID, "--last-run"], 3, False),

--- a/tests/test_host_readiness.py
+++ b/tests/test_host_readiness.py
@@ -249,10 +249,10 @@ self_deploy_reconcile_exit_timestamp_monotonic=123
     assert probe.self_deploy_reconcile_exit_timestamp_monotonic == 123
 
 
-def test_ssh_transport_requires_a_nonempty_bws_token_in_etc_environment() -> None:
+def test_ssh_transport_requires_a_nonempty_bws_token_in_controller_host_env() -> None:
     from infralink.host_transport import _REMOTE_PROBE
 
-    assert "grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/environment" in _REMOTE_PROBE
+    assert "grep -Eq '^[[:space:]]*BWS_ACCESS_TOKEN=.+' /etc/infralink/host.env" in _REMOTE_PROBE
     assert "bws.json" not in _REMOTE_PROBE
     assert "bws.conf" not in _REMOTE_PROBE
 


### PR DESCRIPTION
Adds the fail-closed operator bootstrap path: exact Tailnet/pinned SSH identity, canonical BWS project and registry-read-secret preflight, stdin-only BWS token handling, clean immutable infra-management executor source, and a typed controller bootstrap action.\n\nVerification: full suite 1458 passed, 5 skipped; independent review and real ES2 read-only plan.