### PR TITLE
Fix bootstrap apply handoff for executable prerequisites

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1891,17 +1891,39 @@ def _bootstrap_plan_actions(
             "Reinspect live host readiness",
         )
     ]
-    if not bws_token_supplied and _bootstrap_missing_only_bws_token(readiness):
+    if not bws_token_supplied and _bootstrap_apply_handoff_is_safe(readiness):
         actions.append(_bootstrap_bws_token_apply_action(ctx, target, address))
     return actions
 
 
-def _bootstrap_missing_only_bws_token(readiness: HostReadinessResult) -> bool:
-    """Identify the one safe handoff state without weakening bootstrap gates."""
+_BOOTSTRAP_HANDOFF_ACTION_IDS = frozenset(
+    {
+        "initialize_machine_id",
+        "install_git",
+        "install_docker",
+        "install_jq",
+        "install_bws_cli",
+        "install_self_deploy_dependencies",
+        "bootstrap_infralink_controller",
+    }
+)
+
+_BOOTSTRAP_EXECUTOR_ACTION_IDS = _BOOTSTRAP_HANDOFF_ACTION_IDS - {
+    "initialize_machine_id",
+}
+
+
+def _bootstrap_apply_handoff_is_safe(readiness: HostReadinessResult) -> bool:
+    """Advertise stdin apply only when every failed gate is executor-backed."""
     required_failures = {
         check.id for check in readiness.checks if check.required and not check.passed
     }
-    return required_failures == {"bws_token"}
+    executor_checks = {
+        action.check_id
+        for action in readiness.actions
+        if action.id in _BOOTSTRAP_HANDOFF_ACTION_IDS
+    }
+    return bool(required_failures) and required_failures <= (executor_checks | {"bws_token"})
 
 
 def _bootstrap_bws_token_apply_action(ctx: Context, target: Any, address: str) -> Action:
@@ -2219,14 +2241,11 @@ def _bootstrap_operator_readiness(readiness: HostReadinessResult) -> HostReadine
 
 def _bootstrap_executor_actions(readiness: HostReadinessResult) -> list[str]:
     """Translate only declared bootstrap prerequisites into executor actions."""
-    executor_actions = {
-        "install_git",
-        "install_docker",
-        "install_jq",
-        "install_bws_cli",
-        "install_self_deploy_dependencies",
-    }
-    actions = [item.id for item in readiness.actions if item.id in executor_actions]
+    actions = [
+        item.id
+        for item in readiness.actions
+        if item.id in _BOOTSTRAP_EXECUTOR_ACTION_IDS - {"bootstrap_infralink_controller"}
+    ]
     if not readiness.ready:
         actions.append("bootstrap_infralink_controller")
     return actions

--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -1912,6 +1912,15 @@ _BOOTSTRAP_EXECUTOR_ACTION_IDS = _BOOTSTRAP_HANDOFF_ACTION_IDS - {
     "initialize_machine_id",
 }
 
+_BOOTSTRAP_CONTROLLER_BACKED_CHECK_IDS = frozenset(
+    {
+        "bws_config",
+        "self_deploy_runtime",
+        "self_deploy_timer",
+        "self_deploy_reconcile",
+    }
+)
+
 
 def _bootstrap_apply_handoff_is_safe(readiness: HostReadinessResult) -> bool:
     """Advertise stdin apply only when every failed gate is executor-backed."""
@@ -1923,7 +1932,9 @@ def _bootstrap_apply_handoff_is_safe(readiness: HostReadinessResult) -> bool:
         for action in readiness.actions
         if action.id in _BOOTSTRAP_HANDOFF_ACTION_IDS
     }
-    return bool(required_failures) and required_failures <= (executor_checks | {"bws_token"})
+    return bool(required_failures) and required_failures <= (
+        executor_checks | _BOOTSTRAP_CONTROLLER_BACKED_CHECK_IDS | {"bws_token"}
+    )
 
 
 def _bootstrap_bws_token_apply_action(ctx: Context, target: Any, address: str) -> Action:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -23,6 +23,7 @@ from infralink.cli.main import (
     Context,
     _apply_bootstrap_request,
     _apply_controller_refresh,
+    _bootstrap_apply_request,
     _bootstrap_executor_actions,
     _bootstrap_plan_actions,
     _bootstrap_tailnet_address,
@@ -230,7 +231,7 @@ def test_bootstrap_dry_plan_marks_a_missing_token_as_required() -> None:
     assert planned.actions[-1].id == "provide_bws_token"
 
 
-def test_bootstrap_cli_plan_advertises_apply_when_only_bws_token_is_missing(
+def test_bootstrap_cli_plan_advertises_apply_for_blank_host_executor_prerequisites(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registry = tmp_path / "hosts"
@@ -269,7 +270,34 @@ def test_bootstrap_cli_plan_advertises_apply_when_only_bws_token_is_missing(
     monkeypatch.setattr(
         "infralink.cli.main.evaluate_host_readiness",
         lambda *_args, **_kwargs: HostReadinessResult(
-            transport="root_ssh", ready=True, checks=[], actions=[]
+            transport="root_ssh",
+            ready=False,
+            checks=[
+                HostReadinessCheck(
+                    id="machine_id",
+                    required=True,
+                    passed=False,
+                    description="Machine UUID is missing.",
+                ),
+                HostReadinessCheck(
+                    id="docker",
+                    required=True,
+                    passed=False,
+                    description="Docker is missing.",
+                ),
+            ],
+            actions=[
+                HostBootstrapAction(
+                    id="initialize_machine_id",
+                    check_id="machine_id",
+                    description="Initialize machine UUID.",
+                ),
+                HostBootstrapAction(
+                    id="install_docker",
+                    check_id="docker",
+                    description="Install Docker.",
+                ),
+            ],
         ),
     )
 
@@ -289,7 +317,7 @@ def test_bootstrap_cli_plan_advertises_apply_when_only_bws_token_is_missing(
     assert apply["safe"] is False
 
 
-def test_bootstrap_plan_omits_apply_handoff_when_any_other_prerequisite_is_missing(
+def test_bootstrap_plan_advertises_apply_handoff_for_declared_executor_prerequisites(
     tmp_path: Path,
 ) -> None:
     context = Context()
@@ -329,6 +357,49 @@ def test_bootstrap_plan_omits_apply_handoff_when_any_other_prerequisite_is_missi
         bws_token_supplied=False,
     )
 
+    assert [item.rel for item in actions] == ["reinspect-readiness", "apply"]
+
+
+def test_bootstrap_plan_omits_apply_handoff_for_manual_ssh_prerequisite(
+    tmp_path: Path,
+) -> None:
+    context = Context()
+    context.registry_path = tmp_path / "hosts"
+    target = type(
+        "Target",
+        (),
+        {"uuid": HOST_ID, "canonical_name": HOST_NAME},
+    )()
+    readiness = _readiness_with_bws_token_required(
+        HostReadinessResult(
+            transport="root_ssh",
+            ready=False,
+            checks=[
+                HostReadinessCheck(
+                    id="ssh",
+                    required=True,
+                    passed=False,
+                    description="Root SSH is unavailable.",
+                )
+            ],
+            actions=[
+                HostBootstrapAction(
+                    id="establish_root_ssh",
+                    check_id="ssh",
+                    description="Establish root SSH.",
+                )
+            ],
+        )
+    )
+
+    actions = _bootstrap_plan_actions(
+        context,
+        target,
+        "100.64.68.83",
+        readiness,
+        bws_token_supplied=False,
+    )
+
     assert [item.rel for item in actions] == ["reinspect-readiness"]
 
 
@@ -338,6 +409,11 @@ def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_act
         ready=False,
         checks=[],
         actions=[
+            HostBootstrapAction(
+                id="initialize_machine_id",
+                check_id="machine_id",
+                description="Machine UUID.",
+            ),
             HostBootstrapAction(id="install_git", check_id="git", description="Git."),
             HostBootstrapAction(id="install_docker", check_id="docker", description="Docker."),
             HostBootstrapAction(id="install_jq", check_id="jq", description="jq."),
@@ -354,6 +430,32 @@ def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_act
         "install_bws_cli",
         "bootstrap_infralink_controller",
     ]
+    target = type(
+        "Target",
+        (),
+        {
+            "uuid": HOST_ID,
+            "canonical_name": HOST_NAME,
+            "tailscale_ip": "100.64.68.83",
+        },
+    )()
+    request = _bootstrap_apply_request(
+        Context(),
+        target,
+        _bootstrap_executor_actions(readiness),
+        controller_state=HostControllerBootstrapState.model_validate(
+            {
+                "controller_image": "ghcr.io/example/controller:main",
+                "registry_read_identity_secret": {
+                    "project": "fleet",
+                    "id": "11111111-1111-4111-8111-111111111111",
+                },
+                "registry_repo_url": "https://example.invalid/registry.git",
+                "registry_ref": "main",
+            }
+        ),
+    )
+    assert "initialize_machine_id" not in request.bootstrap_actions
 
 
 def test_controller_bootstrap_requires_a_registry_with_a_structured_remediation() -> None:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -285,6 +285,30 @@ def test_bootstrap_cli_plan_advertises_apply_for_blank_host_executor_prerequisit
                     passed=False,
                     description="Docker is missing.",
                 ),
+                HostReadinessCheck(
+                    id="bws_config",
+                    required=True,
+                    passed=False,
+                    description="BWS configuration is missing.",
+                ),
+                HostReadinessCheck(
+                    id="self_deploy_runtime",
+                    required=True,
+                    passed=False,
+                    description="Controller runtime is missing.",
+                ),
+                HostReadinessCheck(
+                    id="self_deploy_timer",
+                    required=True,
+                    passed=False,
+                    description="Controller timer is inactive.",
+                ),
+                HostReadinessCheck(
+                    id="self_deploy_reconcile",
+                    required=True,
+                    passed=False,
+                    description="Controller reconcile is unavailable.",
+                ),
             ],
             actions=[
                 HostBootstrapAction(
@@ -296,6 +320,26 @@ def test_bootstrap_cli_plan_advertises_apply_for_blank_host_executor_prerequisit
                     id="install_docker",
                     check_id="docker",
                     description="Install Docker.",
+                ),
+                HostBootstrapAction(
+                    id="configure_bws",
+                    check_id="bws_config",
+                    description="Configure BWS.",
+                ),
+                HostBootstrapAction(
+                    id="install_self_deploy_runtime",
+                    check_id="self_deploy_runtime",
+                    description="Install controller runtime.",
+                ),
+                HostBootstrapAction(
+                    id="enable_self_deploy_timer",
+                    check_id="self_deploy_timer",
+                    description="Enable controller timer.",
+                ),
+                HostBootstrapAction(
+                    id="inspect_self_deploy_reconcile",
+                    check_id="self_deploy_reconcile",
+                    description="Inspect controller reconcile.",
                 ),
             ],
         ),
@@ -419,6 +463,26 @@ def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_act
             HostBootstrapAction(id="install_jq", check_id="jq", description="jq."),
             HostBootstrapAction(id="install_bws_cli", check_id="bws", description="BWS."),
             HostBootstrapAction(
+                id="configure_bws",
+                check_id="bws_config",
+                description="Configure BWS.",
+            ),
+            HostBootstrapAction(
+                id="install_self_deploy_runtime",
+                check_id="self_deploy_runtime",
+                description="Install controller runtime.",
+            ),
+            HostBootstrapAction(
+                id="enable_self_deploy_timer",
+                check_id="self_deploy_timer",
+                description="Enable controller timer.",
+            ),
+            HostBootstrapAction(
+                id="inspect_self_deploy_reconcile",
+                check_id="self_deploy_reconcile",
+                description="Inspect controller reconcile.",
+            ),
+            HostBootstrapAction(
                 id="create_devops_account", check_id="devops", description="obsolete"
             ),
         ],
@@ -456,6 +520,10 @@ def test_bootstrap_executor_carries_missing_prerequisites_and_one_controller_act
         ),
     )
     assert "initialize_machine_id" not in request.bootstrap_actions
+    assert "configure_bws" not in request.bootstrap_actions
+    assert "install_self_deploy_runtime" not in request.bootstrap_actions
+    assert "enable_self_deploy_timer" not in request.bootstrap_actions
+    assert "inspect_self_deploy_reconcile" not in request.bootstrap_actions
 
 
 def test_controller_bootstrap_requires_a_registry_with_a_structured_remediation() -> None:


### PR DESCRIPTION
## Summary
- advertise the redacted stdin `host bootstrap --apply` action when every failed required check is either the BWS token or backed by a declared baseline executor action
- include machine UUID initialization in the executor-backed set
- retain suppression for manual SSH, identity, and Tailnet gates
- cover a reachable blank-host CLI response and manual SSH suppression

## Verification
- `python3 -m pytest -q` (`1467 passed, 1 skipped`, 86.87% coverage)
- `python3 -m pytest -q --no-cov tests/test_cli_host_bootstrap.py`
- `python3 -m ruff check src/infralink/cli/main.py tests/test_cli_host_bootstrap.py`
- `python3 -m ruff format --check src/infralink/cli/main.py tests/test_cli_host_bootstrap.py`
- `git diff --check`