### PR TITLE
fix: expose sanitized bootstrap executor failures

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2294,6 +2294,7 @@ def _apply_bootstrap_request(
         completed = subprocess.run(
             [
                 "ansible-playbook",
+                "-vv",
                 "-i",
                 f"{request.host_address},",
                 "-u",
@@ -2316,7 +2317,7 @@ def _apply_bootstrap_request(
             message="Host baseline apply failed",
             exit_code=ExitCode.PROVIDER_ERROR,
             fix="Verify the declared bootstrap executor and rerun host bootstrap --apply",
-            details=_bootstrap_failure_details(target.uuid, completed),
+            details=_bootstrap_failure_details(target.uuid, completed, token=token),
         )
     return _bootstrap_operator_readiness(
         evaluate_host_readiness(
@@ -2486,10 +2487,11 @@ def _controller_image_reference(image: Any) -> str:
 
 
 def _bootstrap_failure_details(
-    host_uuid: str, completed: subprocess.CompletedProcess[str]
+    host_uuid: str, completed: subprocess.CompletedProcess[str], *, token: str | None
 ) -> dict[str, Any]:
-    """Expose bounded execution shape only, never controller-rendered task names."""
-    task_count = min(len(re.findall(r"^TASK \[[^\]]+\]", completed.stdout, re.MULTILINE)), 8)
+    """Return bounded, token-safe executor failure evidence."""
+    task_headers = list(re.finditer(r"^TASK \[([^\]]+)\]", completed.stdout, re.MULTILINE))
+    task_count = min(len(task_headers), 8)
     details: dict[str, Any] = {
         "host": host_uuid,
         "executor": "host_baseline",
@@ -2497,8 +2499,41 @@ def _bootstrap_failure_details(
     }
     if task_count:
         details["task_count"] = task_count
-        details["task_output_redacted"] = True
+        failed_task: dict[str, str] = {"name": task_headers[-1].group(1)}
+        following_output = completed.stdout[task_headers[-1].end() :]
+        task_path = re.search(
+            r"^task path: (?:/app/)?(ansible/[A-Za-z0-9_./-]+\.yml:\d+)\s*$",
+            following_output,
+            re.MULTILINE,
+        )
+        if task_path is not None:
+            failed_task["path"] = task_path.group(1)
+        details["failed_task"] = failed_task
+    stderr = _sanitize_bootstrap_diagnostic(completed.stderr, token)
+    if stderr:
+        details["stderr"] = stderr
     return details
+
+
+def _sanitize_bootstrap_diagnostic(value: str, token: str | None) -> str:
+    """Keep a short diagnostic tail while removing BWS credentials."""
+    if token:
+        value = value.replace(token, "[REDACTED]")
+    value = re.sub(
+        r"(?im)(BWS_ACCESS_TOKEN\s*[=:]\s*)\S+",
+        r"\1[REDACTED]",
+        value,
+    )
+    value = re.sub(
+        r"(?im)(Authorization:\s*(?:Bearer\s+)?)\S+",
+        r"\1[REDACTED]",
+        value,
+    )
+    value = value.strip()
+    maximum_length = 1200
+    if len(value) > maximum_length:
+        return "[truncated]\n" + value[-maximum_length:]
+    return value
 
 
 def _apply_controller_refresh(ctx: Context, target: Any, runtime_revision: str | None) -> None:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -22,6 +22,7 @@ from infralink.cli.host_readiness import evaluate_host_readiness as evaluate_rea
 from infralink.cli.main import (
     Context,
     _apply_bootstrap_request,
+    _bootstrap_failure_details,
     _apply_controller_refresh,
     _bootstrap_apply_request,
     _bootstrap_executor_actions,
@@ -41,6 +42,36 @@ ROOT = Path(__file__).resolve().parents[1]
 HOST_ID = "d1b9e5d5-36b0-459d-a556-96622811fbd5"
 HOST_NAME = "database.example.com"
 HOST_FINGERPRINT = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+
+def test_bootstrap_failure_details_exposes_sanitized_failed_task_evidence() -> None:
+    """A baseline failure names its task without leaking the BWS handoff token."""
+    token = "0.11111111-1111-4111-8111-111111111111.secret-value"
+    completed = subprocess.CompletedProcess(
+        args=["ansible-playbook"],
+        returncode=2,
+        stdout=(
+            "TASK [Bootstrap the controller-owned host runtime] *******************\n"
+            "task path: /app/ansible/tasks/infralink_host_baseline.yml:96\n"
+            "fatal: [100.91.194.110]: FAILED! => {\"censored\": \"the output has been hidden\"}\n"
+        ),
+        stderr=f"[WARNING]: BWS_ACCESS_TOKEN={token} was provided by the environment\n",
+    )
+
+    details = _bootstrap_failure_details(HOST_ID, completed, token=token)
+
+    assert details == {
+        "host": HOST_ID,
+        "executor": "host_baseline",
+        "return_code": 2,
+        "task_count": 1,
+        "failed_task": {
+            "name": "Bootstrap the controller-owned host runtime",
+            "path": "ansible/tasks/infralink_host_baseline.yml:96",
+        },
+        "stderr": "[WARNING]: BWS_ACCESS_TOKEN=[REDACTED] was provided by the environment",
+    }
+    assert token not in repr(details)
 
 
 def test_control_root_can_be_supplied_by_the_controller_runtime(
@@ -706,6 +737,7 @@ def test_bootstrap_uses_baked_executor_when_control_checkout_is_dirty(
     )
 
     assert any(command[0] == "ansible-playbook" for command in commands)
+    assert ["ansible-playbook", "-vv"] in [command[:2] for command in commands]
     assert ansible_cwds == [executor_root]
     assert not any(command[:2] == ["git", "-C"] for command in commands)
 


### PR DESCRIPTION
Urgent ES2 bootstrap diagnostic repair.

- runs baseline executor at `-vv` so Ansible emits task path
- surfaces only last failed task name/path and bounded stderr
- removes the BWS handoff token and common credential assignments from diagnostics

Focused tests: `pytest -q --no-cov tests/test_cli_host_bootstrap.py -k "bootstrap_failure_details or uses_baked_executor"`