### PR TITLE
fix: expose nested bootstrap executor failure evidence

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import ipaddress
 import json
@@ -2509,10 +2510,39 @@ def _bootstrap_failure_details(
         if task_path is not None:
             failed_task["path"] = task_path.group(1)
         details["failed_task"] = failed_task
+    nested_failure = _bootstrap_nested_failure_details(completed.stdout, token)
+    if nested_failure is not None:
+        details["nested_failure"] = nested_failure
     stderr = _sanitize_bootstrap_diagnostic(completed.stderr, token)
     if stderr:
         details["stderr"] = stderr
     return details
+
+
+def _bootstrap_nested_failure_details(value: str, token: str | None) -> dict[str, Any] | None:
+    """Decode the baseline's bounded, already-sanitized nested-controller evidence."""
+    match = re.search(
+        r"INFRALINK_BOOTSTRAP_NESTED_FAILURE_B64=([A-Za-z0-9+/=]+)", value
+    )
+    if match is None:
+        return None
+    try:
+        payload = json.loads(base64.b64decode(match.group(1), validate=True))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return_code = payload.get("return_code")
+    if isinstance(return_code, str) and return_code.isdecimal():
+        return_code = int(return_code)
+    if not isinstance(return_code, int):
+        return None
+    result: dict[str, Any] = {"return_code": return_code}
+    for key in ("stdout_tail", "stderr_tail"):
+        diagnostic = payload.get(key)
+        if isinstance(diagnostic, str):
+            result[key] = _sanitize_bootstrap_diagnostic(diagnostic, token)
+    return result
 
 
 def _sanitize_bootstrap_diagnostic(value: str, token: str | None) -> str:

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -22,11 +22,11 @@ from infralink.cli.host_readiness import evaluate_host_readiness as evaluate_rea
 from infralink.cli.main import (
     Context,
     _apply_bootstrap_request,
-    _bootstrap_failure_details,
     _apply_controller_refresh,
     _bootstrap_apply_request,
     _bootstrap_executor_actions,
     _bootstrap_executor_source,
+    _bootstrap_failure_details,
     _bootstrap_plan_actions,
     _bootstrap_tailnet_address,
     _controller_bootstrap_state,

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+from base64 import b64encode
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -70,6 +71,38 @@ def test_bootstrap_failure_details_exposes_sanitized_failed_task_evidence() -> N
             "path": "ansible/tasks/infralink_host_baseline.yml:96",
         },
         "stderr": "[WARNING]: BWS_ACCESS_TOKEN=[REDACTED] was provided by the environment",
+    }
+    assert token not in repr(details)
+
+
+def test_bootstrap_failure_details_exposes_sanitized_nested_controller_failure() -> None:
+    """The baseline executor returns bounded nested-controller evidence safely."""
+    token = "0.11111111-1111-4111-8111-111111111111.secret-value"
+    nested_failure = json.dumps(
+        {
+            "return_code": "2",
+            "stdout_tail": "registry fetch failed",
+            "stderr_tail": f"BWS_ACCESS_TOKEN={token}",
+        },
+        separators=(",", ":"),
+    )
+    completed = subprocess.CompletedProcess(
+        args=["ansible-playbook"],
+        returncode=2,
+        stdout=(
+            "TASK [Report sanitized controller bootstrap failure] *******************\n"
+            "INFRALINK_BOOTSTRAP_NESTED_FAILURE_B64="
+            f"{b64encode(nested_failure.encode()).decode()}\n"
+        ),
+        stderr="",
+    )
+
+    details = _bootstrap_failure_details(HOST_ID, completed, token=token)
+
+    assert details["nested_failure"] == {
+        "return_code": 2,
+        "stdout_tail": "registry fetch failed",
+        "stderr_tail": "BWS_ACCESS_TOKEN=[REDACTED]",
     }
     assert token not in repr(details)
 

--- a/tests/test_cli_host_bootstrap.py
+++ b/tests/test_cli_host_bootstrap.py
@@ -53,7 +53,7 @@ def test_bootstrap_failure_details_exposes_sanitized_failed_task_evidence() -> N
         stdout=(
             "TASK [Bootstrap the controller-owned host runtime] *******************\n"
             "task path: /app/ansible/tasks/infralink_host_baseline.yml:96\n"
-            "fatal: [100.91.194.110]: FAILED! => {\"censored\": \"the output has been hidden\"}\n"
+            'fatal: [100.91.194.110]: FAILED! => {"censored": "the output has been hidden"}\n'
         ),
         stderr=f"[WARNING]: BWS_ACCESS_TOKEN={token} was provided by the environment\n",
     )


### PR DESCRIPTION
Emergency bootstrap diagnostic: the baseline executor preserves the BWS token under `no_log`, but reports a bounded, token-sanitized nested controller stdout/stderr tail only on failure. Infralink decodes the marker into the failure envelope.