### PR TITLE
Registry authoring: support explicit file value sources

### DIFF
--- a/src/infralink/cli/main.py
+++ b/src/infralink/cli/main.py
@@ -382,6 +382,36 @@ HELP_METADATA: dict[tuple[str, ...], dict[str, Any]] = {
         "options": [{"name": "last_run", "type": "boolean", "required": True}],
         "examples": ["infralink host logs relaxgg-db-es1 --last-run"],
     },
+    ("registry",): {
+        "description": "Inspect and author local registry declarations.",
+        "arguments": [],
+        "options": [],
+        "examples": ["infralink registry host get relaxgg-db-es1"],
+    },
+    ("registry", "host"): {
+        "description": "Resolve and patch host declarations in an operator working tree.",
+        "arguments": [],
+        "options": [],
+        "examples": ["infralink registry host get relaxgg-db-es1"],
+    },
+    ("registry", "host", "get"): {
+        "description": "Resolve a host to its authoritative manifest and declaration.",
+        "arguments": [{"name": "host_ref", "type": "string", "required": True}],
+        "options": [],
+        "examples": ["infralink registry host get relaxgg-db-es1"],
+    },
+    ("registry", "host", "patch"): {
+        "description": "Preview or explicitly write typed dot-addressed host mutations.",
+        "arguments": [{"name": "host_ref", "type": "string", "required": True}],
+        "options": [
+            {"name": "set", "type": "text", "required": True},
+            {"name": "write", "type": "boolean", "required": False},
+        ],
+        "examples": [
+            "infralink registry host patch HOST --set controller_bootstrap.bootstrap_note=@text:FILE",
+            "infralink registry host patch HOST --set controller_bootstrap.pull_enabled=@yaml:FILE --write",
+        ],
+    },
     ("operation",): {
         "description": "Inspect declared host-local reconcile operations.",
         "arguments": [],

--- a/src/infralink/cli/registry_authoring.py
+++ b/src/infralink/cli/registry_authoring.py
@@ -7,7 +7,7 @@ import tempfile
 from collections.abc import Iterable, MutableMapping
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
 import click
 import yaml
@@ -31,6 +31,9 @@ except ModuleNotFoundError:
 
     def pass_context(func: Any) -> Any:
         return func
+
+
+ResolvedAssignment: TypeAlias = tuple[str, list[str], Any]
 
 
 def _failure(message: str, fix: str, details: dict[str, Any]) -> CliFailure:
@@ -115,6 +118,48 @@ def _find_host(
     return matches[0]
 
 
+def _read_source_value(encoded_value: str, assignment: str) -> Any:
+    source_type, separator, source_name = encoded_value[1:].partition(":")
+    if not separator or not source_name:
+        raise _failure(
+            "Mutation file source is incomplete",
+            "Use @text:PATH for literal text or @yaml:PATH for one typed YAML value",
+            {"assignment": assignment},
+        )
+    if source_type not in {"text", "yaml"}:
+        raise _failure(
+            "Mutation file source is not supported",
+            "Use @text:PATH for literal text or @yaml:PATH for one typed YAML value",
+            {"assignment": assignment, "source_type": source_type},
+        )
+    source_path = Path(source_name)
+    try:
+        source = source_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _failure(
+            "Mutation file source could not be read",
+            "Provide a readable UTF-8 file path after @text: or @yaml:",
+            {"assignment": assignment, "source_path": str(source_path)},
+        ) from exc
+    if source_type == "text":
+        return source
+    try:
+        documents = list(yaml.safe_load_all(source))
+    except yaml.YAMLError as exc:
+        raise _failure(
+            "Mutation YAML file source is not valid YAML",
+            "Provide one valid YAML document after @yaml:",
+            {"assignment": assignment, "source_path": str(source_path)},
+        ) from exc
+    if len(documents) != 1:
+        raise _failure(
+            "Mutation YAML file source must contain exactly one document",
+            "Provide one YAML value in the @yaml: file",
+            {"assignment": assignment, "source_path": str(source_path)},
+        )
+    return documents[0]
+
+
 def _parse_assignment(value: str) -> tuple[list[str], Any]:
     path, separator, encoded_value = value.partition("=")
     if not separator or not path or any(not segment for segment in path.split(".")):
@@ -123,21 +168,25 @@ def _parse_assignment(value: str) -> tuple[list[str], Any]:
             "Use a dot-addressed path, for example controller_bootstrap.controller_image=ghcr.io/example/controller:v0.5.5",
             {"assignment": value},
         )
-    try:
-        decoded_value = yaml.safe_load(encoded_value)
-    except yaml.YAMLError as exc:
-        raise _failure(
-            "Mutation value is not valid YAML",
-            "Quote the value or provide a valid YAML scalar, list, or mapping",
-            {"assignment": value},
-        ) from exc
+    if encoded_value.startswith("@"):
+        decoded_value = _read_source_value(encoded_value, value)
+    else:
+        try:
+            decoded_value = yaml.safe_load(encoded_value)
+        except yaml.YAMLError as exc:
+            raise _failure(
+                "Mutation value is not valid YAML",
+                "Quote the value or provide a valid YAML scalar, list, or mapping",
+                {"assignment": value},
+            ) from exc
     return path.split("."), decoded_value
 
 
-def _validate_unique_assignments(assignments: tuple[str, ...]) -> None:
+def _resolve_assignments(assignments: tuple[str, ...]) -> tuple[ResolvedAssignment, ...]:
     paths: set[str] = set()
+    resolved: list[ResolvedAssignment] = []
     for assignment in assignments:
-        segments, _value = _parse_assignment(assignment)
+        segments, decoded_value = _parse_assignment(assignment)
         path = ".".join(segments)
         if path in paths:
             raise _failure(
@@ -146,6 +195,8 @@ def _validate_unique_assignments(assignments: tuple[str, ...]) -> None:
                 {"path": path},
             )
         paths.add(path)
+        resolved.append((assignment, segments, decoded_value))
+    return tuple(resolved)
 
 
 def _public_value(value: Any, *, key: str | None = None) -> Any:
@@ -166,8 +217,10 @@ def _public_value(value: Any, *, key: str | None = None) -> Any:
     return value
 
 
-def _apply_assignment(declaration: MutableMapping[str, Any], assignment: str) -> dict[str, Any]:
-    segments, value = _parse_assignment(assignment)
+def _apply_assignment(
+    declaration: MutableMapping[str, Any], assignment: ResolvedAssignment
+) -> dict[str, Any]:
+    source_assignment, segments, value = assignment
     current: MutableMapping[str, Any] = declaration
     for segment in segments[:-1]:
         child = current.get(segment)
@@ -175,7 +228,7 @@ def _apply_assignment(declaration: MutableMapping[str, Any], assignment: str) ->
             raise _failure(
                 "Mutation parent path does not exist",
                 "Inspect the host declaration and target an existing mapping path",
-                {"assignment": assignment, "missing_parent": ".".join(segments[:-1])},
+                {"assignment": source_assignment, "missing_parent": ".".join(segments[:-1])},
             )
         current = child
     leaf = segments[-1]
@@ -183,7 +236,7 @@ def _apply_assignment(declaration: MutableMapping[str, Any], assignment: str) ->
         raise _failure(
             "Mutation path does not exist",
             "Inspect the host declaration and mutate an existing field",
-            {"assignment": assignment, "missing_path": ".".join(segments)},
+            {"assignment": source_assignment, "missing_path": ".".join(segments)},
         )
     before = current[leaf]
     if before is not None and type(value) is not type(before):
@@ -191,7 +244,7 @@ def _apply_assignment(declaration: MutableMapping[str, Any], assignment: str) ->
             "Mutation value has the wrong type",
             "Provide YAML with the same type as the existing declaration value",
             {
-                "assignment": assignment,
+                "assignment": source_assignment,
                 "path": ".".join(segments),
                 "expected_type": type(before).__name__,
                 "actual_type": type(value).__name__,
@@ -233,7 +286,9 @@ def _node_reference_counts(root: Node) -> dict[int, int]:
     return counts
 
 
-def _replace_scalar_assignments(source: str, host_id: str, assignments: tuple[str, ...]) -> str:
+def _replace_scalar_assignments(
+    source: str, host_id: str, assignments: tuple[ResolvedAssignment, ...]
+) -> str:
     root = yaml.compose(source)
     if not isinstance(root, MappingNode):
         raise _failure(
@@ -254,35 +309,34 @@ def _replace_scalar_assignments(source: str, host_id: str, assignments: tuple[st
 
     replacements: list[tuple[int, int, str]] = []
     reference_counts = _node_reference_counts(root)
-    for assignment in assignments:
-        segments, value = _parse_assignment(assignment)
+    for source_assignment, segments, value in assignments:
         node: Node = host
         for segment in segments:
             if not isinstance(node, MappingNode):
                 raise _failure(
                     "Mutation path does not address a mapping field",
                     "Inspect the host declaration and target an existing scalar field",
-                    {"assignment": assignment},
+                    {"assignment": source_assignment},
                 )
             child = _mapping_child(node, segment)
             if child is None:
                 raise _failure(
                     "Mutation path does not exist",
                     "Inspect the host declaration and mutate an existing field",
-                    {"assignment": assignment},
+                    {"assignment": source_assignment},
                 )
             node = child
         if not isinstance(node, ScalarNode) or isinstance(value, (MutableMapping, list)):
             raise _failure(
                 "Dot-addressed mutations support existing scalar fields only",
                 "Replace a containing mapping through a dedicated typed command",
-                {"assignment": assignment},
+                {"assignment": source_assignment},
             )
         if reference_counts[id(node)] != 1:
             raise _failure(
                 "Dot-addressed mutations refuse alias-backed fields",
                 "Replace the alias with an explicit value manually before using this command",
-                {"assignment": assignment},
+                {"assignment": source_assignment},
             )
         replacement = (
             yaml.safe_dump(value, default_flow_style=True, allow_unicode=False)
@@ -388,7 +442,14 @@ def registry_host_get(ctx: Context, host_ref: str) -> None:
 
 @registry_host.command(name="patch")
 @click.argument("host_ref")
-@click.option("--set", "assignments", multiple=True, required=True, metavar="PATH=YAML_VALUE")
+@click.option(
+    "--set",
+    "assignments",
+    multiple=True,
+    required=True,
+    metavar="PATH=YAML_VALUE|@text:FILE|@yaml:FILE",
+    help="Set an existing scalar from inline YAML, literal UTF-8 text, or one YAML file value",
+)
 @click.option(
     "--write", is_flag=True, help="Atomically write the validated mutation to the manifest"
 )
@@ -402,16 +463,21 @@ def registry_host_patch(
     """Preview or explicitly write typed dot-addressed host mutations."""
     root = _registry_root(ctx, for_write=write)
     host_id, manifest_path, source, document, declaration = _find_host(root, host_ref)
-    _validate_unique_assignments(assignments)
+    resolved_assignments = _resolve_assignments(assignments)
     candidate = deepcopy(document)
     candidate_hosts = candidate.get("hosts")
     assert isinstance(candidate_hosts, MutableMapping)
     candidate_declaration = candidate_hosts[host_id]
     assert isinstance(candidate_declaration, MutableMapping)
-    changes = [_apply_assignment(candidate_declaration, assignment) for assignment in assignments]
+    changes = [
+        _apply_assignment(candidate_declaration, assignment) for assignment in resolved_assignments
+    ]
     _validate_candidate(candidate, host_id)
     if write:
-        _write_document(manifest_path, _replace_scalar_assignments(source, host_id, assignments))
+        _write_document(
+            manifest_path,
+            _replace_scalar_assignments(source, host_id, resolved_assignments),
+        )
     result = RegistryHostPatchResult(
         mode="written" if write else "preview",
         host=RegistryHostIdentity(

--- a/tests/test_cli_registry_authoring.py
+++ b/tests/test_cli_registry_authoring.py
@@ -22,6 +22,8 @@ hosts:
     tailscale_ip: 100.64.1.9
     controller_bootstrap:
       controller_image: ghcr.io/example/controller:main
+      bootstrap_note: initial note
+      pull_enabled: false
 """.lstrip(),
         encoding="utf-8",
     )
@@ -124,6 +126,114 @@ def test_registry_host_patch_previews_then_writes_a_typed_dot_addressed_mutation
         ]
         == "ghcr.io/example/controller:v0.5.5"
     )
+
+
+def test_registry_host_patch_reads_literal_multiline_text_from_an_explicit_file_source(
+    tmp_path: Path,
+) -> None:
+    root = _registry_root(tmp_path)
+    source = tmp_path / "bootstrap-note.txt"
+    source.write_text("first line\nsecond line\n", encoding="utf-8")
+    command = [
+        "--registry",
+        str(root),
+        "registry",
+        "host",
+        "patch",
+        "alpha",
+        "--set",
+        f"controller_bootstrap.bootstrap_note=@text:{source}",
+    ]
+
+    preview = CliRunner().invoke(cli, command)
+    preview_payload = _payload(preview)
+    assert preview.exit_code == 0, preview.output
+    assert preview_payload["result"]["changes"][0]["after"] == "first line\nsecond line\n"
+
+    applied = CliRunner().invoke(cli, [*command, "--write"])
+    assert applied.exit_code == 0, applied.output
+    document = yaml.safe_load(
+        (root / "11111111-1111-4111-8111-111111111111" / "manifest.yml").read_text(encoding="utf-8")
+    )
+    assert (
+        document["hosts"]["11111111-1111-4111-8111-111111111111"]["controller_bootstrap"][
+            "bootstrap_note"
+        ]
+        == "first line\nsecond line\n"
+    )
+
+
+def test_registry_host_patch_help_documents_explicit_file_source_grammars() -> None:
+    result = CliRunner().invoke(cli, ["help", "registry", "host", "patch"])
+
+    payload = _payload(result)
+    assert result.exit_code == 0, result.output
+    assert "@text:FILE" in payload["result"]["examples"][0]
+    assert "@yaml:FILE" in payload["result"]["examples"][1]
+
+
+def test_registry_host_patch_reads_a_typed_yaml_value_from_an_explicit_file_source(
+    tmp_path: Path,
+) -> None:
+    root = _registry_root(tmp_path)
+    source = tmp_path / "pull-enabled.yml"
+    source.write_text("true\n", encoding="utf-8")
+    command = [
+        "--registry",
+        str(root),
+        "registry",
+        "host",
+        "patch",
+        "alpha",
+        "--set",
+        f"controller_bootstrap.pull_enabled=@yaml:{source}",
+    ]
+
+    preview = CliRunner().invoke(cli, command)
+    preview_payload = _payload(preview)
+    assert preview.exit_code == 0, preview.output
+    assert preview_payload["result"]["changes"][0]["after"] is True
+
+    applied = CliRunner().invoke(cli, [*command, "--write"])
+    assert applied.exit_code == 0, applied.output
+    document = yaml.safe_load(
+        (root / "11111111-1111-4111-8111-111111111111" / "manifest.yml").read_text(encoding="utf-8")
+    )
+    assert (
+        document["hosts"]["11111111-1111-4111-8111-111111111111"]["controller_bootstrap"][
+            "pull_enabled"
+        ]
+        is True
+    )
+
+
+def test_registry_host_patch_rejects_an_unreadable_explicit_file_source_without_writing(
+    tmp_path: Path,
+) -> None:
+    root = _registry_root(tmp_path)
+    manifest = root / "11111111-1111-4111-8111-111111111111" / "manifest.yml"
+    original = manifest.read_text(encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--registry",
+            str(root),
+            "registry",
+            "host",
+            "patch",
+            "alpha",
+            "--set",
+            f"controller_bootstrap.bootstrap_note=@text:{tmp_path / 'missing.txt'}",
+            "--write",
+        ],
+    )
+
+    payload = _payload(result)
+    assert result.exit_code == 2
+    assert payload["error"]["code"] == "usage_error"
+    assert "file source" in payload["error"]["message"]
+    assert manifest.read_text(encoding="utf-8") == original
 
 
 def test_registry_host_patch_rejects_unknown_parent_paths_without_writing(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #149

Adds explicit noninteractive value sources for `infralink registry host patch`:
- `@text:FILE` reads literal UTF-8 text, preserving newlines
- `@yaml:FILE` accepts exactly one typed YAML value
- resolves sources once before preview/write
- HATEOAS help advertises both source forms

No environment expansion, implicit generic `@file`, or client-side template rendering.