### PR TITLE
Expose registry mutation value grammar in HATEOAS

### DIFF
--- a/src/infralink/cli/contracts.py
+++ b/src/infralink/cli/contracts.py
@@ -47,6 +47,8 @@ class Binding(ContractModel):
     type: Literal["string", "integer", "boolean"]
     required: bool
     source: str
+    syntax: str | None = Field(default=None, exclude_if=lambda value: value is None)
+    examples: list[str] = Field(default_factory=list, exclude_if=lambda value: not value)
 
 
 class Action(ContractModel):

--- a/src/infralink/cli/registry_authoring.py
+++ b/src/infralink/cli/registry_authoring.py
@@ -432,7 +432,17 @@ def registry_host_get(ctx: Context, host_ref: str) -> None:
                     "Preview a typed host declaration mutation",
                     bindings={
                         "path": Binding(type="string", required=True, source="operator.input"),
-                        "value": Binding(type="string", required=True, source="operator.input"),
+                        "value": Binding(
+                            type="string",
+                            required=True,
+                            source="operator.input",
+                            syntax="YAML_VALUE | @text:FILE | @yaml:FILE",
+                            examples=[
+                                "ghcr.io/example/controller:v0.5.5",
+                                "@text:FILE",
+                                "@yaml:FILE",
+                            ],
+                        ),
                     },
                 )
             ],

--- a/src/infralink/schemas/cli/v1/analyze.json
+++ b/src/infralink/schemas/cli/v1/analyze.json
@@ -117,6 +117,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -124,6 +131,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/app-list.json
+++ b/src/infralink/schemas/cli/v1/app-list.json
@@ -62,6 +62,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -69,6 +76,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/app-show.json
+++ b/src/infralink/schemas/cli/v1/app-show.json
@@ -90,6 +90,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -97,6 +104,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/capabilities.json
+++ b/src/infralink/schemas/cli/v1/capabilities.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/check.json
+++ b/src/infralink/schemas/cli/v1/check.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/diagram.json
+++ b/src/infralink/schemas/cli/v1/diagram.json
@@ -103,6 +103,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -110,6 +117,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/docs.json
+++ b/src/infralink/schemas/cli/v1/docs.json
@@ -103,6 +103,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -110,6 +117,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/doctor.json
+++ b/src/infralink/schemas/cli/v1/doctor.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/edge-show.json
+++ b/src/infralink/schemas/cli/v1/edge-show.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/edges-list.json
+++ b/src/infralink/schemas/cli/v1/edges-list.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/explain.json
+++ b/src/infralink/schemas/cli/v1/explain.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/help.json
+++ b/src/infralink/schemas/cli/v1/help.json
@@ -69,6 +69,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -76,6 +83,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-apply.json
+++ b/src/infralink/schemas/cli/v1/host-apply.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-bootstrap.json
+++ b/src/infralink/schemas/cli/v1/host-bootstrap.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-logs.json
+++ b/src/infralink/schemas/cli/v1/host-logs.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-show.json
+++ b/src/infralink/schemas/cli/v1/host-show.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-status.json
+++ b/src/infralink/schemas/cli/v1/host-status.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/host-verifier.json
+++ b/src/infralink/schemas/cli/v1/host-verifier.json
@@ -73,6 +73,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -80,6 +87,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/hosts.json
+++ b/src/infralink/schemas/cli/v1/hosts.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/info.json
+++ b/src/infralink/schemas/cli/v1/info.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/observation-validate.json
+++ b/src/infralink/schemas/cli/v1/observation-validate.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/operation-status.json
+++ b/src/infralink/schemas/cli/v1/operation-status.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/project-readiness.json
+++ b/src/infralink/schemas/cli/v1/project-readiness.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/project-secrets.json
+++ b/src/infralink/schemas/cli/v1/project-secrets.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/project-view.json
+++ b/src/infralink/schemas/cli/v1/project-view.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/registry-host-get.json
+++ b/src/infralink/schemas/cli/v1/registry-host-get.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/registry-host-patch.json
+++ b/src/infralink/schemas/cli/v1/registry-host-patch.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/release-inspect-attestation.json
+++ b/src/infralink/schemas/cli/v1/release-inspect-attestation.json
@@ -81,6 +81,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -88,6 +95,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/release-inspect.json
+++ b/src/infralink/schemas/cli/v1/release-inspect.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/release-render-publisher-request.json
+++ b/src/infralink/schemas/cli/v1/release-render-publisher-request.json
@@ -81,6 +81,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -88,6 +95,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/release-validate-candidate.json
+++ b/src/infralink/schemas/cli/v1/release-validate-candidate.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/resolve.json
+++ b/src/infralink/schemas/cli/v1/resolve.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/root.json
+++ b/src/infralink/schemas/cli/v1/root.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/secrets-audit.json
+++ b/src/infralink/schemas/cli/v1/secrets-audit.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/secrets-inspect.json
+++ b/src/infralink/schemas/cli/v1/secrets-inspect.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/service-show.json
+++ b/src/infralink/schemas/cli/v1/service-show.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/services.json
+++ b/src/infralink/schemas/cli/v1/services.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/validate.json
+++ b/src/infralink/schemas/cli/v1/validate.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/src/infralink/schemas/cli/v1/version.json
+++ b/src/infralink/schemas/cli/v1/version.json
@@ -45,6 +45,13 @@
     "Binding": {
       "additionalProperties": false,
       "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
         "required": {
           "title": "Required",
           "type": "boolean"
@@ -52,6 +59,18 @@
         "source": {
           "title": "Source",
           "type": "string"
+        },
+        "syntax": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Syntax"
         },
         "type": {
           "enum": [

--- a/tests/test_cli_registry_authoring.py
+++ b/tests/test_cli_registry_authoring.py
@@ -54,7 +54,13 @@ def test_registry_host_get_returns_the_authoritative_manifest_location(tmp_path:
     assert patch["templated"] is True
     assert patch["bindings"] == {
         "path": {"type": "string", "required": True, "source": "operator.input"},
-        "value": {"type": "string", "required": True, "source": "operator.input"},
+        "value": {
+            "type": "string",
+            "required": True,
+            "source": "operator.input",
+            "syntax": "YAML_VALUE | @text:FILE | @yaml:FILE",
+            "examples": ["ghcr.io/example/controller:v0.5.5", "@text:FILE", "@yaml:FILE"],
+        },
     }
 
 


### PR DESCRIPTION
Adds explicit `syntax` and `examples` to the typed HATEOAS value binding returned by `infralink registry host get`. Regenerates CLI schemas.\n\nVerification: full pytest suite, mypy, ruff.