### PR TITLE
feat(observation): add profile metrics operations views

### DIFF
--- a/src/infralink/observation/codes.py
+++ b/src/infralink/observation/codes.py
@@ -77,6 +77,8 @@ PLANNER_DIAGNOSTIC_CODES = _DYNAMIC_DUPLICATE_CODES | frozenset(
         "unknown-endpoint-override",
         "unknown-host",
         "unknown-host-metrics-profile",
+        "profile-metrics-profile-capability-required",
+        "unknown-profile-metrics-profile",
         "unknown-observation-backend",
         "unknown-profile",
         "unknown-provider-alias",

--- a/src/infralink/observation/models.py
+++ b/src/infralink/observation/models.py
@@ -474,7 +474,7 @@ class OperationsView(StrictModel):
     id: CanonicalId
     purpose: Annotated[str, Field(min_length=1)]
     sections: list[OperationsViewSection]
-    kind: Literal["standard", "fleet_convergence", "host_metrics"] = "standard"
+    kind: Literal["standard", "fleet_convergence", "host_metrics", "profile_metrics"] = "standard"
     freshness_seconds: PositiveSeconds | None = None
     datasource_binding_id: CanonicalId | None = None
     metric_profile_id: CanonicalId | None = None
@@ -505,7 +505,7 @@ class OperationsView(StrictModel):
             or self.datasource_binding_id is None
             or self.metric_profile_id is None
         ):
-            raise ValueError("host metrics view has an invalid declaration")
+            raise ValueError(f"{self.kind} view has an invalid declaration")
         return self
 
 

--- a/src/infralink/observation/planner.py
+++ b/src/infralink/observation/planner.py
@@ -228,8 +228,9 @@ class PlannedOperationsView(PlanModel):
     id: str
     purpose: str
     sections: tuple[PlannedViewSection, ...]
-    kind: Literal["standard", "fleet_convergence", "host_metrics"] = "standard"
+    kind: Literal["standard", "fleet_convergence", "host_metrics", "profile_metrics"] = "standard"
     host_ids: tuple[str, ...] = ()
+    service_ids: tuple[str, ...] = ()
     freshness_seconds: int | None = None
     datasource_binding_id: str | None = None
     metric_profile_id: str | None = None
@@ -1107,8 +1108,9 @@ def resolve_observation_documents(
                 )
             )
             continue
-        if view.kind == "host_metrics":
+        if view.kind in {"host_metrics", "profile_metrics"}:
             metric_profile_supports_host_metrics = False
+            metric_profile_exposes_metrics = False
             if view.datasource_binding_id not in datasources:
                 _finding(
                     findings,
@@ -1117,14 +1119,38 @@ def resolve_observation_documents(
                     view.id,
                     "Reference a declared datasource binding.",
                 )
+            else:
+                datasource = datasources[view.datasource_binding_id][0]
+                assert isinstance(datasource, DatasourceBinding)
+                backend_entry = backends.get(datasource.observation_backend_id)
+                if backend_entry is not None:
+                    backend = backend_entry[0]
+                    assert isinstance(backend, ObservationBackend)
+                    if backend.kind != BackendKind.METRICS:
+                        _finding(
+                            findings,
+                            "view-datasource-kind-incompatible",
+                            _child(ref, "datasource_binding_id"),
+                            view.id,
+                            "Bind metrics views to a metrics observation backend.",
+                        )
             if view.metric_profile_id not in profiles:
-                _finding(
-                    findings,
-                    "unknown-host-metrics-profile",
-                    _child(ref, "metric_profile_id"),
-                    view.id,
-                    "Reference a declared service profile.",
-                )
+                if view.kind == "host_metrics":
+                    _finding(
+                        findings,
+                        "unknown-host-metrics-profile",
+                        _child(ref, "metric_profile_id"),
+                        view.id,
+                        "Reference a declared service profile.",
+                    )
+                else:
+                    _finding(
+                        findings,
+                        "unknown-profile-metrics-profile",
+                        _child(ref, "metric_profile_id"),
+                        view.id,
+                        "Reference a declared service profile.",
+                    )
             else:
                 metric_profile = profiles[view.metric_profile_id][0]
                 assert isinstance(metric_profile, ServiceProfile)
@@ -1132,7 +1158,12 @@ def resolve_observation_documents(
                     HostBaselineCapability.HOST_METRICS
                     in metric_profile.required_host_baseline_capabilities
                 )
-            if not metric_profile_supports_host_metrics and view.metric_profile_id in profiles:
+                metric_profile_exposes_metrics = bool(metric_profile.metrics)
+            if (
+                view.kind == "host_metrics"
+                and not metric_profile_supports_host_metrics
+                and view.metric_profile_id in profiles
+            ):
                 _finding(
                     findings,
                     "host-metrics-profile-capability-required",
@@ -1140,22 +1171,45 @@ def resolve_observation_documents(
                     view.id,
                     "Reference a profile that requires the host-metrics baseline capability.",
                 )
+            if (
+                view.kind == "profile_metrics"
+                and not metric_profile_exposes_metrics
+                and view.metric_profile_id in profiles
+            ):
+                _finding(
+                    findings,
+                    "profile-metrics-profile-capability-required",
+                    _child(ref, "metric_profile_id"),
+                    view.id,
+                    "Reference a profile that declares at least one metrics capability.",
+                )
+            matching_services = tuple(
+                sorted(
+                    (
+                        service
+                        for service in planned_services
+                        if service.profile_id == view.metric_profile_id
+                    ),
+                    key=lambda service: service.id,
+                )
+            )
+            membership_source_refs = (
+                (ref, profiles[view.metric_profile_id][1])
+                + tuple(service_refs[service.id] for service in matching_services)
+                if view.kind == "profile_metrics" and view.metric_profile_id in profiles
+                else (ref,)
+            )
             planned_views.append(
                 PlannedOperationsView(
                     id=view.id,
                     purpose=view.purpose,
                     sections=(),
-                    kind="host_metrics",
-                    host_ids=tuple(
-                        sorted(
-                            service.host_id
-                            for service in planned_services
-                            if service.profile_id == view.metric_profile_id
-                        )
-                    ),
+                    kind=view.kind,
+                    host_ids=tuple(sorted({service.host_id for service in matching_services})),
+                    service_ids=tuple(service.id for service in matching_services),
                     datasource_binding_id=view.datasource_binding_id,
                     metric_profile_id=view.metric_profile_id,
-                    source_refs=(ref,),
+                    source_refs=membership_source_refs,
                 )
             )
             continue

--- a/src/infralink/schemas/cli/v1/project-observation.json
+++ b/src/infralink/schemas/cli/v1/project-observation.json
@@ -1091,7 +1091,8 @@
           "enum": [
             "standard",
             "fleet_convergence",
-            "host_metrics"
+            "host_metrics",
+            "profile_metrics"
           ],
           "title": "Kind",
           "type": "string"
@@ -1117,6 +1118,14 @@
             "$ref": "#/$defs/PlannedViewSection"
           },
           "title": "Sections",
+          "type": "array"
+        },
+        "service_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Service Ids",
           "type": "array"
         },
         "source_refs": {

--- a/src/infralink/schemas/cli/v1/project-view.json
+++ b/src/infralink/schemas/cli/v1/project-view.json
@@ -196,7 +196,8 @@
           "enum": [
             "standard",
             "fleet_convergence",
-            "host_metrics"
+            "host_metrics",
+            "profile_metrics"
           ],
           "title": "Kind",
           "type": "string"
@@ -222,6 +223,14 @@
             "$ref": "#/$defs/PlannedViewSection"
           },
           "title": "Sections",
+          "type": "array"
+        },
+        "service_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Service Ids",
           "type": "array"
         },
         "source_refs": {

--- a/src/infralink/schemas/observation/v1/operations-view.json
+++ b/src/infralink/schemas/observation/v1/operations-view.json
@@ -120,7 +120,8 @@
           "enum": [
             "standard",
             "fleet_convergence",
-            "host_metrics"
+            "host_metrics",
+            "profile_metrics"
           ],
           "title": "Kind",
           "type": "string"

--- a/tests/observation/test_operations.py
+++ b/tests/observation/test_operations.py
@@ -124,6 +124,7 @@ def test_fleet_convergence_rejects_declarative_host_membership() -> None:
 
 def test_resolves_host_metrics_membership_from_declared_profile_instances() -> None:
     data = deepcopy(operational_data())
+    data["observation_backends"][0]["kind"] = "metrics"  # type: ignore[index]
     data["service_profiles"][0]["required_host_baseline_capabilities"] = ["host-metrics"]  # type: ignore[index]
     for host in data["hosts"]:  # type: ignore[union-attr]
         host["baseline_capabilities"] = ["host-metrics"]
@@ -170,6 +171,114 @@ def test_host_metrics_rejects_a_profile_without_host_metrics_capability() -> Non
     assert "host-metrics-profile-capability-required" in {
         item.code for item in caught.value.report.diagnostics
     }
+
+
+def test_resolves_profile_metrics_membership_from_declared_profile_instances() -> None:
+    data = deepcopy(operational_data())
+    data["observation_backends"][0]["kind"] = "metrics"  # type: ignore[index]
+    data["service_profiles"][0]["metrics"] = [  # type: ignore[index]
+        {"id": "metrics", "endpoint_id": "http", "evaluator": "prometheus-scrape"}
+    ]
+    data["operations_views"] = [
+        {
+            "id": "nginx",
+            "purpose": "Fleet NGINX metrics.",
+            "kind": "profile_metrics",
+            "metric_profile_id": "web",
+            "datasource_binding_id": "primary-metrics",
+            "sections": [],
+        }
+    ]
+    data["readiness_suites"] = []
+
+    plan = resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    view = plan.operations_views[0]
+    assert view.kind == "profile_metrics"
+    assert view.host_ids == (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    assert view.service_ids == (
+        "11111111-1111-4111-8111-111111111111/api",
+        "22222222-2222-4222-8222-222222222222/frontend",
+    )
+    assert view.metric_profile_id == "web"
+    assert view.datasource_binding_id == "primary-metrics"
+    assert [item.pointer for item in view.source_refs] == [
+        "/operations_views/0",
+        "/service_profiles/0",
+        "/service_instances/1",
+        "/service_instances/0",
+    ]
+
+
+def test_profile_metrics_rejects_a_profile_without_metrics_capability() -> None:
+    data = deepcopy(operational_data())
+    data["operations_views"] = [
+        {
+            "id": "nginx",
+            "purpose": "Fleet NGINX metrics.",
+            "kind": "profile_metrics",
+            "metric_profile_id": "web",
+            "datasource_binding_id": "primary-metrics",
+            "sections": [],
+        }
+    ]
+    data["readiness_suites"] = []
+
+    with pytest.raises(PlanValidationError) as caught:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert "profile-metrics-profile-capability-required" in {
+        item.code for item in caught.value.report.diagnostics
+    }
+
+
+def test_profile_metrics_rejects_a_non_metrics_datasource() -> None:
+    data = deepcopy(operational_data())
+    data["service_profiles"][0]["metrics"] = [  # type: ignore[index]
+        {"id": "metrics", "endpoint_id": "http", "evaluator": "prometheus-scrape"}
+    ]
+    data["operations_views"] = [
+        {
+            "id": "nginx",
+            "purpose": "Fleet NGINX metrics.",
+            "kind": "profile_metrics",
+            "metric_profile_id": "web",
+            "datasource_binding_id": "primary-metrics",
+            "sections": [],
+        }
+    ]
+    data["readiness_suites"] = []
+
+    with pytest.raises(PlanValidationError) as caught:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert "view-datasource-kind-incompatible" in {
+        item.code for item in caught.value.report.diagnostics
+    }
+
+
+def test_host_metrics_preserves_its_unknown_profile_diagnostic() -> None:
+    data = deepcopy(operational_data())
+    data["observation_backends"][0]["kind"] = "metrics"  # type: ignore[index]
+    data["operations_views"] = [
+        {
+            "id": "host-metrics",
+            "purpose": "Default host resource metrics.",
+            "kind": "host_metrics",
+            "metric_profile_id": "missing",
+            "datasource_binding_id": "primary-metrics",
+            "sections": [],
+        }
+    ]
+    data["readiness_suites"] = []
+
+    with pytest.raises(PlanValidationError) as caught:
+        resolve_observation_documents([document(data)], as_of=AS_OF)
+
+    assert "unknown-host-metrics-profile" in {item.code for item in caught.value.report.diagnostics}
 
 
 def test_plan_digest_is_exactly_public_canonical_plan_without_digest() -> None:

--- a/tests/test_cli_observation.py
+++ b/tests/test_cli_observation.py
@@ -84,6 +84,54 @@ def test_project_observation_and_capabilities_are_offline_yaml(tmp_path: Path) -
     assert "redis-ready" in advertised["evaluator_types"]["health"]
 
 
+def test_project_view_exposes_profile_metrics_membership(tmp_path: Path) -> None:
+    source = _source(
+        tmp_path,
+        (
+            SOURCE
+            + """\
+observation_backends:
+  - {id: metrics-primary, kind: metrics, backend_ref: prometheus}
+datasource_bindings:
+  - {id: primary-metrics, observation_backend_id: metrics-primary, datasource_ref: main}
+operations_views:
+  - id: nginx
+    purpose: Fleet NGINX metrics.
+    kind: profile_metrics
+    metric_profile_id: web
+    datasource_binding_id: primary-metrics
+    sections: []
+"""
+        ).replace(
+            "    health:\n",
+            "    metrics:\n      - {id: metrics, endpoint_id: http, evaluator: prometheus-scrape}\n    health:\n",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "project",
+            "view",
+            "nginx",
+            "--source",
+            str(source),
+            "--as-of",
+            "2026-08-04T00:00:00Z",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = yaml.safe_load(result.output)
+    assert payload["result"]["view"]["kind"] == "profile_metrics"
+    assert payload["result"]["view"]["host_ids"] == ["11111111-1111-4111-8111-111111111111"]
+    assert payload["result"]["view"]["service_ids"] == [
+        "11111111-1111-4111-8111-111111111111/frontend"
+    ]
+    assert payload["result"]["view"]["source_refs"][0]["path"] == source.name
+    assert any(action["rel"] == "validate" for action in payload["next_actions"])
+
+
 def test_observation_errors_are_typed_and_exact_exit_codes(tmp_path: Path) -> None:
     unsupported = _source(tmp_path, "schema_version: infralink.observation/v99\n")
     invalid = CliRunner().invoke(


### PR DESCRIPTION
Closes cyberstorm-dev/infralink#157

Adds typed `profile_metrics` operations views for profile-derived Grafana membership. The planner resolves matching services and hosts deterministically, requires a metrics-capable profile and metrics datasource, and retains source provenance for the view, profile, and instances.

Validation: `python -m pytest -q` (1487 passed, 5 skipped).