### PR TITLE
feat(schema): add typed host epitaph

### DIFF
--- a/src/infralink/core/schema.py
+++ b/src/infralink/core/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from datetime import date
 from enum import Enum
 from pathlib import PurePosixPath
 from typing import Annotated, Any, Literal
@@ -30,6 +31,16 @@ class HostStatus(str, Enum):
     TERMINATED = "terminated"
     PROVISIONING = "provisioning"
     MAINTENANCE = "maintenance"
+
+
+class HostEpitaph(StrictModel):
+    """Structured retirement record for an inactive host."""
+
+    retired_at: date
+    reason: str
+    rollback_ref: str | None = None
+    rollback_path: str | None = None
+    external_release: str | None = None
 
 
 class HostBootstrapExecutorSchema(StrictModel):
@@ -246,6 +257,7 @@ class HostSchema(NodeSchema):
     status: HostStatus = HostStatus.ACTIVE
     projects: list[str] = Field(default_factory=list)
     cloud: str | None = None
+    epitaph: HostEpitaph | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_host_epitaph.py
+++ b/tests/test_host_epitaph.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from infralink.core.schema import HostSchema
+
+
+def test_inactive_host_parses_typed_epitaph() -> None:
+    host = HostSchema(
+        canonical_name="retired-host",
+        status="inactive",
+        epitaph={
+            "retired_at": "2026-08-16",
+            "reason": "superseded by a managed replacement",
+            "rollback_ref": "archive/retired-host-2026-08",
+            "rollback_path": "hosts/retired-host",
+        },
+    )
+
+    assert host.epitaph is not None
+    assert host.epitaph.retired_at == date(2026, 8, 16)
+    assert host.epitaph.rollback_ref == "archive/retired-host-2026-08"
+
+
+def test_epitaph_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="unexpected"):
+        HostSchema(
+            canonical_name="retired-host",
+            status="inactive",
+            epitaph={
+                "retired_at": "2026-08-16",
+                "reason": "superseded by a managed replacement",
+                "unexpected": "not a schema contract",
+            },
+        )


### PR DESCRIPTION
## Summary
- add a strict `HostEpitaph` schema to the host contract
- expose it through `HostSchema.epitaph`
- validate date parsing and reject undeclared epitaph fields

## Verification
- `/root/.venvs/infralink-dev/bin/ruff check src/infralink/core/schema.py tests/test_host_epitaph.py`
- `/root/.venvs/infralink-dev/bin/pytest -q`

Result: 1,489 passed, 5 skipped, 87% coverage.